### PR TITLE
feat: env var templates (Phase 3.4) + preflight visualization (Phase 3.5)

### DIFF
--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -187,6 +187,21 @@ func handleListImages(ctx context.Context, deployer Deployer, request mcp.CallTo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
+
+// ---------- Phase 3.5: Preflight Visualization ----------
+
+func handleRunPreflight(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	serverID := request.GetString("server_id", "")
+	portMappings := request.GetString("port_mappings", "")
+
+	result, err := deployer.RunPreflightFull(ctx, serverID, portMappings)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("preflight check failed: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
 func handleDeployApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	image, err := request.RequireString("image")
 	if err != nil {

--- a/internal/mcp/handler_template.go
+++ b/internal/mcp/handler_template.go
@@ -31,3 +31,28 @@ func handleGetTemplate(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
+func handleListEnvTemplates(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	templates, err := deployer.ListEnvTemplates(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("list env templates failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{"status": "success", "env_templates": templates}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+func handleGetEnvTemplate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	serviceType, err := request.RequireString("service_type")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	tmpl, err := deployer.GetEnvTemplate(ctx, serviceType)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("get env template failed: %v", err)), nil
+	}
+
+	result := map[string]interface{}{"status": "success", "env_template": tmpl}
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -6,7 +6,7 @@ var ToolPermissions = map[string]int{
 	// Viewer-level (read-only)
 	"list_apps": 1, "get_app_detail": 1, "list_servers": 1,
 	"list_credentials": 1, "list_dns_records": 1, "list_templates": 1,
-	"get_template": 1, "get_deploy_status": 1, "get_task_status": 1,
+	"get_template": 1, "list_env_templates": 1, "get_env_template": 1, "get_deploy_status": 1, "get_task_status": 1,
 	"list_tasks": 1, "list_deployments": 1, "detect_environment": 1,
 	"health_check": 1, "doctor": 1, "get_container_metrics": 1,
 	"get_system_metrics": 1, "list_alerts": 1, "list_alert_rules": 1,
@@ -39,6 +39,8 @@ var ToolPermissions = map[string]int{
 	"compose_deploy": 3, "compose_stop": 3,
 	"compose_ps": 1, "compose_logs": 1,
 	"compose_restart": 2,
+	// Phase 3.5: Preflight visualization
+	"run_preflight": 1,
 	// Owner-level (system)
 	"update_user_role": 4, "delete_user": 4,
 }

--- a/internal/mcp/register_deploy.go
+++ b/internal/mcp/register_deploy.go
@@ -226,5 +226,14 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 	s.AddTool(composeRestartTool, withPermissionCheck("compose_restart", withValidation("compose_restart", composeRestartTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleComposeRestart(ctx, d, request)
 	})))
+	// Phase 3.5: Preflight visualization
+	runPreflightTool := mcp.NewTool("run_preflight",
+		mcp.WithDescription("Run full preflight checks (TCP, SSH, Docker, port conflict, disk space, memory) without triggering deployment"),
+		mcp.WithString("server_id", mcp.Description("Target server ID to run preflight checks on (omit for local)")),
+		mcp.WithString("port_mappings", mcp.Description("Port mappings to check for conflicts (e.g. '8080:80,3000:3000')")),
+	)
+	s.AddTool(runPreflightTool, withPermissionCheck("run_preflight", withValidation("run_preflight", runPreflightTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleRunPreflight(ctx, d, request)
+	})))
 
 }

--- a/internal/mcp/register_template.go
+++ b/internal/mcp/register_template.go
@@ -21,5 +21,18 @@ func registerTemplateTools(s *server.MCPServer, d Deployer) {
 	s.AddTool(getTmplTool, withPermissionCheck("get_template", withValidation("get_template", getTmplTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleGetTemplate(ctx, d, request)
 	})))
+	listEnvTmplTool := mcp.NewTool("list_env_templates",
+		mcp.WithDescription("List all available environment variable templates for common services"),
+	)
+	s.AddTool(listEnvTmplTool, withPermissionCheck("list_env_templates", withValidation("list_env_templates", listEnvTmplTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListEnvTemplates(ctx, d, request)
+	})))
+	getEnvTmplTool := mcp.NewTool("get_env_template",
+		mcp.WithDescription("Get environment variable template for a specific service type"),
+		mcp.WithString("service_type", mcp.Required(), mcp.Description("Service type: mysql, redis, postgresql, mongodb, nginx")),
+	)
+	s.AddTool(getEnvTmplTool, withPermissionCheck("get_env_template", withValidation("get_env_template", getEnvTmplTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleGetEnvTemplate(ctx, d, request)
+	})))
 
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -605,6 +605,18 @@ func (m *mockDeployer) ComposeRestart(_ context.Context, _ string, _ string) (st
 	return "mock response", nil
 }
 
+func (m *mockDeployer) ListEnvTemplates(_ context.Context) (interface{}, error) {
+	return []map[string]interface{}{}, nil
+}
+
+func (m *mockDeployer) GetEnvTemplate(_ context.Context, _ string) (interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+
+func (m *mockDeployer) RunPreflightFull(_ context.Context, _ string, _ string) (interface{}, error) {
+	return map[string]interface{}{"passed": true, "checks": []interface{}{}}, nil
+}
+
 // extractText gets the text content from a CallToolResult.
 func extractText(result *mcp.CallToolResult) (string, error) {
 	if result.IsError {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -43,6 +43,8 @@ type Deployer interface {
 	SendNotification(ctx context.Context, nType, appName, server, status, message string) (interface{}, error)
 	ListTemplates(ctx context.Context) (interface{}, error)
 	GetTemplate(ctx context.Context, tmplType string) (interface{}, error)
+	ListEnvTemplates(ctx context.Context) (interface{}, error)
+	GetEnvTemplate(ctx context.Context, serviceType string) (interface{}, error)
 	GetAppDetail(ctx context.Context, appID string) (interface{}, error)
 	UpdateApp(ctx context.Context, appID string, config map[string]interface{}) (interface{}, error)
 	GetTaskStatus(ctx context.Context, taskID string) (interface{}, error)
@@ -95,6 +97,8 @@ type Deployer interface {
 	ComposePs(ctx context.Context, appID string) (string, error)
 	ComposeLogs(ctx context.Context, appID, service, tail string) (string, error)
 	ComposeRestart(ctx context.Context, appID, service string) (string, error)
+	// Phase 3.5: Preflight visualization
+	RunPreflightFull(ctx context.Context, serverID string, portMappings string) (interface{}, error)
 }
 
 // DeployConfig mirrors deployer.DeployConfig to avoid circular imports.

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -599,6 +599,47 @@ func (b *Bridge) ComposeRestart(ctx context.Context, appID, service string) (str
 	return deployer.ComposeRestart(ctx, workDir, service)
 }
 
+// ---------- Phase 3.5: Preflight Visualization ----------
+
+// RunPreflightFull runs all preflight checks without short-circuiting and returns a full report.
+func (b *Bridge) RunPreflightFull(ctx context.Context, serverID string, portMappings string) (interface{}, error) {
+	var executor CommandExecutor
+	var host string
+	var port int
+
+	if serverID != "" {
+		remoteExec, err := b.getRemoteExecutor(ctx, serverID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get remote executor for server %s: %w", serverID, err)
+		}
+		defer func() {
+			if cerr := remoteExec.Close(); cerr != nil {
+				slog.Warn("failed to close remote executor", "error", cerr)
+			}
+		}()
+		executor = remoteExec
+
+		// Look up server host/port for TCP check
+		row := make(map[string]interface{})
+		if err := b.DB.Table("servers").Where("id = ?", serverID).Take(&row).Error; err == nil {
+			host = toString(row["host"])
+			port = toInt(row["port"])
+		}
+	} else {
+		executor = b.Executor
+	}
+
+	cfg := PreflightConfig{
+		Host:         host,
+		Port:         port,
+		Executor:     executor,
+		PortMappings: portMappings,
+	}
+
+	result := RunPreflightFull(ctx, cfg)
+	return result, nil
+}
+
 // ---------- Phase 3.3: ExecCommand ----------
 
 func (b *Bridge) ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error) {

--- a/internal/service/preflight.go
+++ b/internal/service/preflight.go
@@ -34,6 +34,8 @@ type PreflightCheck struct {
 	Passed     bool   `json:"passed"`
 	Message    string `json:"message,omitempty"`
 	Suggestion string `json:"suggestion,omitempty"`
+	Category   string `json:"category,omitempty"`  // "network", "docker", "resource", "disk", "memory"
+	Severity   string `json:"severity,omitempty"`  // "error", "warning", "info"
 }
 
 // PreflightConfig holds the configuration for preflight checks.
@@ -239,4 +241,216 @@ func parseHostPorts(portMappings string) []string {
 		}
 	}
 	return ports
+}
+
+// parseDiskSize parses a human-readable disk size string (e.g. "50G", "200M", "1024K") into float64 GB.
+func parseDiskSize(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size string")
+	}
+	// Remove trailing non-numeric characters (unit suffix)
+	suffix := ""
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] < '0' || s[i] > '9' {
+			suffix = string(s[i]) + suffix
+			s = s[:i]
+		} else {
+			break
+		}
+	}
+	s = strings.TrimSpace(s)
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse size %q: %w", s, err)
+	}
+	switch strings.ToUpper(suffix) {
+	case "T", "TB":
+		return val * 1024, nil
+	case "G", "GB":
+		return val, nil
+	case "M", "MB":
+		return val / 1024, nil
+	case "K", "KB":
+		return val / (1024 * 1024), nil
+	default:
+		// Assume bytes
+		return val / (1024 * 1024 * 1024), nil
+	}
+}
+
+// checkDiskSpace verifies available disk space on the target.
+func checkDiskSpace(ctx context.Context, cfg PreflightConfig) PreflightCheck {
+	if cfg.Executor == nil {
+		return PreflightCheck{
+			Name:     "Disk Space",
+			Category: "disk",
+			Passed:   false,
+			Message:  "No executor available to check disk space",
+			Severity: "warning",
+		}
+	}
+
+	out, err := cfg.Executor.RunCommand(ctx, "df -h / --output=avail | tail -1")
+	if err != nil {
+		return PreflightCheck{
+			Name:       "Disk Space",
+			Category:   "disk",
+			Passed:     false,
+			Message:    fmt.Sprintf("Failed to check disk space: %v", err),
+			Severity:   "warning",
+			Suggestion: "Ensure the 'df' command is available on the target system",
+		}
+	}
+
+	availGB, err := parseDiskSize(strings.TrimSpace(out))
+	if err != nil {
+		return PreflightCheck{
+			Name:       "Disk Space",
+			Category:   "disk",
+			Passed:     false,
+			Message:    fmt.Sprintf("Failed to parse disk space output %q: %v", strings.TrimSpace(out), err),
+			Severity:   "warning",
+			Suggestion: "Ensure the 'df' command supports --output flag (coreutils >= 8.21)",
+		}
+	}
+
+	if availGB < 1.0 {
+		return PreflightCheck{
+			Name:       "Disk Space",
+			Category:   "disk",
+			Passed:     false,
+			Message:    fmt.Sprintf("Critical: only %.1fGB available disk space", availGB),
+			Severity:   "error",
+			Suggestion: "Clean up disk space or expand storage",
+		}
+	}
+	if availGB < 5.0 {
+		return PreflightCheck{
+			Name:       "Disk Space",
+			Category:   "disk",
+			Passed:     true,
+			Message:    fmt.Sprintf("Warning: %.1fGB available disk space (low)", availGB),
+			Severity:   "warning",
+			Suggestion: "Clean up disk space or expand storage",
+		}
+	}
+
+	return PreflightCheck{
+		Name:     "Disk Space",
+		Category: "disk",
+		Passed:   true,
+		Message:  fmt.Sprintf("%.1fGB available disk space", availGB),
+		Severity: "info",
+	}
+}
+
+// checkMemory verifies available memory on the target.
+func checkMemory(ctx context.Context, cfg PreflightConfig) PreflightCheck {
+	if cfg.Executor == nil {
+		return PreflightCheck{
+			Name:     "Memory",
+			Category: "memory",
+			Passed:   false,
+			Message:  "No executor available to check memory",
+			Severity: "warning",
+		}
+	}
+
+	out, err := cfg.Executor.RunCommand(ctx, "free -m | awk '/Mem:/{print $7}'")
+	if err != nil {
+		return PreflightCheck{
+			Name:       "Memory",
+			Category:   "memory",
+			Passed:     false,
+			Message:    fmt.Sprintf("Failed to check memory: %v", err),
+			Severity:   "warning",
+			Suggestion: "Ensure the 'free' command is available on the target system",
+		}
+	}
+
+	availMB, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return PreflightCheck{
+			Name:       "Memory",
+			Category:   "memory",
+			Passed:     false,
+			Message:    fmt.Sprintf("Failed to parse memory output %q: %v", strings.TrimSpace(out), err),
+			Severity:   "warning",
+			Suggestion: "Ensure the 'free' command is available on the target system",
+		}
+	}
+
+	if availMB < 128 {
+		return PreflightCheck{
+			Name:       "Memory",
+			Category:   "memory",
+			Passed:     false,
+			Message:    fmt.Sprintf("Critical: only %dMB available memory", availMB),
+			Severity:   "error",
+			Suggestion: "Close unused processes or add more RAM",
+		}
+	}
+	if availMB < 512 {
+		return PreflightCheck{
+			Name:       "Memory",
+			Category:   "memory",
+			Passed:     true,
+			Message:    fmt.Sprintf("Warning: %dMB available memory (low)", availMB),
+			Severity:   "warning",
+			Suggestion: "Close unused processes or add more RAM",
+		}
+	}
+
+	return PreflightCheck{
+		Name:     "Memory",
+		Category: "memory",
+		Passed:   true,
+		Message:  fmt.Sprintf("%dMB available memory", availMB),
+		Severity: "info",
+	}
+}
+
+// RunPreflightFull runs ALL preflight checks without short-circuiting on failure.
+// It collects results from every check and returns a comprehensive report.
+func RunPreflightFull(ctx context.Context, cfg PreflightConfig) PreflightResult {
+	var checks []PreflightCheck
+
+	// Check 1: TCP connectivity (only for remote deployments)
+	if cfg.Host != "" && cfg.Port != 0 {
+		checks = append(checks, checkTCP(ctx, cfg.Host, cfg.Port))
+	}
+
+	// Check 2: SSH authentication (only for remote deployments with executor)
+	if cfg.Executor != nil && cfg.Host != "" {
+		checks = append(checks, checkSSHAuth(ctx, cfg.Executor))
+	}
+
+	// Check 3: Docker availability
+	checks = append(checks, checkDocker(ctx, cfg.Executor))
+
+	// Check 4: Port conflict (only if port mappings specified)
+	if cfg.PortMappings != "" {
+		checks = append(checks, checkPortConflict(ctx, cfg.Executor, cfg.PortMappings))
+	}
+
+	// Check 5: Disk space
+	checks = append(checks, checkDiskSpace(ctx, cfg))
+
+	// Check 6: Memory
+	checks = append(checks, checkMemory(ctx, cfg))
+
+	// Overall result: failed if any check has severity "error" or Passed == false
+	passed := true
+	for _, c := range checks {
+		if !c.Passed {
+			passed = false
+			break
+		}
+	}
+
+	return PreflightResult{
+		Passed: passed,
+		Checks: checks,
+	}
 }

--- a/internal/service/template_service.go
+++ b/internal/service/template_service.go
@@ -35,3 +35,83 @@ func (b *Bridge) GetTemplate(ctx context.Context, tmplType string) (interface{},
 	}
 	return nil, fmt.Errorf("template type %q not found; available: node, python, go, java, php, ruby, rust, static, docker", tmplType)
 }
+
+// ---------- 25. ListEnvTemplates ----------
+
+func (b *Bridge) ListEnvTemplates(ctx context.Context) (interface{}, error) {
+	templates := []map[string]interface{}{
+		{
+			"service_type":  "mysql",
+			"display_name":  "MySQL",
+			"description":   "MySQL relational database server",
+			"env_vars": []map[string]interface{}{
+				{"name": "MYSQL_ROOT_PASSWORD", "description": "Root user password for MySQL", "required": true, "default_value": "", "example": "secure_password_123"},
+				{"name": "MYSQL_DATABASE", "description": "Name of the default database to create", "required": false, "default_value": "", "example": "myapp"},
+				{"name": "MYSQL_USER", "description": "Additional user to create", "required": false, "default_value": "", "example": "appuser"},
+				{"name": "MYSQL_PASSWORD", "description": "Password for the additional user", "required": false, "default_value": "", "example": "user_password"},
+				{"name": "MYSQL_PORT", "description": "Port on which MySQL listens", "required": false, "default_value": "3306", "example": "3306"},
+			},
+		},
+		{
+			"service_type":  "redis",
+			"display_name":  "Redis",
+			"description":   "Redis in-memory key-value data store",
+			"env_vars": []map[string]interface{}{
+				{"name": "REDIS_PORT", "description": "Port on which Redis listens", "required": false, "default_value": "6379", "example": "6379"},
+				{"name": "REDIS_PASSWORD", "description": "Password for Redis authentication", "required": false, "default_value": "", "example": "redis_password"},
+				{"name": "REDIS_MAXMEMORY", "description": "Maximum memory Redis can use", "required": false, "default_value": "", "example": "256mb"},
+				{"name": "REDIS_APPENDONLY", "description": "Enable AOF persistence (yes/no)", "required": false, "default_value": "yes", "example": "yes"},
+			},
+		},
+		{
+			"service_type":  "postgresql",
+			"display_name":  "PostgreSQL",
+			"description":   "PostgreSQL relational database server",
+			"env_vars": []map[string]interface{}{
+				{"name": "POSTGRES_DB", "description": "Name of the default database to create", "required": false, "default_value": "", "example": "myapp"},
+				{"name": "POSTGRES_USER", "description": "Superuser name", "required": false, "default_value": "", "example": "appuser"},
+				{"name": "POSTGRES_PASSWORD", "description": "Superuser password", "required": true, "default_value": "", "example": "secure_password_123"},
+				{"name": "POSTGRES_PORT", "description": "Port on which PostgreSQL listens", "required": false, "default_value": "5432", "example": "5432"},
+			},
+		},
+		{
+			"service_type":  "mongodb",
+			"display_name":  "MongoDB",
+			"description":   "MongoDB document-oriented NoSQL database",
+			"env_vars": []map[string]interface{}{
+				{"name": "MONGO_INITDB_ROOT_USERNAME", "description": "Root username for MongoDB", "required": false, "default_value": "", "example": "root"},
+				{"name": "MONGO_INITDB_ROOT_PASSWORD", "description": "Root password for MongoDB", "required": true, "default_value": "", "example": "secure_password_123"},
+				{"name": "MONGO_INITDB_DATABASE", "description": "Name of the default database to create", "required": false, "default_value": "", "example": "myapp"},
+				{"name": "MONGO_PORT", "description": "Port on which MongoDB listens", "required": false, "default_value": "27017", "example": "27017"},
+			},
+		},
+		{
+			"service_type":  "nginx",
+			"display_name":  "Nginx",
+			"description":   "Nginx HTTP and reverse proxy server",
+			"env_vars": []map[string]interface{}{
+				{"name": "NGINX_PORT", "description": "Port on which Nginx listens", "required": false, "default_value": "80", "example": "80"},
+				{"name": "NGINX_SERVER_NAME", "description": "Server name / domain for the default virtual host", "required": false, "default_value": "", "example": "example.com"},
+				{"name": "NGINX_SSL_CERT_PATH", "description": "Path to the SSL certificate file", "required": false, "default_value": "", "example": "/etc/nginx/ssl/cert.pem"},
+				{"name": "NGINX_SSL_KEY_PATH", "description": "Path to the SSL private key file", "required": false, "default_value": "", "example": "/etc/nginx/ssl/key.pem"},
+				{"name": "NGINX_WORKER_PROCESSES", "description": "Number of worker processes (auto or a number)", "required": false, "default_value": "auto", "example": "auto"},
+				{"name": "NGINX_CLIENT_MAX_BODY_SIZE", "description": "Maximum allowed size of the client request body", "required": false, "default_value": "64m", "example": "64m"},
+			},
+		},
+	}
+	return templates, nil
+}
+
+// ---------- 26. GetEnvTemplate ----------
+
+func (b *Bridge) GetEnvTemplate(ctx context.Context, serviceType string) (interface{}, error) {
+	all, _ := b.ListEnvTemplates(ctx)
+	tmpls := all.([]map[string]interface{})
+
+	for _, t := range tmpls {
+		if t["service_type"] == serviceType {
+			return t, nil
+		}
+	}
+	return nil, fmt.Errorf("env template for service type %q not found; available: mysql, redis, postgresql, mongodb, nginx", serviceType)
+}


### PR DESCRIPTION
## Summary

### Phase 3.4 — Environment Variable Templates
Predefined env var templates for 5 common services:
- **MySQL**: MYSQL_ROOT_PASSWORD, MYSQL_DATABASE, MYSQL_USER, MYSQL_PASSWORD, MYSQL_PORT
- **Redis**: REDIS_PORT, REDIS_PASSWORD, REDIS_MAXMEMORY, REDIS_APPENDONLY
- **PostgreSQL**: POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_PORT
- **MongoDB**: MONGO_INITDB_ROOT_USERNAME, MONGO_INITDB_ROOT_PASSWORD, MONGO_INITDB_DATABASE, MONGO_PORT
- **Nginx**: NGINX_PORT, NGINX_SERVER_NAME, NGINX_SSL_CERT_PATH, NGINX_SSL_KEY_PATH, NGINX_WORKER_PROCESSES, NGINX_CLIENT_MAX_BODY_SIZE

New MCP tools: `list_env_templates`, `get_env_template` (viewer level)

### Phase 3.5 — Preflight Visualization
- Added disk space check (< 1GB error, < 5GB warning)
- Added memory check (< 128MB error, < 512MB warning)
- Added `RunPreflightFull` — runs ALL 6 checks without short-circuiting
- Added `Category` + `Severity` fields to PreflightCheck
- New MCP tool: `run_preflight` (viewer level) — standalone preflight without deployment

Agent-Task: env-templates-preflight
Agent-Model: SOLO