### PR TITLE
feat: implement request tracing with X-Request-ID and slog integration (Phase 1.9)

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -191,6 +191,7 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 
 		// Audit logs
 		protected.GET("/audit-logs", ListAuditLogs(auditSvc))
+		protected.GET("/audit-logs/trace/:trace_id", GetAuditLogsByTraceID(auditSvc))
 
 		// System (4 endpoints)
 		system := protected.Group("/system")

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Yogdunana/deploypilot/internal/backup"
 	"github.com/Yogdunana/deploypilot/internal/confirm"
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/Yogdunana/deploypilot/internal/version"
 	"github.com/gin-gonic/gin"
@@ -419,5 +420,21 @@ func RejectRequest(bridge *service.Bridge) gin.HandlerFunc {
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "success", "data": req})
+	}
+}
+
+// GetAuditLogsByTraceID returns audit logs for a specific trace ID.
+func GetAuditLogsByTraceID(auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := c.Param("trace_id")
+		logs, total, err := auditSvc.ListByTraceID(c.Request.Context(), traceID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if logs == nil {
+			logs = []model.AuditLog{}
+		}
+		c.JSON(http.StatusOK, gin.H{"trace_id": traceID, "total": total, "logs": logs})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,11 +108,12 @@ type SecurityConfig struct {
 
 // LogConfig holds logging settings.
 type LogConfig struct {
-	Level      string `mapstructure:"level"`
-	Format     string `mapstructure:"format"`
-	File       string `mapstructure:"file"`
-	MaxSize    string `mapstructure:"max_size"`
-	MaxBackups int    `mapstructure:"max_backups"`
+	Level         string `mapstructure:"level"`
+	Format        string `mapstructure:"format"`
+	File          string `mapstructure:"file"`
+	MaxSize       string `mapstructure:"max_size"`
+	MaxBackups    int    `mapstructure:"max_backups"`
+	EnableTracing bool   `mapstructure:"enable_tracing"`
 }
 
 // NotifyConfig holds notification settings.
@@ -235,6 +236,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("log.file", "./logs/deploypilot.log")
 	v.SetDefault("log.max_size", "100MB")
 	v.SetDefault("log.max_backups", 10)
+	v.SetDefault("log.enable_tracing", true)
 
 	// Notify
 	v.SetDefault("notify.default_channels", []string{"webhook"})

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -3,6 +3,8 @@ package config
 import (
 	"log/slog"
 	"os"
+
+	"github.com/Yogdunana/deploypilot/internal/tracing"
 )
 
 // InitLogger configures the global slog logger based on the provided LogConfig.
@@ -28,5 +30,6 @@ func InitLogger(cfg LogConfig) {
 		handler = slog.NewTextHandler(os.Stdout, handlerOpts)
 	}
 
+	handler = tracing.NewTraceHandler(handler)
 	slog.SetDefault(slog.New(handler))
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -380,6 +380,16 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("backup_records")
 			},
 		},
+		// 202604270003: Add trace_id column to audit_logs
+		{
+			ID: "202604270003",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE audit_logs ADD COLUMN trace_id TEXT DEFAULT ''").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return nil
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/middleware/audit.go
+++ b/internal/middleware/audit.go
@@ -21,6 +21,7 @@ func AuditMiddleware(auditSvc *service.AuditService) gin.HandlerFunc {
 
 		userID, _ := c.Get("userID")
 		username, _ := c.Get("username")
+		traceID, _ := c.Get(TraceIDContextKey)
 
 		action := mapMethodToAction(method, c.Request.URL.Path)
 		_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
@@ -31,6 +32,7 @@ func AuditMiddleware(auditSvc *service.AuditService) gin.HandlerFunc {
 			ResourceID:   extractResourceID(c.Request.URL.Path),
 			IPAddress:    service.ClientIP(c.ClientIP(), c.GetHeader("X-Forwarded-For")),
 			UserAgent:    c.Request.UserAgent(),
+			TraceID:      toString(traceID),
 		})
 	}
 }

--- a/internal/middleware/tracing.go
+++ b/internal/middleware/tracing.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/tracing"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	TraceIDHeader     = "X-Request-ID"
+	TraceIDContextKey = "trace_id"
+)
+
+// RequestTracing is a Gin middleware that extracts or generates a trace ID
+// for each request, stores it in both the Gin context and the request context,
+// and logs request completion with the trace ID.
+func RequestTracing() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		traceID := c.GetHeader(TraceIDHeader)
+		if traceID == "" {
+			traceID = tracing.GenerateTraceID()
+		}
+		c.Set(TraceIDContextKey, traceID)
+		ctx := tracing.ContextWithTraceID(c.Request.Context(), traceID)
+		c.Request = c.Request.WithContext(ctx)
+		c.Header(TraceIDHeader, traceID)
+
+		start := time.Now()
+		c.Next()
+
+		slog.InfoContext(ctx, "request completed",
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path,
+			"status", c.Writer.Status(),
+			"duration_ms", time.Since(start).Milliseconds(),
+			"client_ip", c.ClientIP(),
+		)
+	}
+}

--- a/internal/middleware/tracing_test.go
+++ b/internal/middleware/tracing_test.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupRouter() *gin.Engine {
+	r := gin.New()
+	r.Use(RequestTracing())
+	r.GET("/test", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok")
+	})
+	return r
+}
+
+func TestRequestTracing_AutoGenerate(t *testing.T) {
+	r := setupRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	resp := w.Result()
+	resp.Header.Del("Content-Type")
+
+	traceID := resp.Header.Get(TraceIDHeader)
+	if traceID == "" {
+		t.Fatal("expected trace ID in response header, got empty string")
+	}
+}
+
+func TestRequestTracing_ReuseFromHeader(t *testing.T) {
+	r := setupRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set(TraceIDHeader, "my-custom-trace-id")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	resp := w.Result()
+	traceID := resp.Header.Get(TraceIDHeader)
+	if traceID != "my-custom-trace-id" {
+		t.Errorf("trace ID = %q, want %q", traceID, "my-custom-trace-id")
+	}
+}
+
+func TestRequestTracing_ResponseHeaderContainsTraceID(t *testing.T) {
+	r := setupRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	resp := w.Result()
+	traceID := resp.Header.Get(TraceIDHeader)
+	if traceID == "" {
+		t.Fatal("expected X-Request-ID in response headers")
+	}
+}
+
+func TestRequestTracing_GinContextHasTraceID(t *testing.T) {
+	r := gin.New()
+	r.Use(RequestTracing())
+	r.GET("/test", func(c *gin.Context) {
+		val, exists := c.Get(TraceIDContextKey)
+		if !exists {
+			c.String(http.StatusInternalServerError, "no trace_id in gin context")
+			return
+		}
+		traceID, ok := val.(string)
+		if !ok || traceID == "" {
+			c.String(http.StatusInternalServerError, "trace_id is not a non-empty string")
+			return
+		}
+		c.String(http.StatusOK, traceID)
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if w.Body.String() == "" {
+		t.Error("expected non-empty trace ID from gin context")
+	}
+}
+
+func TestRequestTracing_RequestContextHasTraceID(t *testing.T) {
+	r := gin.New()
+	r.Use(RequestTracing())
+	r.GET("/test", func(c *gin.Context) {
+		traceID := c.GetString(TraceIDContextKey)
+		if traceID == "" {
+			c.String(http.StatusInternalServerError, "no trace_id")
+			return
+		}
+		c.String(http.StatusOK, traceID)
+	})
+
+	customID := "ctx-trace-123"
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set(TraceIDHeader, customID)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != customID {
+		t.Errorf("body = %q, want %q", w.Body.String(), customID)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -162,6 +162,7 @@ type AuditLog struct {
 	IPAddress    string    `json:"ip_address" gorm:"size:45"`
 	UserAgent    string    `json:"user_agent" gorm:"size:500"`
 	RecordHash   string    `json:"record_hash" gorm:"column:record_hash;size:128"`
+	TraceID      string    `json:"trace_id,omitempty" gorm:"size:36;index"`
 	CreatedAt    time.Time `json:"created_at" gorm:"autoCreateTime"`
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,9 @@ type Server struct {
 func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService) *Server {
 	r := gin.Default()
 
+	// Request tracing — must be first middleware
+	r.Use(middleware.RequestTracing())
+
 	// Security middleware
 	r.Use(middleware.SecurityHeaders())
 	r.Use(corsMiddleware(cfg.Server.CORSAllowedOrigins))

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -62,6 +62,7 @@ type AuditEntry struct {
 	Detail       interface{} // will be JSON-marshaled
 	IPAddress    string
 	UserAgent    string
+	TraceID      string
 }
 
 // AuditFilter defines filtering options for listing audit logs.
@@ -69,6 +70,7 @@ type AuditFilter struct {
 	UserID       uint
 	Action       string
 	ResourceType string
+	TraceID      string
 	Page         int
 	PageSize     int
 }
@@ -109,6 +111,7 @@ func (s *AuditService) Record(ctx context.Context, entry AuditEntry) error {
 		Detail:       detail,
 		IPAddress:    entry.IPAddress,
 		UserAgent:    entry.UserAgent,
+		TraceID:      entry.TraceID,
 	}
 
 	// Compute HMAC-SHA256 hash for tamper-evident integrity
@@ -172,6 +175,9 @@ func (s *AuditService) List(ctx context.Context, filter AuditFilter) ([]model.Au
 	if filter.ResourceType != "" {
 		query = query.Where("resource_type = ?", filter.ResourceType)
 	}
+	if filter.TraceID != "" {
+		query = query.Where("trace_id = ?", filter.TraceID)
+	}
 
 	if err := query.Count(&total).Error; err != nil {
 		return nil, 0, err
@@ -191,6 +197,28 @@ func (s *AuditService) List(ctx context.Context, filter AuditFilter) ([]model.Au
 
 	offset := (page - 1) * pageSize
 	if err := query.Order("created_at DESC").Offset(offset).Limit(pageSize).Find(&logs).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if logs == nil {
+		logs = []model.AuditLog{}
+	}
+
+	return logs, total, nil
+}
+
+// ListByTraceID returns audit logs filtered by trace ID.
+func (s *AuditService) ListByTraceID(ctx context.Context, traceID string) ([]model.AuditLog, int64, error) {
+	var logs []model.AuditLog
+	var total int64
+
+	query := s.db.WithContext(ctx).Model(&model.AuditLog{}).Where("trace_id = ?", traceID)
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := query.Order("created_at DESC").Find(&logs).Error; err != nil {
 		return nil, 0, err
 	}
 

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -34,6 +34,7 @@ import (
 	registry "github.com/Yogdunana/deploypilot/internal/provider/registry"
 	"github.com/Yogdunana/deploypilot/internal/provider/server"
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
+	"github.com/Yogdunana/deploypilot/internal/tracing"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -73,6 +74,7 @@ type DeployEvent struct {
 	Progress  int    `json:"progress"` // 0-100
 	Message   string `json:"message"`
 	Timestamp string `json:"timestamp"`
+	TraceID   string `json:"trace_id,omitempty"`
 }
 
 // Bridge implements mcp.Deployer by wiring DB + Docker executor.
@@ -500,6 +502,7 @@ func (is *interactiveSession) Close() error {
 // DeployAsync starts a deploy in a goroutine and returns a task ID immediately.
 func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID string) (taskID string, err error) {
 	taskID = createTask("deploy")
+	traceID := tracing.TraceIDFromContext(ctx)
 	updateTask(taskID, "running", 0, "deploy started")
 	go func() {
 		cs, deployErr := b.Deploy(ctx, cfg)
@@ -513,6 +516,7 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 				Progress:  100,
 				Message:   deployErr.Error(),
 				Timestamp: time.Now().Format(time.RFC3339),
+				TraceID:   traceID,
 			})
 		} else {
 			updateTask(taskID, "success", 100, "deploy completed")
@@ -524,6 +528,7 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 				Progress:  100,
 				Message:   "deploy completed",
 				Timestamp: time.Now().Format(time.RFC3339),
+				TraceID:   traceID,
 			})
 			taskMu.Lock()
 			if t, ok := tasks[taskID]; ok {

--- a/internal/tracing/context.go
+++ b/internal/tracing/context.go
@@ -1,0 +1,30 @@
+package tracing
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const traceIDKey contextKey = "trace_id"
+
+// TraceIDFromContext extracts the trace ID from the given context.
+// Returns an empty string if no trace ID is present.
+func TraceIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(traceIDKey).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// ContextWithTraceID returns a new context with the given trace ID.
+func ContextWithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, traceIDKey, traceID)
+}
+
+// GenerateTraceID generates a new UUID-based trace ID.
+func GenerateTraceID() string {
+	return uuid.New().String()
+}

--- a/internal/tracing/context_test.go
+++ b/internal/tracing/context_test.go
@@ -1,0 +1,52 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestContextWithTraceID_Roundtrip(t *testing.T) {
+	traceID := "test-trace-id-123"
+	ctx := context.Background()
+	ctx = ContextWithTraceID(ctx, traceID)
+
+	got := TraceIDFromContext(ctx)
+	if got != traceID {
+		t.Errorf("TraceIDFromContext() = %q, want %q", got, traceID)
+	}
+}
+
+func TestTraceIDFromContext_Empty(t *testing.T) {
+	ctx := context.Background()
+	got := TraceIDFromContext(ctx)
+	if got != "" {
+		t.Errorf("TraceIDFromContext() = %q, want empty string", got)
+	}
+}
+
+func TestGenerateTraceID_ValidUUID(t *testing.T) {
+	id := GenerateTraceID()
+	if id == "" {
+		t.Error("GenerateTraceID() returned empty string")
+	}
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		t.Errorf("GenerateTraceID() = %q, not a valid UUID: %v", id, err)
+	}
+	if parsed.String() != id {
+		t.Errorf("UUID roundtrip mismatch: got %q, want %q", parsed.String(), id)
+	}
+}
+
+func TestGenerateTraceID_Unique(t *testing.T) {
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id := GenerateTraceID()
+		if ids[id] {
+			t.Errorf("GenerateTraceID() produced duplicate: %q", id)
+		}
+		ids[id] = true
+	}
+}

--- a/internal/tracing/logger.go
+++ b/internal/tracing/logger.go
@@ -1,0 +1,41 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+)
+
+// TraceHandler is an slog.Handler wrapper that injects trace_id into log records.
+type TraceHandler struct {
+	handler slog.Handler
+}
+
+// NewTraceHandler wraps an existing slog.Handler to automatically inject
+// trace_id from the context into every log record.
+func NewTraceHandler(handler slog.Handler) slog.Handler {
+	return &TraceHandler{handler: handler}
+}
+
+// Enabled returns true if the underlying handler is enabled for the given level.
+func (h *TraceHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.handler.Enabled(ctx, level)
+}
+
+// Handle injects trace_id from the context into the log record before
+// passing it to the underlying handler.
+func (h *TraceHandler) Handle(ctx context.Context, r slog.Record) error {
+	if traceID := TraceIDFromContext(ctx); traceID != "" {
+		r.AddAttrs(slog.String("trace_id", traceID))
+	}
+	return h.handler.Handle(ctx, r)
+}
+
+// WithAttrs returns a new TraceHandler with the given attributes appended.
+func (h *TraceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &TraceHandler{handler: h.handler.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new TraceHandler with the given group name.
+func (h *TraceHandler) WithGroup(name string) slog.Handler {
+	return &TraceHandler{handler: h.handler.WithGroup(name)}
+}

--- a/internal/tracing/logger_test.go
+++ b/internal/tracing/logger_test.go
@@ -1,0 +1,134 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// mockHandler collects records for inspection.
+type mockHandler struct {
+	records []mockRecord
+}
+
+type mockRecord struct {
+	msg    string
+	attrs  map[string]string
+	groups []string
+}
+
+func (h *mockHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (h *mockHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := mockRecord{msg: r.Message(), attrs: make(map[string]string)}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.records = append(h.records, rec)
+	return nil
+}
+
+func (h *mockHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	clone := &mockHandler{records: h.records}
+	for _, a := range attrs {
+		clone.records = append(clone.records, mockRecord{attrs: map[string]string{a.Key: a.Value.String()}})
+	}
+	return clone
+}
+
+func (h *mockHandler) WithGroup(name string) slog.Handler {
+	return &mockHandler{records: h.records}
+}
+
+func TestTraceHandler_InjectsTraceID(t *testing.T) {
+	mock := &mockHandler{}
+	handler := NewTraceHandler(mock)
+
+	traceID := "abc-123-def"
+	ctx := ContextWithTraceID(context.Background(), traceID)
+
+	r := slog.NewRecord(0, slog.LevelInfo, "test message", 0)
+	if err := handler.Handle(ctx, r); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if len(mock.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(mock.records))
+	}
+	if mock.records[0].attrs["trace_id"] != traceID {
+		t.Errorf("trace_id = %q, want %q", mock.records[0].attrs["trace_id"], traceID)
+	}
+}
+
+func TestTraceHandler_NoTraceID(t *testing.T) {
+	mock := &mockHandler{}
+	handler := NewTraceHandler(mock)
+
+	ctx := context.Background()
+
+	r := slog.NewRecord(0, slog.LevelInfo, "test message", 0)
+	if err := handler.Handle(ctx, r); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if len(mock.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(mock.records))
+	}
+	if _, ok := mock.records[0].attrs["trace_id"]; ok {
+		t.Error("trace_id should not be present when context has no trace ID")
+	}
+}
+
+func TestTraceHandler_WithAttrs(t *testing.T) {
+	mock := &mockHandler{}
+	handler := NewTraceHandler(mock)
+
+	attrs := []slog.Attr{slog.String("service", "deploypilot")}
+	wrapped := handler.WithAttrs(attrs)
+
+	traceID := "trace-456"
+	ctx := ContextWithTraceID(context.Background(), traceID)
+
+	r := slog.NewRecord(0, slog.LevelInfo, "test", 0)
+	if err := wrapped.Handle(ctx, r); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if len(mock.records) != 2 {
+		t.Fatalf("expected 2 records (1 from WithAttrs, 1 from Handle), got %d", len(mock.records))
+	}
+}
+
+func TestTraceHandler_WithGroup(t *testing.T) {
+	mock := &mockHandler{}
+	handler := NewTraceHandler(mock)
+
+	wrapped := handler.WithGroup("request")
+
+	traceID := "trace-789"
+	ctx := ContextWithTraceID(context.Background(), traceID)
+
+	r := slog.NewRecord(0, slog.LevelInfo, "test", 0)
+	if err := wrapped.Handle(ctx, r); err != nil {
+		t.Fatalf("Handle() error: %v", err)
+	}
+
+	if len(mock.records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(mock.records))
+	}
+	if mock.records[0].attrs["trace_id"] != traceID {
+		t.Errorf("trace_id = %q, want %q", mock.records[0].attrs["trace_id"], traceID)
+	}
+}
+
+func TestTraceHandler_Enabled(t *testing.T) {
+	mock := &mockHandler{}
+	handler := NewTraceHandler(mock)
+
+	if !handler.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Enabled() should return true")
+	}
+}

--- a/internal/tracing/logger_test.go
+++ b/internal/tracing/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 )
 
 // mockHandler collects records for inspection.
@@ -22,7 +23,8 @@ func (h *mockHandler) Enabled(_ context.Context, _ slog.Level) bool {
 }
 
 func (h *mockHandler) Handle(_ context.Context, r slog.Record) error {
-	rec := mockRecord{msg: r.Message(), attrs: make(map[string]string)}
+	msg := r.Message
+	rec := mockRecord{msg: msg, attrs: make(map[string]string)}
 	r.Attrs(func(a slog.Attr) bool {
 		rec.attrs[a.Key] = a.Value.String()
 		return true
@@ -50,7 +52,7 @@ func TestTraceHandler_InjectsTraceID(t *testing.T) {
 	traceID := "abc-123-def"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(0, slog.LevelInfo, "test message", 0)
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message")
 	if err := handler.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -69,7 +71,7 @@ func TestTraceHandler_NoTraceID(t *testing.T) {
 
 	ctx := context.Background()
 
-	r := slog.NewRecord(0, slog.LevelInfo, "test message", 0)
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message")
 	if err := handler.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -92,7 +94,7 @@ func TestTraceHandler_WithAttrs(t *testing.T) {
 	traceID := "trace-456"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(0, slog.LevelInfo, "test", 0)
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test")
 	if err := wrapped.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -111,7 +113,7 @@ func TestTraceHandler_WithGroup(t *testing.T) {
 	traceID := "trace-789"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(0, slog.LevelInfo, "test", 0)
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test")
 	if err := wrapped.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}

--- a/internal/tracing/logger_test.go
+++ b/internal/tracing/logger_test.go
@@ -13,9 +13,8 @@ type mockHandler struct {
 }
 
 type mockRecord struct {
-	msg    string
-	attrs  map[string]string
-	groups []string
+	msg   string
+	attrs map[string]string
 }
 
 func (h *mockHandler) Enabled(_ context.Context, _ slog.Level) bool {

--- a/internal/tracing/logger_test.go
+++ b/internal/tracing/logger_test.go
@@ -52,7 +52,7 @@ func TestTraceHandler_InjectsTraceID(t *testing.T) {
 	traceID := "abc-123-def"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
 	if err := handler.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestTraceHandler_NoTraceID(t *testing.T) {
 
 	ctx := context.Background()
 
-	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test message", 0)
 	if err := handler.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestTraceHandler_WithAttrs(t *testing.T) {
 	traceID := "trace-456"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
 	if err := wrapped.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestTraceHandler_WithGroup(t *testing.T) {
 	traceID := "trace-789"
 	ctx := ContextWithTraceID(context.Background(), traceID)
 
-	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test")
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "test", 0)
 	if err := wrapped.Handle(ctx, r); err != nil {
 		t.Fatalf("Handle() error: %v", err)
 	}


### PR DESCRIPTION
## Summary

This PR implements Phase 1.9 of the DeployPilot roadmap: **Request Tracing** with X-Request-ID header propagation and slog integration.

## Changes

### Tracing Package (`internal/tracing/`)
- **context.go**: Core trace ID propagation via `context.Context` — `TraceIDFromContext()`, `ContextWithTraceID()`, `GenerateTraceID()`
- **logger.go**: `TraceHandler` — slog.Handler wrapper that auto-injects `trace_id` into every log record
- Tests for both modules

### Request Tracing Middleware (`internal/middleware/tracing.go`)
- Generates UUID v4 trace ID for each request (or reuses `X-Request-ID` from upstream)
- Propagates trace ID via both Gin Context and `context.Context`
- Returns trace ID in `X-Request-ID` response header
- Logs request completion with trace ID, method, path, status, duration, and client IP
- Registered as the **first middleware** to ensure all downstream logs include trace ID

### slog Integration
- `config/logger.go`: Wraps the base slog handler with `TraceHandler`
- All `slog.InfoContext(ctx, ...)` calls automatically include `trace_id`

### Audit Log Integration
- `model/model.go`: Added `TraceID` field to `AuditLog` with GORM index
- `service/audit.go`: Extended `AuditEntry` and `AuditFilter` with `TraceID`, added `ListByTraceID()` method
- `middleware/audit.go`: Extracts trace ID from Gin context into audit entries
- `database/database.go`: Migration `202604270003` adds `trace_id` column to `audit_logs`

### API
- `GET /api/v1/audit-logs/trace/:trace_id` — Query audit logs by trace ID

### Deploy Event Tracing
- `service/bridge.go`: `DeployEvent` includes `TraceID`, `DeployAsync()` propagates trace ID to all events

### Configuration
- `config/config.go`: `LogConfig.EnableTracing` (default: `true`)

## Files Changed
- `internal/tracing/context.go` (new)
- `internal/tracing/logger.go` (new)
- `internal/tracing/context_test.go` (new)
- `internal/tracing/logger_test.go` (new)
- `internal/middleware/tracing.go` (new)
- `internal/middleware/tracing_test.go` (new)
- `internal/config/logger.go` (modified)
- `internal/config/config.go` (modified)
- `internal/server/server.go` (modified)
- `internal/middleware/audit.go` (modified)
- `internal/model/model.go` (modified)
- `internal/service/audit.go` (modified)
- `internal/service/bridge.go` (modified)
- `internal/api/router.go` (modified)
- `internal/api/system.go` (modified)
- `internal/database/database.go` (modified)

## Testing
```bash
go test -race -v ./internal/tracing/... ./internal/middleware/...
```