### PR TITLE
fix: run go mod tidy in Dockerfile to keep go.sum in sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=frontend /app/web/dist ./web/dist
 # Generate swagger docs (excluded by .dockerignore)
 RUN swag init -g cmd/api-server/main.go -o docs/swagger
 
+# Ensure go.sum is up to date (handles manual go.mod edits)
+RUN go mod tidy
+
 ARG TARGETPLATFORM
 ENV CGO_ENABLED=1
 


### PR DESCRIPTION
## Summary

Fix Docker build failure caused by missing go.sum entries after Viper upgrade.

## Root Cause

PR #68 upgraded `spf13/viper` from `v1.20.0-alpha.6` to `v1.21.0` in `go.mod` but did not run `go mod tidy` to update `go.sum`. The Docker build failed with:
```
missing go.sum entry for module providing package github.com/spf13/viper
```

## Fix

Added `go mod tidy` step in `Dockerfile` after copying source code and before building. This ensures go.sum is always in sync with go.mod during Docker builds, even when go.mod is manually edited without running `go mod tidy` locally.