### PR TITLE
feat: implement two-step confirmation system (Phase 1.4)

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -192,6 +192,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			system.POST("/update/perform", auth.RoleRequired("owner", "admin"), DoUpdate(bridge))
 			system.GET("/sandbox", GetSandboxConfig(bridge))
 			system.POST("/sandbox/validate", ValidateSandboxCommand(bridge))
+			system.GET("/confirmations", ListConfirmations(bridge))
+			system.POST("/confirmations/:id/confirm", auth.RoleRequired("owner", "admin"), ConfirmRequest(bridge))
+			system.POST("/confirmations/:id/reject", auth.RoleRequired("owner", "admin"), RejectRequest(bridge))
 		}
 
 	// Public health check endpoint (no auth required for Docker healthcheck)

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"runtime"
 
+	"github.com/Yogdunana/deploypilot/internal/confirm"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/Yogdunana/deploypilot/internal/version"
 	"github.com/gin-gonic/gin"
@@ -175,5 +176,81 @@ func ValidateSandboxCommand(bridge *service.Bridge) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "success", "data": gin.H{"allowed": true}})
+	}
+}
+
+// ListConfirmations lists pending confirmation requests.
+// @Summary      List confirmations
+// @Description  List all pending confirmation requests
+// @Tags         System
+// @Produce      json
+// @Security     BearerAuth
+// @Param        status query string false "Filter by status (pending/approved/rejected/expired/executed)"
+// @Success      200 {object} map[string]interface{}
+// @Router       /system/confirmations [get]
+func ListConfirmations(bridge *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		store := bridge.GetConfirmationStore()
+		if store == nil {
+			c.JSON(http.StatusOK, gin.H{"status": "success", "data": []interface{}{}})
+			return
+		}
+		statusFilter := c.Query("status")
+		requests := store.List(confirm.Status(statusFilter))
+		c.JSON(http.StatusOK, gin.H{"status": "success", "data": requests})
+	}
+}
+
+// ConfirmRequest approves a pending confirmation.
+// @Summary      Confirm a request
+// @Description  Approve a pending confirmation request by ID
+// @Tags         System
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Confirmation ID"
+// @Success      200 {object} map[string]interface{}
+// @Router       /system/confirmations/{id}/confirm [post]
+func ConfirmRequest(bridge *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		store := bridge.GetConfirmationStore()
+		if store == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "confirmation system not available"})
+			return
+		}
+		req, err := store.Confirm(id, c.GetString("user_id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "success", "data": req})
+	}
+}
+
+// RejectRequest rejects a pending confirmation.
+// @Summary      Reject a request
+// @Description  Reject a pending confirmation request by ID
+// @Tags         System
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Confirmation ID"
+// @Success      200 {object} map[string]interface{}
+// @Router       /system/confirmations/{id}/reject [post]
+func RejectRequest(bridge *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+		store := bridge.GetConfirmationStore()
+		if store == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "confirmation system not available"})
+			return
+		}
+		req, err := store.Reject(id, c.GetString("user_id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "success", "data": req})
 	}
 }

--- a/internal/confirm/store.go
+++ b/internal/confirm/store.go
@@ -1,0 +1,177 @@
+// Package confirm provides a two-step confirmation system for dangerous operations.
+// Instead of executing immediately, dangerous operations create a pending confirmation
+// that must be explicitly confirmed before execution.
+package confirm
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Status represents the state of a confirmation request.
+type Status string
+
+const (
+	StatusPending  Status = "pending"
+	StatusApproved Status = "approved"
+	StatusRejected Status = "rejected"
+	StatusExpired  Status = "expired"
+	StatusExecuted Status = "executed"
+)
+
+// Request represents a pending confirmation for a dangerous operation.
+type Request struct {
+	ID          string            `json:"id"`
+	Tool        string            `json:"tool"`
+	Description string            `json:"description"`
+	Params      map[string]string `json:"params,omitempty"`
+	Status      Status            `json:"status"`
+	CreatedAt   time.Time         `json:"created_at"`
+	ExpiresAt   time.Time         `json:"expires_at"`
+	ConfirmedAt *time.Time        `json:"confirmed_at,omitempty"`
+	ConfirmedBy string            `json:"confirmed_by,omitempty"`
+	Result      string            `json:"result,omitempty"`
+	Error       string            `json:"error,omitempty"`
+}
+
+// Store manages pending confirmation requests.
+type Store struct {
+	mu          sync.RWMutex
+	requests    map[string]*Request
+	defaultTTL  time.Duration
+}
+
+// NewStore creates a new confirmation store.
+func NewStore() *Store {
+	return &Store{
+		requests:   make(map[string]*Request),
+		defaultTTL: 5 * time.Minute,
+	}
+}
+
+// Create creates a new pending confirmation request.
+func (s *Store) Create(tool, description string, params map[string]string) *Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	req := &Request{
+		ID:          fmt.Sprintf("cfm-%d", now.UnixNano()),
+		Tool:        tool,
+		Description: description,
+		Params:      params,
+		Status:      StatusPending,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(s.defaultTTL),
+	}
+	s.requests[req.ID] = req
+
+	// Auto-expire in background
+	go func() {
+		time.Sleep(s.defaultTTL + time.Second)
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if r, ok := s.requests[req.ID]; ok && r.Status == StatusPending {
+			r.Status = StatusExpired
+		}
+	}()
+
+	return req
+}
+
+// Confirm approves a pending confirmation.
+func (s *Store) Confirm(id, confirmedBy string) (*Request, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req, ok := s.requests[id]
+	if !ok {
+		return nil, fmt.Errorf("confirmation %s not found", id)
+	}
+	if req.Status != StatusPending {
+		return nil, fmt.Errorf("confirmation %s is %s (expected pending)", id, req.Status)
+	}
+	if time.Now().After(req.ExpiresAt) {
+		req.Status = StatusExpired
+		return nil, fmt.Errorf("confirmation %s has expired", id)
+	}
+
+	now := time.Now()
+	req.Status = StatusApproved
+	req.ConfirmedAt = &now
+	req.ConfirmedBy = confirmedBy
+	return req, nil
+}
+
+// Reject rejects a pending confirmation.
+func (s *Store) Reject(id, rejectedBy string) (*Request, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	req, ok := s.requests[id]
+	if !ok {
+		return nil, fmt.Errorf("confirmation %s not found", id)
+	}
+	if req.Status != StatusPending {
+		return nil, fmt.Errorf("confirmation %s is %s (expected pending)", id, req.Status)
+	}
+
+	now := time.Now()
+	req.Status = StatusRejected
+	req.ConfirmedAt = &now
+	req.ConfirmedBy = rejectedBy
+	return req, nil
+}
+
+// Get retrieves a confirmation by ID.
+func (s *Store) Get(id string) (*Request, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	req, ok := s.requests[id]
+	return req, ok
+}
+
+// List returns all confirmations, optionally filtered by status.
+func (s *Store) List(statusFilter Status) []*Request {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*Request
+	for _, req := range s.requests {
+		if statusFilter == "" || req.Status == statusFilter {
+			result = append(result, req)
+		}
+	}
+	return result
+}
+
+// SetResult records the execution result of a confirmed operation.
+func (s *Store) SetResult(id, result, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if req, ok := s.requests[id]; ok {
+		if errMsg != "" {
+			req.Error = errMsg
+		} else {
+			req.Result = result
+		}
+		req.Status = StatusExecuted
+	}
+}
+
+// Cleanup removes old confirmations (executed, rejected, expired) older than maxAge.
+func (s *Store) Cleanup(maxAge time.Duration) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(-maxAge)
+	count := 0
+	for id, req := range s.requests {
+		if req.Status != StatusPending && req.CreatedAt.Before(cutoff) {
+			delete(s.requests, id)
+			count++
+		}
+	}
+	return count
+}

--- a/internal/confirm/store_test.go
+++ b/internal/confirm/store_test.go
@@ -1,0 +1,155 @@
+package confirm
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCreateAndGet(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app myapp", map[string]string{"app_id": "123"})
+
+	if req.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if req.Status != StatusPending {
+		t.Errorf("expected pending, got %s", req.Status)
+	}
+	if req.Tool != "delete_app" {
+		t.Errorf("expected delete_app, got %s", req.Tool)
+	}
+
+	got, ok := store.Get(req.ID)
+	if !ok {
+		t.Fatal("expected to find request")
+	}
+	if got.ID != req.ID {
+		t.Errorf("expected %s, got %s", req.ID, got.ID)
+	}
+}
+
+func TestConfirm(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app", nil)
+
+	confirmed, err := store.Confirm(req.ID, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if confirmed.Status != StatusApproved {
+		t.Errorf("expected approved, got %s", confirmed.Status)
+	}
+	if confirmed.ConfirmedBy != "admin" {
+		t.Errorf("expected admin, got %s", confirmed.ConfirmedBy)
+	}
+}
+
+func TestReject(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app", nil)
+
+	rejected, err := store.Reject(req.ID, "admin")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rejected.Status != StatusRejected {
+		t.Errorf("expected rejected, got %s", rejected.Status)
+	}
+}
+
+func TestConfirmNotFound(t *testing.T) {
+	store := NewStore()
+	_, err := store.Confirm("nonexistent", "admin")
+	if err == nil {
+		t.Error("expected error for nonexistent ID")
+	}
+}
+
+func TestConfirmAlreadyApproved(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app", nil)
+	store.Confirm(req.ID, "admin")
+
+	_, err := store.Confirm(req.ID, "admin")
+	if err == nil {
+		t.Error("expected error for already approved confirmation")
+	}
+}
+
+func TestList(t *testing.T) {
+	store := NewStore()
+	store.Create("delete_app", "Delete app 1", nil)
+	store.Create("delete_app", "Delete app 2", nil)
+	store.Create("deploy_app", "Deploy app", nil)
+
+	all := store.List("")
+	if len(all) != 3 {
+		t.Errorf("expected 3, got %d", len(all))
+	}
+
+	pending := store.List(StatusPending)
+	if len(pending) != 3 {
+		t.Errorf("expected 3 pending, got %d", len(pending))
+	}
+}
+
+func TestSetResult(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app", nil)
+	store.Confirm(req.ID, "admin")
+
+	store.SetResult(req.ID, "app deleted", "")
+	got, _ := store.Get(req.ID)
+	if got.Status != StatusExecuted {
+		t.Errorf("expected executed, got %s", got.Status)
+	}
+	if got.Result != "app deleted" {
+		t.Errorf("expected 'app deleted', got %s", got.Result)
+	}
+}
+
+func TestSetResultError(t *testing.T) {
+	store := NewStore()
+	req := store.Create("delete_app", "Delete app", nil)
+	store.Confirm(req.ID, "admin")
+
+	store.SetResult(req.ID, "", "deployment failed")
+	got, _ := store.Get(req.ID)
+	if got.Error != "deployment failed" {
+		t.Errorf("expected error message, got %s", got.Error)
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	store := NewStore()
+	store.defaultTTL = 100 * time.Millisecond
+
+	req := store.Create("delete_app", "Delete app", nil)
+	store.Confirm(req.ID, "admin")
+	store.SetResult(req.ID, "done", "")
+
+	time.Sleep(200 * time.Millisecond)
+
+	count := store.Cleanup(time.Millisecond)
+	if count != 1 {
+		t.Errorf("expected 1 cleaned, got %d", count)
+	}
+
+	_, ok := store.Get(req.ID)
+	if ok {
+		t.Error("expected request to be cleaned up")
+	}
+}
+
+func TestExpiration(t *testing.T) {
+	store := NewStore()
+	store.defaultTTL = 50 * time.Millisecond
+
+	req := store.Create("delete_app", "Delete app", nil)
+	time.Sleep(100 * time.Millisecond)
+
+	_, err := store.Confirm(req.ID, "admin")
+	if err == nil {
+		t.Error("expected error for expired confirmation")
+	}
+}

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/Yogdunana/deploypilot/internal/agent"
+	"github.com/Yogdunana/deploypilot/internal/confirm"
 	"github.com/Yogdunana/deploypilot/internal/crypto"
 	"github.com/Yogdunana/deploypilot/internal/engine/builder"
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
@@ -84,6 +85,7 @@ type Bridge struct {
 	TunnelManager TunnelManager            // agent reverse tunnel manager
 	PluginMgr     *plugin.Manager          // plugin lifecycle manager
 	UpgradeSvc    *UpgradeService          // system upgrade service
+	ConfirmStore  *confirm.Store
 }
 
 // TunnelManager defines the interface for agent reverse tunnel management.
@@ -107,6 +109,7 @@ func NewBridge(db *gorm.DB, executor deployer.CommandExecutor, encryptionKey []b
 		Executor:      executor,
 		EncryptionKey: encryptionKey,
 		EventBus:      eventBus,
+		ConfirmStore:  confirm.NewStore(),
 	}
 }
 
@@ -128,6 +131,11 @@ func (b *Bridge) GetSandbox() interface {
 		return se.Sandbox()
 	}
 	return nil
+}
+
+// GetConfirmationStore returns the confirmation store.
+func (b *Bridge) GetConfirmationStore() *confirm.Store {
+	return b.ConfirmStore
 }
 
 // getDNSProvider loads the first enabled DNS provider from DB and returns a DNSProvider interface.


### PR DESCRIPTION
## Summary

Implements two-step confirmation system (v1.1 Phase 1.4) for dangerous operations.

### New Files

**internal/confirm/store.go** — Confirmation state machine:
- Status lifecycle: `pending → approved/rejected/expired → executed`
- Thread-safe (`sync.RWMutex`)
- Auto-expiration (default 5min TTL with background goroutine)
- CRUD: `Create`, `Get`, `List`, `Confirm`, `Reject`, `SetResult`, `Cleanup`
- Each request tracks: tool name, description, params, status, timestamps

**internal/confirm/store_test.go** — 10 test cases:
- Create/Get, Confirm, Reject, NotFound, AlreadyApproved
- List with filter, SetResult (success + error), Cleanup, Expiration

### Modified Files

**internal/service/bridge.go**: Add `ConfirmStore` field + `GetConfirmationStore()`

**internal/api/system.go**: 3 new API endpoints:
- `GET /api/v1/system/confirmations?status=pending` — List confirmations
- `POST /api/v1/system/confirmations/:id/confirm` — Approve (owner/admin)
- `POST /api/v1/system/confirmations/:id/reject` — Reject (owner/admin)

**internal/api/router.go**: Register confirmation routes

### Design

The confirmation system uses a two-step pattern:
1. **Step 1**: Dangerous operation creates a pending confirmation (returns `confirmation_id`)
2. **Step 2**: User explicitly confirms or rejects via API

This is the foundation for MCP tool integration — MCP handlers for dangerous tools (delete_app, delete_server, etc.) will create confirmations instead of executing immediately.

## Test Plan

- [ ] `go test ./internal/confirm/ -v` passes
- [ ] `go build ./...` compiles
- [ ] `GET /api/v1/system/confirmations` returns empty list
- [ ] Create → Confirm → SetResult flow works
- [ ] Expired confirmations cannot be confirmed

## Related Issues

Closes #41