### PR TITLE
feat: multi-environment (Phase 3.2) + Redis cache layer (Phase 3.6)

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -144,11 +144,13 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		slog.Warn("DEPLOYPILOT_ENCRYPTION_KEY not set, generated a temporary key (credentials will be lost on restart)")
 	}
 
-	// Initialize event bus and token blacklist (Redis if available, otherwise in-memory)
+	// Initialize event bus, token blacklist, and cache (Redis if available, otherwise in-memory)
 	var eventBus service.EventBus
 	var tokenBlacklist auth.TokenBlacklist
+	var cache service.Cache
+	var rdb *redis.Client
 	if cfg.Redis.Addr != "" {
-		rdb := redis.NewClient(&redis.Options{
+		rdb = redis.NewClient(&redis.Options{
 			Addr:     cfg.Redis.Addr,
 			Password: cfg.Redis.Password,
 			DB:       cfg.Redis.DB,
@@ -157,14 +159,17 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 			slog.Warn("Redis unavailable, falling back to in-memory implementations", "error", err)
 			eventBus = service.NewInMemoryEventBus()
 			tokenBlacklist = auth.NewMemoryTokenBlacklist()
+			cache = service.NewMemoryCache("dp:")
 		} else {
 			eventBus = service.NewRedisEventBus(rdb)
 			tokenBlacklist = auth.NewRedisTokenBlacklist(rdb)
-			slog.Info("using Redis for event bus and token blacklist")
+			cache = service.NewRedisCache(rdb, "dp:")
+			slog.Info("using Redis for event bus, token blacklist, and cache")
 		}
 	} else {
 		eventBus = service.NewInMemoryEventBus()
 		tokenBlacklist = auth.NewMemoryTokenBlacklist()
+		cache = service.NewMemoryCache("dp:")
 	}
 
 	// Initialize agent tunnel manager
@@ -172,6 +177,7 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 	tunnelManager.StartCleanup(5 * time.Minute)
 
 	bridge := service.NewBridge(db, executor, encKey, eventBus)
+	bridge.SetCache(cache)
 	bridge.TunnelManager = tunnelManager
 	bridge.UpgradeSvc = service.NewUpgradeService("")
 
@@ -262,7 +268,14 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		}
 	}
 
-	// 5. Close database connection
+	// 5. Close cache (in-memory cache only; Redis cache is closed via rdb)
+	if cache != nil && rdb == nil {
+		if err := cache.Close(); err != nil {
+			slog.Warn("cache close error", "error", err)
+		}
+	}
+
+	// 6. Close database connection
 	if sqlDB, err := db.DB(); err == nil {
 		if err := sqlDB.Close(); err != nil {
 			slog.Warn("database close error", "error", err)

--- a/cmd/deploypilot/serve.go
+++ b/cmd/deploypilot/serve.go
@@ -93,7 +93,6 @@ var serveCmd = &cobra.Command{
 			slog.Warn("DEPLOYPILOT_ENCRYPTION_KEY not set, generated a temporary key (credentials will be lost on restart)")
 		}
 		bridge := service.NewBridge(db, sandboxedExecutor, encKey, nil)
-
 		// Create MCP server
 		mcpServer := mcp.NewServer(bridge)
 

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -121,7 +121,6 @@ func run(configFilePath, cliDriver, cliDSN string) error {
 		slog.Warn("DEPLOYPILOT_ENCRYPTION_KEY not set, generated a temporary key (credentials will be lost on restart)")
 	}
 	bridge := service.NewBridge(db, executor, encKey, nil)
-
 	// Create MCP server
 	mcpServer := mcp.NewServer(bridge)
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -77,6 +77,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
 		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
+		environment TEXT DEFAULT 'production',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS deployments (

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -46,16 +46,17 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		app := model.App{
-			ID:        id,
-			TenantID:  tenantID,
-			Name:      input.Name,
-			RepoURL:   input.RepoURL,
-			Branch:    input.Branch,
-			Domain:    input.Domain,
-			TechStack: input.TechStack,
-			DeployMode: input.DeployMode,
-			ServerID:  input.ServerID,
-			Status:    "created",
+			ID:          id,
+			TenantID:    tenantID,
+			Name:        input.Name,
+			RepoURL:     input.RepoURL,
+			Branch:      input.Branch,
+			Domain:      input.Domain,
+			TechStack:   input.TechStack,
+			DeployMode:  input.DeployMode,
+			ServerID:    input.ServerID,
+			Environment: input.Environment,
+			Status:      "created",
 		}
 		if app.Branch == "" {
 			app.Branch = "main"
@@ -65,6 +66,9 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 		}
 		if app.DeployMode == "" {
 			app.DeployMode = "api"
+		}
+		if app.Environment == "" {
+			app.Environment = "production"
 		}
 
 		if err := db.Create(&app).Error; err != nil {
@@ -88,7 +92,11 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 func ListApps(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var apps []model.App
-		if err := db.Find(&apps).Error; err != nil {
+		query := db.Model(&model.App{})
+		if env := c.Query("environment"); env != "" {
+			query = query.Where("environment = ?", env)
+		}
+		if err := query.Find(&apps).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -82,19 +82,19 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		{
 			apps.POST("", CreateApp(db))
 			apps.GET("", ListApps(db))
-			apps.GET("/:id", auth.RequireResourceAccess(db, "app", "id"), GetApp(db))
-			apps.PUT("/:id", auth.RequireResourceAccess(db, "app", "id"), UpdateApp(db))
-			apps.DELETE("/:id", auth.RequireResourceAccess(db, "app", "id"), DeleteApp(bridge))
-			apps.POST("/:id/deploy", auth.RequireResourceAccess(db, "app", "id"), DeployApp(bridge))
-			apps.POST("/:id/build", auth.RequireResourceAccess(db, "app", "id"), BuildAndDeployApp(bridge))
-			apps.GET("/:id/status", auth.RequireResourceAccess(db, "app", "id"), GetAppStatus(bridge))
-			apps.POST("/:id/rollback", auth.RequireResourceAccess(db, "app", "id"), RollbackApp(bridge))
-			apps.GET("/:id/history", auth.RequireResourceAccess(db, "app", "id"), GetDeploymentHistory(bridge))
-			apps.GET("/:id/logs/container", auth.RequireResourceAccess(db, "app", "id"), GetContainerLogs(bridge))
-			apps.POST("/:id/backup", auth.RequireResourceAccess(db, "app", "id"), BackupApp(bridge))
-			apps.POST("/:id/restore", auth.RequireResourceAccess(db, "app", "id"), RestoreApp(bridge))
-			apps.GET("/:id/env", auth.RequireResourceAccess(db, "app", "id"), GetAppEnv(db))
-			apps.PUT("/:id/env", auth.RequireResourceAccess(db, "app", "id"), UpdateAppEnv(db))
+			apps.GET("/:id", auth.RequireResourceAccessCached(bridge, "app", "id"), GetApp(db))
+			apps.PUT("/:id", auth.RequireResourceAccessCached(bridge, "app", "id"), UpdateApp(db))
+			apps.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "app", "id"), DeleteApp(bridge))
+			apps.POST("/:id/deploy", auth.RequireResourceAccessCached(bridge, "app", "id"), DeployApp(bridge))
+			apps.POST("/:id/build", auth.RequireResourceAccessCached(bridge, "app", "id"), BuildAndDeployApp(bridge))
+			apps.GET("/:id/status", auth.RequireResourceAccessCached(bridge, "app", "id"), GetAppStatus(bridge))
+			apps.POST("/:id/rollback", auth.RequireResourceAccessCached(bridge, "app", "id"), RollbackApp(bridge))
+			apps.GET("/:id/history", auth.RequireResourceAccessCached(bridge, "app", "id"), GetDeploymentHistory(bridge))
+			apps.GET("/:id/logs/container", auth.RequireResourceAccessCached(bridge, "app", "id"), GetContainerLogs(bridge))
+			apps.POST("/:id/backup", auth.RequireResourceAccessCached(bridge, "app", "id"), BackupApp(bridge))
+			apps.POST("/:id/restore", auth.RequireResourceAccessCached(bridge, "app", "id"), RestoreApp(bridge))
+			apps.GET("/:id/env", auth.RequireResourceAccessCached(bridge, "app", "id"), GetAppEnv(db))
+			apps.PUT("/:id/env", auth.RequireResourceAccessCached(bridge, "app", "id"), UpdateAppEnv(db))
 		}
 
 		// Servers (7 endpoints)
@@ -102,11 +102,11 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		{
 			servers.POST("", AddServer(bridge))
 			servers.GET("", ListServers(bridge))
-			servers.PUT("/:id", auth.RequireResourceAccess(db, "server", "id"), UpdateServer(bridge))
-			servers.DELETE("/:id", auth.RequireResourceAccess(db, "server", "id"), DeleteServer(bridge))
-			servers.POST("/:id/detect", auth.RequireResourceAccess(db, "server", "id"), DetectEnvironment(bridge))
-			servers.GET("/:id/environment", auth.RequireResourceAccess(db, "server", "id"), GetServerEnvironment(bridge))
-			servers.POST("/:id/test", auth.RequireResourceAccess(db, "server", "id"), TestServer(bridge))
+			servers.PUT("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), UpdateServer(bridge))
+			servers.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), DeleteServer(bridge))
+			servers.POST("/:id/detect", auth.RequireResourceAccessCached(bridge, "server", "id"), DetectEnvironment(bridge))
+			servers.GET("/:id/environment", auth.RequireResourceAccessCached(bridge, "server", "id"), GetServerEnvironment(bridge))
+			servers.POST("/:id/test", auth.RequireResourceAccessCached(bridge, "server", "id"), TestServer(bridge))
 		}
 
 		// Credentials (5 endpoints)
@@ -114,9 +114,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		{
 			creds.GET("", ListCredentials(bridge))
 			creds.POST("", CreateCredential(bridge))
-			creds.PUT("/:id", auth.RequireResourceAccess(db, "credential", "id"), UpdateCredential(bridge))
-			creds.DELETE("/:id", auth.RequireResourceAccess(db, "credential", "id"), DeleteCredential(bridge))
-			creds.POST("/:id/rotate", auth.RequireResourceAccess(db, "credential", "id"), RotateCredential(bridge, auditSvc))
+			creds.PUT("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), UpdateCredential(bridge))
+			creds.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), DeleteCredential(bridge))
+			creds.POST("/:id/rotate", auth.RequireResourceAccessCached(bridge, "credential", "id"), RotateCredential(bridge, auditSvc))
 		}
 
 		// Clusters (6 endpoints)
@@ -124,10 +124,10 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		{
 			clusters.GET("", ListClusters(bridge))
 			clusters.POST("", CreateCluster(bridge))
-			clusters.GET("/:id", auth.RequireResourceAccess(db, "cluster", "id"), GetCluster(bridge))
-			clusters.PUT("/:id", auth.RequireResourceAccess(db, "cluster", "id"), UpdateCluster(bridge))
-			clusters.DELETE("/:id", auth.RequireResourceAccess(db, "cluster", "id"), DeleteCluster(bridge))
-			clusters.POST("/:id/test", auth.RequireResourceAccess(db, "cluster", "id"), TestClusterConnection(bridge))
+			clusters.GET("/:id", auth.RequireResourceAccessCached(bridge, "cluster", "id"), GetCluster(bridge))
+			clusters.PUT("/:id", auth.RequireResourceAccessCached(bridge, "cluster", "id"), UpdateCluster(bridge))
+			clusters.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "cluster", "id"), DeleteCluster(bridge))
+			clusters.POST("/:id/test", auth.RequireResourceAccessCached(bridge, "cluster", "id"), TestClusterConnection(bridge))
 		}
 
 		// Registries (5 endpoints)

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -31,6 +31,7 @@ func setupSSETestDB(t *testing.T) *gorm.DB {
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
 		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
+		environment TEXT DEFAULT 'production',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS servers (

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -209,10 +209,20 @@ func authorizeAppAccess(db *gorm.DB, appID, role, userID string) bool {
 	return service.CheckResourceAccess(db, "app", appID, role, userID)
 }
 
+// authorizeAppAccessCached checks if the user has permission to access the given app using cache.
+func authorizeAppAccessCached(bridge *service.Bridge, ctx context.Context, appID, role, userID string) bool {
+	return bridge.CheckResourceAccessCached(ctx, "app", appID, role, userID)
+}
+
 // authorizeServerAccess checks if the user has permission to access the given server.
 // Delegates to the shared CheckResourceAccess in the service layer.
 func authorizeServerAccess(db *gorm.DB, serverID, role, userID string) bool {
 	return service.CheckResourceAccess(db, "server", serverID, role, userID)
+}
+
+// authorizeServerAccessCached checks if the user has permission to access the given server using cache.
+func authorizeServerAccessCached(bridge *service.Bridge, ctx context.Context, serverID, role, userID string) bool {
+	return bridge.CheckResourceAccessCached(ctx, "server", serverID, role, userID)
 }
 
 // LogStreamWS handles WebSocket connections for real-time container logs.
@@ -227,7 +237,7 @@ func LogStreamWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketS
 		}
 		// 2. Check resource-level authorization
 		appID := c.Param("app_id")
-		if !authorizeAppAccess(bridge.DB, appID, role, userID) {
+		if !authorizeAppAccessCached(bridge, c.Request.Context(), appID, role, userID) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "no permission to access this app"})
 			return
 		}
@@ -413,7 +423,7 @@ func TerminalWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketSt
 		}
 		// 2. Check resource-level authorization
 		serverID := c.Param("server_id")
-		if !authorizeServerAccess(bridge.DB, serverID, role, userID) {
+		if !authorizeServerAccessCached(bridge, c.Request.Context(), serverID, role, userID) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "no permission to access this server"})
 			return
 		}

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -203,21 +203,9 @@ func (h *WSHub) ClientCount(appID string) int {
 	return len(h.clients[appID])
 }
 
-// authorizeAppAccess checks if the user has permission to access the given app.
-// Delegates to the shared CheckResourceAccess in the service layer.
-func authorizeAppAccess(db *gorm.DB, appID, role, userID string) bool {
-	return service.CheckResourceAccess(db, "app", appID, role, userID)
-}
-
 // authorizeAppAccessCached checks if the user has permission to access the given app using cache.
 func authorizeAppAccessCached(bridge *service.Bridge, ctx context.Context, appID, role, userID string) bool {
 	return bridge.CheckResourceAccessCached(ctx, "app", appID, role, userID)
-}
-
-// authorizeServerAccess checks if the user has permission to access the given server.
-// Delegates to the shared CheckResourceAccess in the service layer.
-func authorizeServerAccess(db *gorm.DB, serverID, role, userID string) bool {
-	return service.CheckResourceAccess(db, "server", serverID, role, userID)
 }
 
 // authorizeServerAccessCached checks if the user has permission to access the given server using cache.

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	"gorm.io/gorm"
 )
 
 // allowedWSSOrigins contains origins permitted for WebSocket connections.

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -30,6 +30,7 @@ func setupWSTestDB(t *testing.T) *gorm.DB {
 		domain TEXT, tech_stack TEXT DEFAULT 'docker', deploy_mode TEXT DEFAULT 'api',
 		status TEXT DEFAULT 'pending', current_version TEXT, container_name TEXT,
 		env_vars TEXT, resource_limits TEXT, compose_content TEXT, compose_project_name TEXT,
+		environment TEXT DEFAULT 'production',
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS servers (

--- a/internal/auth/resource_middleware.go
+++ b/internal/auth/resource_middleware.go
@@ -36,3 +36,31 @@ func RequireResourceAccess(db *gorm.DB, resourceType string, idParam string) gin
 		c.Next()
 	}
 }
+
+// RequireResourceAccessCached returns middleware that checks resource access using cache.
+// It uses the Bridge's cache layer for better performance.
+func RequireResourceAccessCached(bridge *service.Bridge, resourceType string, idParam string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		resourceID := c.Param(idParam)
+		if resourceID == "" {
+			locale := i18n.GetLocaleFromContext(c)
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": i18n.T(locale, "error.common.invalid_request")})
+			c.Abort()
+			return
+		}
+
+		userID, _ := c.Get(string(UserIDKey))
+		role, _ := c.Get(string(RoleKey))
+		userIDStr, _ := userID.(string)
+		roleStr, _ := role.(string)
+
+		if !bridge.CheckResourceAccessCached(c.Request.Context(), resourceType, resourceID, roleStr, userIDStr) {
+			locale := i18n.GetLocaleFromContext(c)
+			c.JSON(http.StatusForbidden, gin.H{"status": "error", "message": i18n.T(locale, "error.auth.insufficient_permissions")})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -464,6 +464,21 @@ func Migrate(db *gorm.DB) error {
 				return nil
 			},
 		},
+		// 202604290001: Add environment column to apps table
+		{
+			ID: "202604290001",
+			Migrate: func(tx *gorm.DB) error {
+				if err := ignoreDuplicateColumnError(tx, tx.Exec(`ALTER TABLE apps ADD COLUMN environment TEXT DEFAULT 'production'`).Error); err != nil {
+					return err
+				}
+				tx.Exec(`CREATE INDEX IF NOT EXISTS idx_apps_environment ON apps(environment)`)
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				// SQLite doesn't support DROP COLUMN easily
+				return nil
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -23,7 +23,6 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 	techStack := request.GetString("tech_stack", "")
 	ports := request.GetString("ports", "")
 	serverID := request.GetString("server_id", "")
-	environment := request.GetString("environment", "production")
 	envVarsStr := request.GetString("env_vars", "")
 
 	var envVars map[string]string

--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -23,6 +23,7 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 	techStack := request.GetString("tech_stack", "")
 	ports := request.GetString("ports", "")
 	serverID := request.GetString("server_id", "")
+	environment := request.GetString("environment", "production")
 	envVarsStr := request.GetString("env_vars", "")
 
 	var envVars map[string]string
@@ -336,13 +337,14 @@ func handleCreateApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 	}
 
 	cfg := CreateAppConfig{
-		Name:    name,
-		RepoURL: repoURL,
-		Branch:  request.GetString("branch", "main"),
-		Domain:  request.GetString("domain", ""),
-		TechStack: request.GetString("tech_stack", "docker"),
-		DeployMode: request.GetString("deploy_mode", "api"),
-		ServerID: request.GetString("server_id", ""),
+		Name:        name,
+		RepoURL:     repoURL,
+		Branch:      request.GetString("branch", "main"),
+		Domain:      request.GetString("domain", ""),
+		TechStack:   request.GetString("tech_stack", "docker"),
+		DeployMode:  request.GetString("deploy_mode", "api"),
+		ServerID:    request.GetString("server_id", ""),
+		Environment: request.GetString("environment", "production"),
 	}
 
 	appID, err := deployer.CreateApp(ctx, cfg)

--- a/internal/mcp/register_deploy.go
+++ b/internal/mcp/register_deploy.go
@@ -45,6 +45,7 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 		mcp.WithString("server_id",
 			mcp.Description("Target server ID for remote deployment via SSH. Omit to deploy locally. The server must be registered via add_server first."),
 		),
+		mcp.WithString("environment", mcp.Description("Deployment environment: production, staging, development, testing"), mcp.Enum("production", "staging", "development", "testing")),
 	)
 
 	s.AddTool(deployTool, withPermissionCheck("deploy_app", withValidation("deploy_app", deployTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -93,6 +94,7 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 		mcp.WithString("server_id",
 			mcp.Description("Target server ID"),
 		),
+		mcp.WithString("environment", mcp.Description("Deployment environment: production, staging, development, testing"), mcp.Enum("production", "staging", "development", "testing")),
 	)
 
 	s.AddTool(createAppTool, withPermissionCheck("create_app", withValidation("create_app", createAppTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -135,6 +137,7 @@ func registerDeployTools(s *server.MCPServer, d Deployer) {
 		mcp.WithString("registry_id", mcp.Description("Registry ID to push the built image to")),
 		mcp.WithBoolean("push_image", mcp.Description("Whether to push the built image to the registry after build")),
 		mcp.WithString("image_tag", mcp.Description("Custom image tag (default: appname:latest)")),
+		mcp.WithString("environment", mcp.Description("Deployment environment: production, staging, development, testing"), mcp.Enum("production", "staging", "development", "testing")),
 	)
 	s.AddTool(buildAndDeployTool, withPermissionCheck("build_and_deploy", withValidation("build_and_deploy", buildAndDeployTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleBuildAndDeploy(ctx, d, request)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -174,13 +174,14 @@ type ServerInfo struct {
 
 // CreateAppConfig holds parameters for creating a new application.
 type CreateAppConfig struct {
-	Name       string `json:"name"`
-	RepoURL    string `json:"repo_url"`
-	Branch     string `json:"branch,omitempty"`
-	Domain     string `json:"domain,omitempty"`
-	TechStack  string `json:"tech_stack,omitempty"`
-	DeployMode string `json:"deploy_mode,omitempty"`
-	ServerID   string `json:"server_id,omitempty"`
+	Name        string `json:"name"`
+	RepoURL     string `json:"repo_url"`
+	Branch      string `json:"branch,omitempty"`
+	Domain      string `json:"domain,omitempty"`
+	TechStack   string `json:"tech_stack,omitempty"`
+	DeployMode  string `json:"deploy_mode,omitempty"`
+	ServerID    string `json:"server_id,omitempty"`
+	Environment string `json:"environment,omitempty"`
 }
 
 // BuildAndDeployConfig holds parameters for a build-and-deploy operation.

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -86,6 +86,7 @@ type App struct {
 	ResourceLimits    string    `gorm:"type:text" json:"resource_limits"`
 	ComposeContent    string    `gorm:"type:text" json:"compose_content,omitempty"`
 	ComposeProjectName string   `json:"compose_project_name,omitempty"`
+	Environment       string   `gorm:"size:20;default:production;index" json:"environment"` // production, staging, development, testing
 	CreatedAt      time.Time `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt      time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 

--- a/internal/service/authorization.go
+++ b/internal/service/authorization.go
@@ -1,6 +1,12 @@
 package service
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
 	"gorm.io/gorm"
 )
 
@@ -35,4 +41,42 @@ func CheckResourceAccess(db *gorm.DB, resourceType, resourceID, role, userID str
 		return false
 	}
 	return count > 0
+}
+
+// CheckResourceAccessCached checks resource access with caching.
+// It uses the Bridge's Cache if available, falling back to direct DB query.
+// Cache key format: perm:{userID}:{resourceType}:{resourceID}, TTL: 5 minutes.
+func (b *Bridge) CheckResourceAccessCached(ctx context.Context, resourceType, resourceID, role, userID string) bool {
+	// owner and admin can access all resources (no need to cache)
+	if role == "owner" || role == "admin" {
+		return true
+	}
+
+	// Try cache first
+	if b.Cache != nil {
+		cacheKey := fmt.Sprintf("perm:%s:%s:%s", userID, resourceType, resourceID)
+		cached, err := b.Cache.Get(ctx, cacheKey)
+		if err == nil {
+			result, parseErr := strconv.ParseBool(cached)
+			if parseErr == nil {
+				return result
+			}
+		}
+		if err != nil && err != ErrCacheMiss {
+			slog.Warn("cache get error, falling back to DB", "error", err)
+		}
+
+		// Cache miss: query DB
+		result := CheckResourceAccess(b.DB, resourceType, resourceID, role, userID)
+
+		// Store result in cache (fire-and-forget)
+		if cacheErr := b.Cache.Set(ctx, cacheKey, strconv.FormatBool(result), 5*time.Minute); cacheErr != nil {
+			slog.Warn("cache set error", "error", cacheErr)
+		}
+
+		return result
+	}
+
+	// No cache available, query directly
+	return CheckResourceAccess(b.DB, resourceType, resourceID, role, userID)
 }

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -79,6 +79,7 @@ type Bridge struct {
 	UpgradeSvc    *UpgradeService          // system upgrade service
 	ConfirmStore  *confirm.Store
 	BFProtector   *bruteforce.Protector
+	Cache         Cache                    // general-purpose cache (Redis or in-memory)
 }
 
 // TunnelManager defines the interface for agent reverse tunnel management.
@@ -105,6 +106,11 @@ func NewBridge(db *gorm.DB, executor deployer.CommandExecutor, encryptionKey []b
 		ConfirmStore:  confirm.NewStore(),
 		BFProtector:   bruteforce.New(bruteforce.DefaultConfig()),
 	}
+}
+
+// SetCache sets the cache on the Bridge.
+func (b *Bridge) SetCache(cache Cache) {
+	b.Cache = cache
 }
 
 // SetBruteForceConfig replaces the brute-force protector with one using the given config.

--- a/internal/service/cache.go
+++ b/internal/service/cache.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Cache defines the interface for a caching backend.
+type Cache interface {
+	// Get retrieves a string value by key. Returns ErrCacheMiss if not found.
+	Get(ctx context.Context, key string) (string, error)
+
+	// Set stores a string value with TTL.
+	Set(ctx context.Context, key string, value string, ttl time.Duration) error
+
+	// Delete removes a key.
+	Delete(ctx context.Context, key string) error
+
+	// GetJSON retrieves a JSON-serialized value into dest.
+	GetJSON(ctx context.Context, key string, dest interface{}) error
+
+	// SetJSON stores a value as JSON with TTL.
+	SetJSON(ctx context.Context, key string, value interface{}, ttl time.Duration) error
+
+	// Close closes the cache connection.
+	Close() error
+}
+
+// ErrCacheMiss is returned when a cache key is not found.
+var ErrCacheMiss = errors.New("cache miss")

--- a/internal/service/dns_service.go
+++ b/internal/service/dns_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/plugin"
@@ -112,6 +113,18 @@ func (b *Bridge) DNSDeleteRecord(ctx context.Context, recordID string) error {
 // ---------- 21. DNSListRecords ----------
 
 func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}, error) {
+	// Try cache first
+	if b.Cache != nil {
+		cacheKey := fmt.Sprintf("dns:%s:records", domain)
+		var cached interface{}
+		if err := b.Cache.GetJSON(ctx, cacheKey, &cached); err == nil {
+			return cached, nil
+		}
+		if err != nil && err != ErrCacheMiss {
+			slog.Warn("DNS cache get error, falling back to provider", "error", err)
+		}
+	}
+
 	provider, err := b.getDNSProvider(ctx)
 	if err != nil {
 		return map[string]interface{}{
@@ -139,11 +152,21 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 			"proxied": r.Proxied,
 		})
 	}
-	return map[string]interface{}{
+	response := map[string]interface{}{
 		"status":  "success",
 		"domain":  domain,
 		"records": result,
-	}, nil
+	}
+
+	// Cache the result (fire-and-forget)
+	if b.Cache != nil {
+		cacheKey := fmt.Sprintf("dns:%s:records", domain)
+		if cacheErr := b.Cache.SetJSON(ctx, cacheKey, response, 10*time.Minute); cacheErr != nil {
+			slog.Warn("DNS cache set error", "error", cacheErr)
+		}
+	}
+
+	return response, nil
 }
 
 // ---------- 30. UpdateDNSRecord ----------

--- a/internal/service/dns_service.go
+++ b/internal/service/dns_service.go
@@ -117,11 +117,11 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 	if b.Cache != nil {
 		cacheKey := fmt.Sprintf("dns:%s:records", domain)
 		var cached interface{}
-		if err := b.Cache.GetJSON(ctx, cacheKey, &cached); err == nil {
+		if cacheErr := b.Cache.GetJSON(ctx, cacheKey, &cached); cacheErr == nil {
 			return cached, nil
 		}
-		if err != nil && err != ErrCacheMiss {
-			slog.Warn("DNS cache get error, falling back to provider", "error", err)
+		if cacheErr != nil && cacheErr != ErrCacheMiss {
+			slog.Warn("DNS cache get error, falling back to provider", "error", cacheErr)
 		}
 	}
 

--- a/internal/service/dns_service.go
+++ b/internal/service/dns_service.go
@@ -117,7 +117,8 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 	if b.Cache != nil {
 		cacheKey := fmt.Sprintf("dns:%s:records", domain)
 		var cached interface{}
-		if cacheErr := b.Cache.GetJSON(ctx, cacheKey, &cached); cacheErr == nil {
+		var cacheErr error
+		if cacheErr = b.Cache.GetJSON(ctx, cacheKey, &cached); cacheErr == nil {
 			return cached, nil
 		}
 		if cacheErr != nil && cacheErr != ErrCacheMiss {

--- a/internal/service/memory_cache.go
+++ b/internal/service/memory_cache.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// MemoryCache implements Cache using an in-memory map with TTL.
+type MemoryCache struct {
+	mu      sync.RWMutex
+	items   map[string]*cacheItem
+	prefix  string
+	closeCh chan struct{}
+}
+
+type cacheItem struct {
+	value    string
+	expireAt time.Time
+}
+
+// NewMemoryCache creates a new in-memory cache.
+func NewMemoryCache(prefix string) *MemoryCache {
+	c := &MemoryCache{
+		items:   make(map[string]*cacheItem),
+		prefix:  prefix,
+		closeCh: make(chan struct{}),
+	}
+	go c.cleanup()
+	return c
+}
+
+func (c *MemoryCache) key(k string) string {
+	return c.prefix + k
+}
+
+func (c *MemoryCache) Get(ctx context.Context, key string) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	item, ok := c.items[c.key(key)]
+	if !ok || time.Now().After(item.expireAt) {
+		return "", ErrCacheMiss
+	}
+	return item.value, nil
+}
+
+func (c *MemoryCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[c.key(key)] = &cacheItem{value: value, expireAt: time.Now().Add(ttl)}
+	return nil
+}
+
+func (c *MemoryCache) Delete(ctx context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.items, c.key(key))
+	return nil
+}
+
+func (c *MemoryCache) GetJSON(ctx context.Context, key string, dest interface{}) error {
+	val, err := c.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(val), dest)
+}
+
+func (c *MemoryCache) SetJSON(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return c.Set(ctx, key, string(data), ttl)
+}
+
+func (c *MemoryCache) Close() error {
+	close(c.closeCh)
+	return nil
+}
+
+func (c *MemoryCache) cleanup() {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.mu.Lock()
+			now := time.Now()
+			for k, item := range c.items {
+				if now.After(item.expireAt) {
+					delete(c.items, k)
+				}
+			}
+			c.mu.Unlock()
+		case <-c.closeCh:
+			return
+		}
+	}
+}

--- a/internal/service/redis_cache.go
+++ b/internal/service/redis_cache.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisCache implements Cache using Redis.
+type RedisCache struct {
+	client *redis.Client
+	prefix string
+}
+
+// NewRedisCache creates a new Redis-backed cache.
+func NewRedisCache(client *redis.Client, prefix string) *RedisCache {
+	return &RedisCache{client: client, prefix: prefix}
+}
+
+func (c *RedisCache) key(k string) string {
+	return c.prefix + k
+}
+
+func (c *RedisCache) Get(ctx context.Context, key string) (string, error) {
+	val, err := c.client.Get(ctx, c.key(key)).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", ErrCacheMiss
+	}
+	return val, err
+}
+
+func (c *RedisCache) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
+	return c.client.Set(ctx, c.key(key), value, ttl).Err()
+}
+
+func (c *RedisCache) Delete(ctx context.Context, key string) error {
+	return c.client.Del(ctx, c.key(key)).Err()
+}
+
+func (c *RedisCache) GetJSON(ctx context.Context, key string, dest interface{}) error {
+	val, err := c.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(val), dest)
+}
+
+func (c *RedisCache) SetJSON(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("cache: json marshal: %w", err)
+	}
+	return c.Set(ctx, key, string(data), ttl)
+}
+
+func (c *RedisCache) Close() error {
+	return c.client.Close()
+}

--- a/internal/service/rollback_test.go
+++ b/internal/service/rollback_test.go
@@ -60,6 +60,7 @@ func setupRollbackTestDB(t *testing.T) *gorm.DB {
 		resource_limits TEXT,
 		compose_content TEXT,
 		compose_project_name TEXT,
+		environment TEXT DEFAULT 'production',
 		created_at DATETIME,
 		updated_at DATETIME
 	)`)


### PR DESCRIPTION
## Summary

### Phase 3.2 — Multi-Environment Separation
- App model: `Environment` field (production/staging/development/testing)
- API: CreateApp, ListApps (filter), UpdateApp all support environment
- MCP: deploy_app, create_app, build_and_deploy accept `environment` param
- DB migration: ALTER TABLE apps ADD COLUMN environment
- All test CREATE TABLE statements updated

### Phase 3.6 — Redis Cache Layer
- `Cache` interface with Get/Set/Delete/GetJSON/SetJSON/Close
- `RedisCache` implementation (go-redis/v9, key prefix)
- `MemoryCache` fallback (in-memory with TTL cleanup goroutine)
- Authorization caching: `CheckResourceAccessCached` (5min TTL)
- DNS record caching: `DNSListRecords` (10min TTL)
- Router: switched to cached middleware
- Graceful degradation: cache failures only log warnings

Agent-Task: multi-env-redis-cache
Agent-Model: SOLO