### PR TITLE
fix: add cluster resource-level access control and upgrade viper to stable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/spf13/cobra v1.8.1
-	github.com/spf13/viper v1.20.0-alpha.6
+	github.com/spf13/viper v1.21.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.6

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -124,10 +124,10 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		{
 			clusters.GET("", ListClusters(bridge))
 			clusters.POST("", CreateCluster(bridge))
-			clusters.GET("/:id", GetCluster(bridge))
-			clusters.PUT("/:id", UpdateCluster(bridge))
-			clusters.DELETE("/:id", DeleteCluster(bridge))
-			clusters.POST("/:id/test", TestClusterConnection(bridge))
+			clusters.GET("/:id", auth.RequireResourceAccess(db, "cluster", "id"), GetCluster(bridge))
+			clusters.PUT("/:id", auth.RequireResourceAccess(db, "cluster", "id"), UpdateCluster(bridge))
+			clusters.DELETE("/:id", auth.RequireResourceAccess(db, "cluster", "id"), DeleteCluster(bridge))
+			clusters.POST("/:id/test", auth.RequireResourceAccess(db, "cluster", "id"), TestClusterConnection(bridge))
 		}
 
 		// Registries (5 endpoints)

--- a/internal/service/authorization.go
+++ b/internal/service/authorization.go
@@ -5,9 +5,10 @@ import (
 )
 
 // CheckResourceAccess checks if a user has access to a specific resource.
-// Resource types: "app", "server", "credential"
+// Resource types: "app", "server", "credential", "cluster"
 // owner and admin roles can access all resources.
-// viewer and dev roles can only access resources they created (user_id match).
+// viewer and dev roles can only access resources they created (user_id match),
+// except for clusters which are tenant-level resources (tenant_id match).
 func CheckResourceAccess(db *gorm.DB, resourceType, resourceID, role, userID string) bool {
 	// owner and admin can access all resources
 	if role == "owner" || role == "admin" {
@@ -23,6 +24,13 @@ func CheckResourceAccess(db *gorm.DB, resourceType, resourceID, role, userID str
 		db.Table("servers").Where("id = ? AND user_id = ?", resourceID, userID).Count(&count)
 	case "credential":
 		db.Table("credentials").Where("id = ? AND user_id = ?", resourceID, userID).Count(&count)
+	case "cluster":
+		// Clusters are tenant-level resources: check tenant_id match
+		var tenantID string
+		if err := db.Table("users").Where("id = ?", userID).Pluck("tenant_id", &tenantID).Error; err != nil {
+			return false
+		}
+		db.Table("clusters").Where("id = ? AND tenant_id = ?", resourceID, tenantID).Count(&count)
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

Fix remaining warning-level issues from the project health check.

## Changes

1. **Cluster resource-level access control**: Added `RequireResourceAccess` middleware to all cluster detail routes (GET/PUT/DELETE/test). Previously, any authenticated user could operate on any cluster. Now viewer/dev roles can only access clusters within their own tenant.

2. **Cluster authorization support**: Added `cluster` case to `CheckResourceAccess()`. Since clusters are tenant-level resources (no `user_id` column), the check verifies the user's `tenant_id` matches the cluster's `tenant_id`.

3. **Viper stable upgrade**: Upgraded `spf13/viper` from `v1.20.0-alpha.6` to `v1.21.0` (stable release, published Sep 2025). This eliminates the risk of using a pre-release dependency for core configuration management.