### PR TITLE
fix: add go mod tidy to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
           npm ci
           npm run build
 
+      - name: Ensure go.sum is up to date
+        run: go mod tidy
+
       - name: Build binaries
         env:
           GOOS: ${{ matrix.goos }}


### PR DESCRIPTION
Fix Release workflow failure caused by missing go.sum entries.

Same root cause as #69 — `go mod tidy` was not run before `go build` in release.yml.