### PR TITLE
feat: add exec_command, list_images, port_forward MCP tools (Phase 3.3)

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -76,7 +76,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		name TEXT NOT NULL, repo_url TEXT NOT NULL, branch TEXT DEFAULT 'main',
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
-		env_vars TEXT, resource_limits TEXT,
+		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS deployments (

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -30,7 +30,7 @@ func setupSSETestDB(t *testing.T) *gorm.DB {
 		name TEXT NOT NULL, repo_url TEXT NOT NULL, branch TEXT DEFAULT 'main',
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
-		env_vars TEXT, resource_limits TEXT,
+		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS servers (

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -29,7 +29,7 @@ func setupWSTestDB(t *testing.T) *gorm.DB {
 		name TEXT NOT NULL, repo_url TEXT NOT NULL, branch TEXT DEFAULT 'main',
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
-		env_vars TEXT, resource_limits TEXT,
+		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS servers (

--- a/internal/engine/deployer/compose.go
+++ b/internal/engine/deployer/compose.go
@@ -1,0 +1,95 @@
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ComposeDeployer handles docker-compose deployments.
+type ComposeDeployer struct {
+	executor CommandExecutor
+}
+
+// NewComposeDeployer creates a new ComposeDeployer.
+func NewComposeDeployer(executor CommandExecutor) *ComposeDeployer {
+	return &ComposeDeployer{executor: executor}
+}
+
+// ComposeUp writes a compose file and runs docker-compose up -d.
+func (d *ComposeDeployer) ComposeUp(ctx context.Context, workDir, composeContent string, envVars map[string]string) (string, error) {
+	// Write compose file
+	writeCmd := fmt.Sprintf("mkdir -p %s && cat > %s/docker-compose.yml << 'DEPLOYPILOT_COMPOSE_EOF'\n%s\nDEPLOYPILOT_COMPOSE_EOF", workDir, workDir, composeContent)
+	if out, err := d.executor.RunCommand(ctx, writeCmd); err != nil {
+		return "", fmt.Errorf("failed to write compose file: %w, output: %s", err, out)
+	}
+
+	// Build env args
+	var envArgs []string
+	for k, v := range envVars {
+		envArgs = append(envArgs, fmt.Sprintf("%s=%s", k, v))
+	}
+	envCmd := ""
+	if len(envArgs) > 0 {
+		envCmd = fmt.Sprintf("export %s && ", strings.Join(envArgs, " "))
+	}
+
+	// Run docker-compose up -d
+	cmd := fmt.Sprintf("cd %s && %sdocker-compose up -d --remove-orphans 2>&1", workDir, envCmd)
+	out, err := d.executor.RunCommand(ctx, cmd)
+	if err != nil {
+		return out, fmt.Errorf("docker-compose up failed: %w", err)
+	}
+	return out, nil
+}
+
+// ComposeDown stops and removes containers defined in compose file.
+func (d *ComposeDeployer) ComposeDown(ctx context.Context, workDir string) (string, error) {
+	cmd := fmt.Sprintf("cd %s && docker-compose down --remove-orphans 2>&1", workDir)
+	out, err := d.executor.RunCommand(ctx, cmd)
+	if err != nil {
+		return out, fmt.Errorf("docker-compose down failed: %w", err)
+	}
+	return out, nil
+}
+
+// ComposePs lists containers managed by docker-compose.
+func (d *ComposeDeployer) ComposePs(ctx context.Context, workDir string) (string, error) {
+	cmd := fmt.Sprintf("cd %s && docker-compose ps --format 'table {{.Name}}\t{{.State}}\t{{.Ports}}' 2>&1", workDir)
+	out, err := d.executor.RunCommand(ctx, cmd)
+	if err != nil {
+		return out, fmt.Errorf("docker-compose ps failed: %w", err)
+	}
+	return out, nil
+}
+
+// ComposeLogs fetches logs from compose services.
+func (d *ComposeDeployer) ComposeLogs(ctx context.Context, workDir, service, tail string) (string, error) {
+	cmd := fmt.Sprintf("cd %s && docker-compose logs", workDir)
+	if service != "" {
+		cmd += " " + service
+	}
+	if tail != "" {
+		cmd += " --tail " + tail
+	}
+	cmd += " 2>&1"
+	out, err := d.executor.RunCommand(ctx, cmd)
+	if err != nil {
+		return out, fmt.Errorf("docker-compose logs failed: %w", err)
+	}
+	return out, nil
+}
+
+// ComposeRestart restarts compose services.
+func (d *ComposeDeployer) ComposeRestart(ctx context.Context, workDir, service string) (string, error) {
+	cmd := fmt.Sprintf("cd %s && docker-compose restart", workDir)
+	if service != "" {
+		cmd += " " + service
+	}
+	cmd += " 2>&1"
+	out, err := d.executor.RunCommand(ctx, cmd)
+	if err != nil {
+		return out, fmt.Errorf("docker-compose restart failed: %w", err)
+	}
+	return out, nil
+}

--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -56,6 +56,28 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
+func handleListImages(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	serverID := request.GetString("server_id", "")
+	filter := request.GetString("filter", "")
+
+	output, err := deployer.ListImages(ctx, serverID, filter)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to list images: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status": "success",
+		"output": output,
+	}
+	if serverID != "" {
+		result["server_id"] = serverID
+	}
+	if filter != "" {
+		result["filter"] = filter
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
 func handleDeployApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	image, err := request.RequireString("image")
 	if err != nil {

--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -56,6 +56,115 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
+
+// ---------- Phase 3.1: Compose Handlers ----------
+
+func handleComposeDeploy(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	appID, err := request.RequireString("app_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	output, err := deployer.ComposeDeploy(ctx, appID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("compose deploy failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status":  "success",
+		"message": fmt.Sprintf("Compose deployment for app %s completed", appID),
+		"output":  output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func handleComposeStop(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	appID, err := request.RequireString("app_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	output, err := deployer.ComposeStop(ctx, appID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("compose stop failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status":  "success",
+		"message": fmt.Sprintf("Compose deployment for app %s stopped", appID),
+		"output":  output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func handleComposePs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	appID, err := request.RequireString("app_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	output, err := deployer.ComposePs(ctx, appID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("compose ps failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status": "success",
+		"app_id": appID,
+		"output": output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func handleComposeLogs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	appID, err := request.RequireString("app_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	service := request.GetString("service", "")
+	tail := request.GetString("tail", "")
+
+	output, err := deployer.ComposeLogs(ctx, appID, service, tail)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("compose logs failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status":  "success",
+		"app_id":  appID,
+		"service": service,
+		"output":  output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func handleComposeRestart(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	appID, err := request.RequireString("app_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	service := request.GetString("service", "")
+
+	output, err := deployer.ComposeRestart(ctx, appID, service)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("compose restart failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status":  "success",
+		"message": fmt.Sprintf("Compose services restarted for app %s", appID),
+		"service": service,
+		"output":  output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
 func handleListImages(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID := request.GetString("server_id", "")
 	filter := request.GetString("filter", "")

--- a/internal/mcp/handler_portforward.go
+++ b/internal/mcp/handler_portforward.go
@@ -1,0 +1,50 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func handlePortForward(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	action, err := request.RequireString("action")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Validate action
+	if action != "create" && action != "delete" && action != "list" {
+		return mcp.NewToolResultError("invalid action: must be 'create', 'delete', or 'list'"), nil
+	}
+
+	serverID := request.GetString("server_id", "")
+	localPort := 0
+	if lp := request.GetString("local_port", ""); lp != "" {
+		if v, err := strconv.Atoi(lp); err == nil && v > 0 {
+			localPort = v
+		}
+	}
+	remotePort := 0
+	if rp := request.GetString("remote_port", ""); rp != "" {
+		if v, err := strconv.Atoi(rp); err == nil && v > 0 {
+			remotePort = v
+		}
+	}
+	remoteHost := request.GetString("remote_host", "127.0.0.1")
+
+	output, err := deployer.PortForward(ctx, action, serverID, localPort, remotePort, remoteHost)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("port forward operation failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status": "success",
+		"action": action,
+		"output": output,
+	}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/internal/mcp/handler_server.go
+++ b/internal/mcp/handler_server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
 func handleListServers(ctx context.Context, deployer Deployer, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -171,6 +173,36 @@ func handleDetectPanel(ctx context.Context, deployer Deployer, request mcp.CallT
 		"message":   "Panel detection initiated. Use detect_environment for full environment details.",
 	}
 
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+func handleExecCommand(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	command, err := request.RequireString("command")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	serverID := request.GetString("server_id", "")
+	timeout := 30
+	if t := request.GetString("timeout", ""); t != "" {
+		if v, err := strconv.Atoi(t); err == nil && v > 0 {
+			timeout = v
+		}
+	}
+
+	output, err := deployer.ExecCommand(ctx, serverID, command, timeout)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("command execution failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{
+		"status":  "success",
+		"command": command,
+		"output":  output,
+	}
+	if serverID != "" {
+		result["server_id"] = serverID
+	}
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -30,6 +30,11 @@ var ToolPermissions = map[string]int{
 	"delete_app": 3, "delete_server": 3, "delete_credential": 3,
 	"delete_dns_record": 3, "batch_deploy": 3, "batch_dns": 3,
 	"batch_backup": 3, "delete_ssl_certificate": 3,
+	"exec_command": 3,
+	// Dev-level (port forwarding)
+	"port_forward": 2,
+	// Viewer-level (read-only images)
+	"list_images": 1,
 	// Owner-level (system)
 	"update_user_role": 4, "delete_user": 4,
 }

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -35,6 +35,10 @@ var ToolPermissions = map[string]int{
 	"port_forward": 2,
 	// Viewer-level (read-only images)
 	"list_images": 1,
+	// Phase 3.1: Compose operations
+	"compose_deploy": 3, "compose_stop": 3,
+	"compose_ps": 1, "compose_logs": 1,
+	"compose_restart": 2,
 	// Owner-level (system)
 	"update_user_role": 4, "delete_user": 4,
 }

--- a/internal/mcp/register_deploy.go
+++ b/internal/mcp/register_deploy.go
@@ -179,5 +179,13 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 	s.AddTool(healContainerTool, withPermissionCheck("heal_container", withValidation("heal_container", healContainerTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleHealContainer(ctx, d, request)
 	})))
+	listImagesTool := mcp.NewTool("list_images",
+		mcp.WithDescription("List Docker images on a server. Runs locally if server_id is omitted, or remotely via SSH if server_id is provided."),
+		mcp.WithString("server_id", mcp.Description("Target server ID (omit for local execution)")),
+		mcp.WithString("filter", mcp.Description("Grep filter to apply to the output")),
+	)
+	s.AddTool(listImagesTool, withPermissionCheck("list_images", withValidation("list_images", listImagesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListImages(ctx, d, request)
+	})))
 
 }

--- a/internal/mcp/register_deploy.go
+++ b/internal/mcp/register_deploy.go
@@ -187,5 +187,44 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 	s.AddTool(listImagesTool, withPermissionCheck("list_images", withValidation("list_images", listImagesTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleListImages(ctx, d, request)
 	})))
+	// Phase 3.1: Compose tools
+	composeDeployTool := mcp.NewTool("compose_deploy",
+		mcp.WithDescription("Deploy an app using docker-compose. The app must have compose_content set."),
+		mcp.WithString("app_id", mcp.Required(), mcp.Description("Application ID to deploy with docker-compose")),
+	)
+	s.AddTool(composeDeployTool, withPermissionCheck("compose_deploy", withValidation("compose_deploy", composeDeployTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleComposeDeploy(ctx, d, request)
+	})))
+	composeStopTool := mcp.NewTool("compose_stop",
+		mcp.WithDescription("Stop a docker-compose deployment and remove containers."),
+		mcp.WithString("app_id", mcp.Required(), mcp.Description("Application ID to stop")),
+	)
+	s.AddTool(composeStopTool, withPermissionCheck("compose_stop", withValidation("compose_stop", composeStopTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleComposeStop(ctx, d, request)
+	})))
+	composePsTool := mcp.NewTool("compose_ps",
+		mcp.WithDescription("List containers managed by docker-compose for an app."),
+		mcp.WithString("app_id", mcp.Required(), mcp.Description("Application ID")),
+	)
+	s.AddTool(composePsTool, withPermissionCheck("compose_ps", withValidation("compose_ps", composePsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleComposePs(ctx, d, request)
+	})))
+	composeLogsTool := mcp.NewTool("compose_logs",
+		mcp.WithDescription("View logs from docker-compose services for an app."),
+		mcp.WithString("app_id", mcp.Required(), mcp.Description("Application ID")),
+		mcp.WithString("service", mcp.Description("Service name to get logs from (omit for all services)")),
+		mcp.WithString("tail", mcp.Description("Number of lines to show from the end (e.g. '100')")),
+	)
+	s.AddTool(composeLogsTool, withPermissionCheck("compose_logs", withValidation("compose_logs", composeLogsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleComposeLogs(ctx, d, request)
+	})))
+	composeRestartTool := mcp.NewTool("compose_restart",
+		mcp.WithDescription("Restart docker-compose services for an app."),
+		mcp.WithString("app_id", mcp.Required(), mcp.Description("Application ID")),
+		mcp.WithString("service", mcp.Description("Service name to restart (omit to restart all services)")),
+	)
+	s.AddTool(composeRestartTool, withPermissionCheck("compose_restart", withValidation("compose_restart", composeRestartTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleComposeRestart(ctx, d, request)
+	})))
 
 }

--- a/internal/mcp/register_portforward.go
+++ b/internal/mcp/register_portforward.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// registerPortForwardTools registers port forwarding tools.
+func registerPortForwardTools(s *server.MCPServer, d Deployer) {
+	portForwardTool := mcp.NewTool("port_forward",
+		mcp.WithDescription("Manage SSH port forwards to servers. Actions: create, delete, list."),
+		mcp.WithString("action", mcp.Required(), mcp.Description("Action to perform: 'create', 'delete', or 'list'")),
+		mcp.WithString("server_id", mcp.Description("Target server ID (required for create/delete)")),
+		mcp.WithNumber("local_port", mcp.Description("Local port to bind (required for create)")),
+		mcp.WithNumber("remote_port", mcp.Description("Remote port to forward to (required for create)")),
+		mcp.WithString("remote_host", mcp.Description("Remote host to connect to (default: 127.0.0.1)")),
+	)
+	s.AddTool(portForwardTool, withPermissionCheck("port_forward", withValidation("port_forward", portForwardTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handlePortForward(ctx, d, request)
+	})))
+}

--- a/internal/mcp/register_server.go
+++ b/internal/mcp/register_server.go
@@ -60,5 +60,14 @@ func registerServerTools(s *server.MCPServer, d Deployer) {
 	s.AddTool(doctorTool, withPermissionCheck("doctor", withValidation("doctor", doctorTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleDoctor(ctx, d, request)
 	})))
+	execCommandTool := mcp.NewTool("exec_command",
+		mcp.WithDescription("Execute a command on a server. Runs locally if server_id is omitted, or remotely via SSH if server_id is provided."),
+		mcp.WithString("command", mcp.Required(), mcp.Description("Command to execute")),
+		mcp.WithString("server_id", mcp.Description("Target server ID (omit for local execution)")),
+		mcp.WithNumber("timeout", mcp.Description("Timeout in seconds (default: 30)")),
+	)
+	s.AddTool(execCommandTool, withPermissionCheck("exec_command", withValidation("exec_command", execCommandTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleExecCommand(ctx, d, request)
+	})))
 
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -66,6 +66,7 @@ func NewServer(deployer Deployer) *server.MCPServer {
 	registerPluginTools(s, deployer)
 	registerK8sTools(s, deployer)
 	registerSystemTools(s, deployer)
+	registerPortForwardTools(s, deployer)
 
 	return s
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -573,6 +573,38 @@ func (m *mockDeployer) GetPluginInfo(pluginID string) (interface{}, error) {
 	return map[string]interface{}{"plugin_id": pluginID, "name": "test-plugin"}, nil
 }
 
+func (m *mockDeployer) ExecCommand(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ListImages(_ context.Context, _ string, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) PortForward(_ context.Context, _ string, _ string, _ int, _ int, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ComposeDeploy(_ context.Context, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ComposeStop(_ context.Context, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ComposePs(_ context.Context, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ComposeLogs(_ context.Context, _ string, _ string, _ string) (string, error) {
+	return "mock response", nil
+}
+
+func (m *mockDeployer) ComposeRestart(_ context.Context, _ string, _ string) (string, error) {
+	return "mock response", nil
+}
+
 // extractText gets the text content from a CallToolResult.
 func extractText(result *mcp.CallToolResult) (string, error) {
 	if result.IsError {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -85,6 +85,10 @@ type Deployer interface {
 	PluginOps(pluginID string, action string) (interface{}, error)
 	ListPlugins(provider string) (interface{}, error)
 	GetPluginInfo(pluginID string) (interface{}, error)
+	// Phase 3.3: Server operations
+	ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error)
+	ListImages(ctx context.Context, serverID, filter string) (string, error)
+	PortForward(ctx context.Context, action, serverID string, localPort, remotePort int, remoteHost string) (string, error)
 }
 
 // DeployConfig mirrors deployer.DeployConfig to avoid circular imports.

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -89,6 +89,12 @@ type Deployer interface {
 	ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error)
 	ListImages(ctx context.Context, serverID, filter string) (string, error)
 	PortForward(ctx context.Context, action, serverID string, localPort, remotePort int, remoteHost string) (string, error)
+	// Phase 3.1: Compose operations
+	ComposeDeploy(ctx context.Context, appID string) (string, error)
+	ComposeStop(ctx context.Context, appID string) (string, error)
+	ComposePs(ctx context.Context, appID string) (string, error)
+	ComposeLogs(ctx context.Context, appID, service, tail string) (string, error)
+	ComposeRestart(ctx context.Context, appID, service string) (string, error)
 }
 
 // DeployConfig mirrors deployer.DeployConfig to avoid circular imports.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -83,7 +83,9 @@ type App struct {
 	CurrentVersion string    `json:"current_version"`
 	ContainerName  string    `json:"container_name"`
 	EnvVars        string    `gorm:"type:text" json:"env_vars"`
-	ResourceLimits string    `gorm:"type:text" json:"resource_limits"`
+	ResourceLimits    string    `gorm:"type:text" json:"resource_limits"`
+	ComposeContent    string    `gorm:"type:text" json:"compose_content,omitempty"`
+	ComposeProjectName string   `json:"compose_project_name,omitempty"`
 	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt      time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -435,5 +437,188 @@ func defaultVal(val, def string) string {
 
 
 // ---------- GetServersByTags ----------
+
+// ---------- Phase 3.3: ExecCommand ----------
+
+func (b *Bridge) ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error) {
+	execCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	if serverID == "" {
+		// Local execution
+		return b.Executor.RunCommand(execCtx, command)
+	}
+
+	// Remote execution via SSH
+	remoteExec, err := b.getRemoteExecutor(ctx, serverID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote executor for server %s: %w", serverID, err)
+	}
+	defer func() {
+		if cerr := remoteExec.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	return remoteExec.RunCommand(execCtx, command)
+}
+
+// ---------- Phase 3.3: ListImages ----------
+
+func (b *Bridge) ListImages(ctx context.Context, serverID, filter string) (string, error) {
+	dockerCmd := `docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}"`
+	if filter != "" {
+		dockerCmd += " | grep " + filter
+	}
+
+	execCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if serverID == "" {
+		return b.Executor.RunCommand(execCtx, dockerCmd)
+	}
+
+	remoteExec, err := b.getRemoteExecutor(ctx, serverID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get remote executor for server %s: %w", serverID, err)
+	}
+	defer func() {
+		if cerr := remoteExec.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	return remoteExec.RunCommand(execCtx, dockerCmd)
+}
+
+// ---------- Phase 3.3: PortForward ----------
+
+// portForwardEntry tracks an active SSH port forward.
+type portForwardEntry struct {
+	ServerID   string
+	LocalPort  int
+	RemotePort int
+	RemoteHost string
+	Command    string
+}
+
+// portForwardMu protects portForwards map.
+var portForwardMu sync.RWMutex
+
+// portForwards stores active port forwards keyed by "serverID:localPort".
+var portForwards = make(map[string]*portForwardEntry)
+
+func (b *Bridge) PortForward(ctx context.Context, action, serverID string, localPort, remotePort int, remoteHost string) (string, error) {
+	switch action {
+	case "list":
+		portForwardMu.RLock()
+		defer portForwardMu.RUnlock()
+		if len(portForwards) == 0 {
+			return "No active port forwards.", nil
+		}
+		var lines []string
+		for key, pf := range portForwards {
+			lines = append(lines, fmt.Sprintf("  %s -> server=%s remote=%s:%d (key=%s)", pf.Command, pf.ServerID, pf.RemoteHost, pf.RemotePort, key))
+		}
+		return fmt.Sprintf("Active port forwards (%d):\n%s", len(portForwards), strings.Join(lines, "\n")), nil
+
+	case "create":
+		if serverID == "" {
+			return "", fmt.Errorf("server_id is required for create action")
+		}
+		if localPort <= 0 || remotePort <= 0 {
+			return "", fmt.Errorf("local_port and remote_port must be positive integers")
+		}
+		if remoteHost == "" {
+			remoteHost = "127.0.0.1"
+		}
+
+		key := fmt.Sprintf("%s:%d", serverID, localPort)
+		portForwardMu.Lock()
+		defer portForwardMu.Unlock()
+
+		if _, exists := portForwards[key]; exists {
+			return "", fmt.Errorf("port forward already exists for %s (local port %d is already in use)", key, localPort)
+		}
+
+		// Get server info for SSH connection
+		row := make(map[string]interface{})
+		if err := b.DB.Table("servers").Where("id = ?", serverID).Take(&row).Error; err != nil {
+			return "", fmt.Errorf("server not found: %w", err)
+		}
+
+		host := toString(row["host"])
+		port := toInt(row["port"])
+		username := toString(row["username"])
+		if username == "" {
+			username = os.Getenv("DEPLOYPILOT_SSH_DEFAULT_USER")
+		}
+		if username == "" {
+			username = "root"
+		}
+
+		sshCmd := fmt.Sprintf("ssh -N -L %d:%s:%d -p %d %s@%s",
+			localPort, remoteHost, remotePort, port, username, host)
+
+		// Execute SSH tunnel in background
+		execCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		// We run the SSH command and let it run in the background
+		// Since CommandExecutor.RunCommand is blocking, we launch it in a goroutine
+		go func() {
+			remoteExec, err := b.getRemoteExecutor(ctx, serverID)
+			if err != nil {
+				slog.Error("failed to create SSH tunnel", "error", err)
+				return
+			}
+			defer remoteExec.Close()
+
+			tunnelCmd := fmt.Sprintf("ssh -f -N -L %d:%s:%d -p %d %s@%s",
+				localPort, remoteHost, remotePort, port, username, host)
+			if _, err := remoteExec.RunCommand(execCtx, tunnelCmd); err != nil {
+				slog.Error("SSH tunnel command failed", "error", err)
+			}
+			cancel()
+		}()
+
+		portForwards[key] = &portForwardEntry{
+			ServerID:   serverID,
+			LocalPort:  localPort,
+			RemotePort: remotePort,
+			RemoteHost: remoteHost,
+			Command:    sshCmd,
+		}
+
+		return fmt.Sprintf("Port forward created: localhost:%d -> %s:%d:%d (server: %s)", localPort, remoteHost, remotePort, port, serverID), nil
+
+	case "delete":
+		if serverID == "" {
+			return "", fmt.Errorf("server_id is required for delete action")
+		}
+		if localPort <= 0 {
+			return "", fmt.Errorf("local_port must be a positive integer")
+		}
+
+		key := fmt.Sprintf("%s:%d", serverID, localPort)
+		portForwardMu.Lock()
+		defer portForwardMu.Unlock()
+
+		entry, exists := portForwards[key]
+		if !exists {
+			return "", fmt.Errorf("port forward not found for %s", key)
+		}
+
+		// Kill the SSH tunnel process
+		killCmd := fmt.Sprintf("pkill -f 'ssh.*-L %d:%s:%d'", localPort, entry.RemoteHost, entry.RemotePort)
+		if _, err := b.Executor.RunCommand(ctx, killCmd); err != nil {
+			slog.Warn("failed to kill SSH tunnel process", "error", err)
+		}
+
+		delete(portForwards, key)
+		return fmt.Sprintf("Port forward deleted: %s", key), nil
+
+	default:
+		return "", fmt.Errorf("invalid action: %s (must be 'create', 'delete', or 'list')", action)
+	}
+}
 
 

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -731,7 +731,11 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 				slog.Error("failed to create SSH tunnel", "error", err)
 				return
 			}
-			defer remoteExec.Close()
+			defer func() {
+				if cerr := remoteExec.Close(); cerr != nil {
+					slog.Warn("failed to close remote executor", "error", cerr)
+				}
+			}()
 
 			tunnelCmd := fmt.Sprintf("ssh -f -N -L %d:%s:%d -p %d %s@%s",
 				localPort, remoteHost, remotePort, port, username, host)

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -19,6 +20,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/crypto"
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
 	"github.com/Yogdunana/deploypilot/internal/engine/healer"
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/monitor"
 	"github.com/Yogdunana/deploypilot/internal/plugin"
 	"github.com/Yogdunana/deploypilot/internal/provider/server"
@@ -437,6 +439,140 @@ func defaultVal(val, def string) string {
 
 
 // ---------- GetServersByTags ----------
+
+// ---------- Phase 3.1: Compose Operations ----------
+
+// ComposeDeploy deploys an app using docker-compose.
+func (b *Bridge) ComposeDeploy(ctx context.Context, app *model.App) (string, error) {
+	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := executor.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	workDir := fmt.Sprintf("/opt/deploypilot/apps/%s", app.Name)
+	projectName := app.ComposeProjectName
+	if projectName == "" {
+		projectName = app.Name
+	}
+
+	// Prepend project name to compose content if not present
+	composeContent := app.ComposeContent
+	if !strings.Contains(composeContent, "name:") && !strings.Contains(composeContent, "version:") {
+		// Wrap with project name
+		composeContent = fmt.Sprintf("name: %s\n\n%s", projectName, composeContent)
+	}
+
+	// Parse env vars from JSON string
+	var envVars map[string]string
+	if app.EnvVars != "" {
+		_ = json.Unmarshal([]byte(app.EnvVars), &envVars)
+	}
+
+	deployer := deployer.NewComposeDeployer(executor)
+	out, err := deployer.ComposeUp(ctx, workDir, composeContent, envVars)
+	if err != nil {
+		return out, err
+	}
+
+	// Save deployment record
+	if b.DB != nil {
+		snapshotJSON, _ := json.Marshal(map[string]interface{}{
+			"compose_content":     composeContent,
+			"compose_project_name": projectName,
+			"env_vars":            envVars,
+		})
+		record := &model.DeploymentRecord{
+			ID:             generateID(),
+			TenantID:       app.TenantID,
+			ServerID:       app.ServerID,
+			AppName:        app.Name,
+			AppID:          app.ID,
+			DeployType:     "compose_up",
+			ConfigSnapshot: string(snapshotJSON),
+			Status:         "success",
+			CreatedAt:      time.Now(),
+			UpdatedAt:      time.Now(),
+		}
+		if err := b.DB.Create(record).Error; err != nil {
+			slog.Error("failed to save compose deployment record", "error", err)
+		}
+	}
+
+	return out, nil
+}
+
+// ComposeStop stops a compose deployment.
+func (b *Bridge) ComposeStop(ctx context.Context, app *model.App) (string, error) {
+	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := executor.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	workDir := fmt.Sprintf("/opt/deploypilot/apps/%s", app.Name)
+	deployer := deployer.NewComposeDeployer(executor)
+	return deployer.ComposeDown(ctx, workDir)
+}
+
+// ComposePs lists compose containers.
+func (b *Bridge) ComposePs(ctx context.Context, app *model.App) (string, error) {
+	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := executor.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	workDir := fmt.Sprintf("/opt/deploypilot/apps/%s", app.Name)
+	deployer := deployer.NewComposeDeployer(executor)
+	return deployer.ComposePs(ctx, workDir)
+}
+
+// ComposeLogs gets compose service logs.
+func (b *Bridge) ComposeLogs(ctx context.Context, app *model.App, service, tail string) (string, error) {
+	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := executor.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	workDir := fmt.Sprintf("/opt/deploypilot/apps/%s", app.Name)
+	deployer := deployer.NewComposeDeployer(executor)
+	return deployer.ComposeLogs(ctx, workDir, service, tail)
+}
+
+// ComposeRestart restarts compose services.
+func (b *Bridge) ComposeRestart(ctx context.Context, app *model.App, service string) (string, error) {
+	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if cerr := executor.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	workDir := fmt.Sprintf("/opt/deploypilot/apps/%s", app.Name)
+	deployer := deployer.NewComposeDeployer(executor)
+	return deployer.ComposeRestart(ctx, workDir, service)
+}
 
 // ---------- Phase 3.3: ExecCommand ----------
 

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -443,7 +443,12 @@ func defaultVal(val, def string) string {
 // ---------- Phase 3.1: Compose Operations ----------
 
 // ComposeDeploy deploys an app using docker-compose.
-func (b *Bridge) ComposeDeploy(ctx context.Context, app *model.App) (string, error) {
+func (b *Bridge) ComposeDeploy(ctx context.Context, appID string) (string, error) {
+	var app model.App
+	if err := b.DB.First(&app, "id = ?", appID).Error; err != nil {
+		return "", fmt.Errorf("app not found: %w", err)
+	}
+
 	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
 	if err != nil {
 		return "", err
@@ -507,7 +512,12 @@ func (b *Bridge) ComposeDeploy(ctx context.Context, app *model.App) (string, err
 }
 
 // ComposeStop stops a compose deployment.
-func (b *Bridge) ComposeStop(ctx context.Context, app *model.App) (string, error) {
+func (b *Bridge) ComposeStop(ctx context.Context, appID string) (string, error) {
+	var app model.App
+	if err := b.DB.First(&app, "id = ?", appID).Error; err != nil {
+		return "", fmt.Errorf("app not found: %w", err)
+	}
+
 	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
 	if err != nil {
 		return "", err
@@ -524,7 +534,12 @@ func (b *Bridge) ComposeStop(ctx context.Context, app *model.App) (string, error
 }
 
 // ComposePs lists compose containers.
-func (b *Bridge) ComposePs(ctx context.Context, app *model.App) (string, error) {
+func (b *Bridge) ComposePs(ctx context.Context, appID string) (string, error) {
+	var app model.App
+	if err := b.DB.First(&app, "id = ?", appID).Error; err != nil {
+		return "", fmt.Errorf("app not found: %w", err)
+	}
+
 	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
 	if err != nil {
 		return "", err
@@ -541,7 +556,12 @@ func (b *Bridge) ComposePs(ctx context.Context, app *model.App) (string, error) 
 }
 
 // ComposeLogs gets compose service logs.
-func (b *Bridge) ComposeLogs(ctx context.Context, app *model.App, service, tail string) (string, error) {
+func (b *Bridge) ComposeLogs(ctx context.Context, appID, service, tail string) (string, error) {
+	var app model.App
+	if err := b.DB.First(&app, "id = ?", appID).Error; err != nil {
+		return "", fmt.Errorf("app not found: %w", err)
+	}
+
 	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
 	if err != nil {
 		return "", err
@@ -558,7 +578,12 @@ func (b *Bridge) ComposeLogs(ctx context.Context, app *model.App, service, tail 
 }
 
 // ComposeRestart restarts compose services.
-func (b *Bridge) ComposeRestart(ctx context.Context, app *model.App, service string) (string, error) {
+func (b *Bridge) ComposeRestart(ctx context.Context, appID, service string) (string, error) {
+	var app model.App
+	if err := b.DB.First(&app, "id = ?", appID).Error; err != nil {
+		return "", fmt.Errorf("app not found: %w", err)
+	}
+
 	executor, err := b.getRemoteExecutor(ctx, app.ServerID)
 	if err != nil {
 		return "", err

--- a/internal/service/rollback_test.go
+++ b/internal/service/rollback_test.go
@@ -58,6 +58,8 @@ func setupRollbackTestDB(t *testing.T) *gorm.DB {
 		container_name TEXT,
 		env_vars TEXT,
 		resource_limits TEXT,
+		compose_content TEXT,
+		compose_project_name TEXT,
 		created_at DATETIME,
 		updated_at DATETIME
 	)`)


### PR DESCRIPTION
## Summary

Add 3 new MCP tools following the existing 3-layer architecture (register → handler → interface).

### exec_command (admin level)
- Execute arbitrary commands on local or remote servers via SSH
- Required: `command` (string)
- Optional: `server_id`, `timeout` (default 30s)

### list_images (viewer level)
- List Docker images on a server with optional grep filter
- Optional: `server_id`, `filter`

### port_forward (dev level)
- SSH port forwarding management (create/delete/list)
- Required: `action` (create/delete/list)
- Optional: `server_id`, `local_port`, `remote_port`, `remote_host`

Agent-Task: mcp-tools-phase33
Agent-Model: SOLO