### PR TITLE
feat: WS broadcast (Phase 3.7) + monitoring (Phase 3.8) + ai-guide #24-#28

### DIFF
--- a/.github/ai-guide.md
+++ b/.github/ai-guide.md
@@ -172,6 +172,40 @@ DeployPilot 的 Web Dashboard **不依赖** Apache、Nginx 或 OpenResty 来提�
 **不要**: 假设面板前端由 Nginx 代理或固定在 8080 端口。
 **不要**: 在部署用户项目时将面板自身的端口配置与项目的 Web 服务器混淆。
 
+### 24. 新增 App 模型字段必须同步更新所有测试的 CREATE TABLE
+当在 `internal/model/model.go` 的 `App` 结构体中新增字段时，不能只改模型。必须同步更新所有测试文件中硬编码的 `CREATE TABLE IF NOT EXISTS apps` 语句。
+涉及文件（每次新增字段都需检查）:
+- `internal/api/api_test.go`
+- `internal/api/sse_test.go`
+- `internal/api/ws_test.go`
+- `internal/service/rollback_test.go`
+
+**反例**: 新增 `ComposeContent` 字段后 CI 报 `table apps has no column named compose_content`。
+**最佳实践**: 使用 GORM AutoMigrate 而非硬编码 DDL，或在 PR checklist 中加入"检查所有 CREATE TABLE"。
+
+### 25. 新增 Deployer 接口方法必须同步更新 mockDeployer
+`internal/mcp/server_test.go` 中的 `mockDeployer` 实现了 `Deployer` 接口。每次在 `internal/mcp/types.go` 的 `Deployer` 接口中新增方法，都必须在 `mockDeployer` 中添加对应的 stub 方法，否则编译失败。
+stub 模式: `func (m *mockDeployer) MethodName(_ context.Context, ...) (type, error) { return zeroValue, nil }`
+
+**反例**: 新增 `ListEnvTemplates` 后 Lint 报 `mockDeployer does not implement Deployer`。
+
+### 26. Go 变量作用域陷阱：if 内 := 声明在外层不可见
+在 `if err := doSomething(); err == nil { ... }` 中声明的 `err` 只在 if 块内可见。如果后续需要在外层使用该变量，必须在外层先声明 `var err error`，然后在 if 中用 `err = doSomething()`（赋值而非声明）。
+
+**反例**: `if err := cache.Get(...); err == nil { return }` 后又写 `if err != nil { ... }` 导致 `err` 未定义编译错误。
+**正确写法**: `var cacheErr error; if cacheErr = cache.Get(...); cacheErr == nil { return }; if cacheErr != nil { ... }`
+
+### 27. 删除函数后必须检查 import 是否仍被使用
+当删除一个使用特定包的函数后，该包的 import 可能变成未使用的。golangci-lint 的 `unused` 检查会报错。
+常见场景: 删除了使用 `gorm.io/gorm` 的函数后，`import "gorm.io/gorm"` 变成多余的。
+
+**反例**: 删除 `authorizeAppAccess(db *gorm.DB, ...)` 后 Lint 报 `imported and not used: "gorm.io/gorm"`。
+
+### 28. Redis Pub/Sub 多实例广播必须防止消息回环
+当通过 Redis Pub/Sub 广播消息时，每个实例都会收到自己发出的消息。必须使用 `SourceInstance` 或类似机制标识消息来源，接收时跳过自己发出的消息，否则消息会在实例间无限循环。
+
+**实现**: WSHub 使用 UUID 前 8 位作为 instanceID，WSMessage 新增 `SourceInstance` 字段，Redis 订阅者收到消息后检查 `msg.SourceInstance != h.instanceID`。
+
 ## 项目结构关键路径
 
 | 路径 | 说明 |

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -203,7 +203,7 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		slog.Info("OAuth service initialized", "providers", len(cfg.Auth.OAuthProviders))
 	}
 
-	srv := server.New(listenAddr, db, bridge, cfg, tokenBlacklist, oauthSvc)
+	srv := server.New(listenAddr, db, bridge, cfg, tokenBlacklist, oauthSvc, rdb)
 
 	// Initialize and start Prometheus metrics server
 	metrics.Init()

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -172,6 +172,40 @@ DeployPilot 的 Web Dashboard **不依赖** Apache、Nginx 或 OpenResty 来提�
 **不要**: 假设面板前端由 Nginx 代理或固定在 8080 端口。
 **不要**: 在部署用户项目时将面板自身的端口配置与项目的 Web 服务器混淆。
 
+### 24. 新增 App 模型字段必须同步更新所有测试的 CREATE TABLE
+当在 `internal/model/model.go` 的 `App` 结构体中新增字段时，不能只改模型。必须同步更新所有测试文件中硬编码的 `CREATE TABLE IF NOT EXISTS apps` 语句。
+涉及文件（每次新增字段都需检查）:
+- `internal/api/api_test.go`
+- `internal/api/sse_test.go`
+- `internal/api/ws_test.go`
+- `internal/service/rollback_test.go`
+
+**反例**: 新增 `ComposeContent` 字段后 CI 报 `table apps has no column named compose_content`。
+**最佳实践**: 使用 GORM AutoMigrate 而非硬编码 DDL，或在 PR checklist 中加入"检查所有 CREATE TABLE"。
+
+### 25. 新增 Deployer 接口方法必须同步更新 mockDeployer
+`internal/mcp/server_test.go` 中的 `mockDeployer` 实现了 `Deployer` 接口。每次在 `internal/mcp/types.go` 的 `Deployer` 接口中新增方法，都必须在 `mockDeployer` 中添加对应的 stub 方法，否则编译失败。
+stub 模式: `func (m *mockDeployer) MethodName(_ context.Context, ...) (type, error) { return zeroValue, nil }`
+
+**反例**: 新增 `ListEnvTemplates` 后 Lint 报 `mockDeployer does not implement Deployer`。
+
+### 26. Go 变量作用域陷阱：if 内 := 声明在外层不可见
+在 `if err := doSomething(); err == nil { ... }` 中声明的 `err` 只在 if 块内可见。如果后续需要在外层使用该变量，必须在外层先声明 `var err error`，然后在 if 中用 `err = doSomething()`（赋值而非声明）。
+
+**反例**: `if err := cache.Get(...); err == nil { return }` 后又写 `if err != nil { ... }` 导致 `err` 未定义编译错误。
+**正确写法**: `var cacheErr error; if cacheErr = cache.Get(...); cacheErr == nil { return }; if cacheErr != nil { ... }`
+
+### 27. 删除函数后必须检查 import 是否仍被使用
+当删除一个使用特定包的函数后，该包的 import 可能变成未使用的。golangci-lint 的 `unused` 检查会报错。
+常见场景: 删除了使用 `gorm.io/gorm` 的函数后，`import "gorm.io/gorm"` 变成多余的。
+
+**反例**: 删除 `authorizeAppAccess(db *gorm.DB, ...)` 后 Lint 报 `imported and not used: "gorm.io/gorm"`。
+
+### 28. Redis Pub/Sub 多实例广播必须防止消息回环
+当通过 Redis Pub/Sub 广播消息时，每个实例都会收到自己发出的消息。必须使用 `SourceInstance` 或类似机制标识消息来源，接收时跳过自己发出的消息，否则消息会在实例间无限循环。
+
+**实现**: WSHub 使用 UUID 前 8 位作为 instanceID，WSMessage 新增 `SourceInstance` 字段，Redis 订阅者收到消息后检查 `msg.SourceInstance != h.instanceID`。
+
 ## 项目结构关键路径
 
 | 路径 | 说明 |

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -174,7 +174,7 @@ func setupTestRouter(db *gorm.DB) *gin.Engine {
 func setupFullTestRouter(db *gorm.DB, bridge *service.Bridge) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	wsHub := NewWSHub()
+	wsHub := NewWSHub(nil)
 	go wsHub.Run()
 	auditSvc := service.NewAuditService(db)
 	backupSvc := backup.New(backup.Config{BackupDir: os.TempDir()}, db, "sqlite", "")

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -16,7 +16,9 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/metrics"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/redis/go-redis/v9"
 )
 
 // allowedWSSOrigins contains origins permitted for WebSocket connections.
@@ -61,10 +63,11 @@ var upgrader = websocket.Upgrader{
 
 // WSMessage is the standard WebSocket message format.
 type WSMessage struct {
-	Type      string      `json:"type"`
-	Timestamp string      `json:"timestamp"`
-	Data      interface{} `json:"data"`
-	AppID     string      `json:"app_id,omitempty"`
+	Type           string      `json:"type"`
+	Timestamp      string      `json:"timestamp"`
+	Data           interface{} `json:"data"`
+	AppID          string      `json:"app_id,omitempty"`
+	SourceInstance string      `json:"source_instance,omitempty"`
 }
 
 // wsClient represents a single WebSocket connection tied to an app.
@@ -75,29 +78,49 @@ type wsClient struct {
 
 // WSHub manages WebSocket connections for broadcasting log/deployment events.
 type WSHub struct {
-	clients    map[string]map[*websocket.Conn]bool
-	mu         sync.RWMutex
-	register   chan *wsClient
-	unregister chan *wsClient
-	done       chan struct{} // signals the Run loop to stop
-	closeOnce  sync.Once     // ensures Close() is safe to call multiple times
-	runDone    chan struct{} // closed when Run() goroutine exits
+	clients        map[string]map[*websocket.Conn]bool
+	mu             sync.RWMutex
+	register       chan *wsClient
+	unregister     chan *wsClient
+	done           chan struct{} // signals the Run loop to stop
+	closeOnce      sync.Once     // ensures Close() is safe to call multiple times
+	runDone        chan struct{} // closed when Run() goroutine exits
+	rdb            *redis.Client
+	instanceID     string
+	redisSub       *redis.PubSub
+	redisDone      chan struct{}
 }
 
-// NewWSHub creates a new WSHub.
-func NewWSHub() *WSHub {
-	return &WSHub{
+// NewWSHub creates a new WSHub. If rdb is non-nil, Redis Pub/Sub is enabled
+// for multi-instance broadcast.
+func NewWSHub(rdb *redis.Client) *WSHub {
+	instanceID := uuid.New().String()[:8]
+	hub := &WSHub{
 		clients:    make(map[string]map[*websocket.Conn]bool),
 		register:   make(chan *wsClient),
 		unregister: make(chan *wsClient),
 		done:       make(chan struct{}),
 		runDone:    make(chan struct{}),
+		rdb:        rdb,
+		instanceID: instanceID,
 	}
+	if rdb != nil {
+		hub.redisDone = make(chan struct{})
+	}
+	return hub
 }
 
 // Run starts the background goroutine that handles register/unregister events.
+// If Redis is configured, it also starts a Redis Pub/Sub subscriber for
+// cross-instance message relay.
 func (h *WSHub) Run() {
 	defer close(h.runDone)
+
+	// Start Redis subscriber if Redis is available
+	if h.rdb != nil {
+		go h.runRedisSubscriber()
+	}
+
 	for {
 		select {
 		case <-h.done:
@@ -125,14 +148,23 @@ func (h *WSHub) Run() {
 }
 
 // Close gracefully shuts down the WebSocket hub.
-// It stops the Run loop and closes all active WebSocket connections.
+// It stops the Run loop, closes the Redis subscription, and closes all active WebSocket connections.
 // Safe to call multiple times.
 func (h *WSHub) Close() {
 	h.closeOnce.Do(func() {
 		close(h.done) // signal Run() to exit
+		// Signal Redis subscriber to stop
+		if h.redisDone != nil {
+			close(h.redisDone)
+		}
 	})
 
 	<-h.runDone // wait for Run() goroutine to exit
+
+	// Close Redis Pub/Sub subscription
+	if h.redisSub != nil {
+		_ = h.redisSub.Close()
+	}
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -162,6 +194,8 @@ func (h *WSHub) Unregister(conn *websocket.Conn, appID string) {
 }
 
 // Broadcast sends a message to all connections subscribed to the given appID.
+// If Redis is configured, the message is also published to the Redis Pub/Sub
+// channel so other instances can relay it to their local clients.
 func (h *WSHub) Broadcast(appID string, msg WSMessage) {
 	data, err := json.Marshal(msg)
 	if err != nil {
@@ -181,6 +215,74 @@ func (h *WSHub) Broadcast(appID string, msg WSMessage) {
 	for _, c := range keys {
 		if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
 			slog.Warn("broadcast write error", "error", err)
+		}
+	}
+
+	// Redis broadcast for cross-instance delivery
+	if h.rdb != nil {
+		msg.SourceInstance = h.instanceID
+		redisData, err := json.Marshal(msg)
+		if err != nil {
+			slog.Error("failed to marshal redis broadcast message", "error", err)
+			return
+		}
+		h.rdb.Publish(context.Background(), "deploypilot:ws:broadcast", redisData)
+	}
+}
+
+// runRedisSubscriber subscribes to the Redis Pub/Sub channel and relays
+// messages from other instances to local WebSocket clients.
+// Messages originating from this instance (same SourceInstance) are skipped
+// to prevent echo.
+func (h *WSHub) runRedisSubscriber() {
+	const channel = "deploypilot:ws:broadcast"
+	ctx := context.Background()
+	sub := h.rdb.Subscribe(ctx, channel)
+	h.redisSub = sub
+
+	slog.Info("WebSocket Redis subscriber started", "channel", channel, "instance", h.instanceID)
+
+	defer func() {
+		_ = sub.Close()
+		slog.Info("WebSocket Redis subscriber stopped", "instance", h.instanceID)
+	}()
+
+	for {
+		select {
+		case <-h.redisDone:
+			return
+		case msg, ok := <-sub.Channel():
+			if !ok {
+				return
+			}
+			var wsMsg WSMessage
+			if err := json.Unmarshal([]byte(msg.Payload), &wsMsg); err != nil {
+				slog.Warn("failed to unmarshal redis ws message", "error", err)
+				continue
+			}
+			// Skip messages from this instance to avoid echo
+			if wsMsg.SourceInstance == h.instanceID {
+				continue
+			}
+			// Relay to local clients
+			appID := wsMsg.AppID
+			data, err := json.Marshal(wsMsg)
+			if err != nil {
+				slog.Warn("failed to marshal relay ws message", "error", err)
+				continue
+			}
+			h.mu.RLock()
+			conns := h.clients[appID]
+			keys := make([]*websocket.Conn, 0, len(conns))
+			for c := range conns {
+				keys = append(keys, c)
+			}
+			h.mu.RUnlock()
+			for _, c := range keys {
+				if err := c.WriteMessage(websocket.TextMessage, data); err != nil {
+					slog.Warn("redis relay write error", "error", err)
+				}
+			}
 		}
 	}
 }

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -93,9 +93,9 @@ func dialWS(t *testing.T, server *httptest.Server, path string) *websocket.Conn 
 // --- WSHub Tests ---
 
 func TestNewWSHub(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	if hub == nil {
-		t.Fatal("NewWSHub() returned nil")
+		t.Fatal("NewWSHub(nil) returned nil")
 	}
 	if hub.clients == nil {
 		t.Fatal("expected non-nil clients map")
@@ -109,7 +109,7 @@ func TestNewWSHub(t *testing.T) {
 }
 
 func TestWSHubRegisterUnregister(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	registered := make(chan struct{})
@@ -171,7 +171,7 @@ func TestWSHubRegisterUnregister(t *testing.T) {
 }
 
 func TestWSHubBroadcast(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	// Create a server that registers the server-side conn with the hub
@@ -232,7 +232,7 @@ func TestWSHubBroadcast(t *testing.T) {
 }
 
 func TestWSHubClientCount(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	// No clients for unknown app
@@ -360,7 +360,7 @@ func TestWSMessageJSON(t *testing.T) {
 func TestLogStreamWS_NoToken(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -382,7 +382,7 @@ func TestLogStreamWS_NoToken(t *testing.T) {
 func TestLogStreamWS_InvalidToken(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -405,7 +405,7 @@ func TestLogStreamWS_InvalidToken(t *testing.T) {
 func TestTerminalWS_NoToken(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -426,7 +426,7 @@ func TestTerminalWS_NoToken(t *testing.T) {
 func TestTerminalWS_InvalidToken(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -446,7 +446,7 @@ func TestTerminalWS_InvalidToken(t *testing.T) {
 func TestTerminalWS_ServerNotFound(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -477,7 +477,7 @@ func TestTerminalWS_ServerNotFound(t *testing.T) {
 func TestLogStreamWS_AppNotFound(t *testing.T) {
 	db := setupWSTestDB(t)
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -506,7 +506,7 @@ func TestLogStreamWS_AppNotFound(t *testing.T) {
 }
 
 func TestWSHub_Send(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	done := make(chan struct{})
@@ -549,7 +549,7 @@ func TestWSHub_Send(t *testing.T) {
 }
 
 func TestWSHub_BroadcastNoClients(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	// Broadcasting to an app with no clients should not panic
@@ -559,7 +559,7 @@ func TestWSHub_BroadcastNoClients(t *testing.T) {
 }
 
 func TestWSHub_BroadcastMarshalError(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	// Broadcasting a message with unmarshalable data should not panic
@@ -569,7 +569,7 @@ func TestWSHub_BroadcastMarshalError(t *testing.T) {
 }
 
 func TestWSHub_SendMarshalError(t *testing.T) {
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 
 	// Create a server that upgrades and immediately closes
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -699,7 +699,7 @@ func TestLogStreamWS_ValidApp(t *testing.T) {
 	db.Exec(`INSERT INTO apps (id, tenant_id, name, repo_url, container_name) VALUES ('app-ws-1', 'tenant-default', 'ws-app', 'https://github.com/test/test', 'ws-app-container')`)
 
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -735,7 +735,7 @@ func TestLogStreamWS_AppWithFallbackName(t *testing.T) {
 	db.Exec(`INSERT INTO apps (id, tenant_id, name, repo_url, container_name) VALUES ('app-ws-2', 'tenant-default', 'fallback-app', 'https://github.com/test/test', '')`)
 
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -766,7 +766,7 @@ func TestTerminalWS_ValidServer(t *testing.T) {
 	db.Exec(`INSERT INTO credentials (id, tenant_id, name, type, encrypted_value) VALUES ('cred-ws-1', 'tenant-default', 'ssh-key', 'ssh', 'encrypted-value')`)
 
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)
@@ -810,7 +810,7 @@ func TestTerminalWS_InvalidCommand(t *testing.T) {
 	db.Exec(`INSERT INTO credentials (id, tenant_id, name, type, encrypted_value) VALUES ('cred-ws-3', 'tenant-default', 'ssh-key-3', 'ssh', 'encrypted-value')`)
 
 	bridge := service.NewBridge(db, &localExecutor{}, []byte("test-key-1234567890abcdef"), nil)
-	hub := NewWSHub()
+	hub := NewWSHub(nil)
 	go hub.Run()
 
 	router := setupWSRouter(db, bridge, hub)

--- a/internal/mcp/handler_monitor.go
+++ b/internal/mcp/handler_monitor.go
@@ -131,22 +131,3 @@ func handleListAlertRules(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetRemoteSystemMetrics(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	serverID := request.GetString("server_id", "")
-
-	var result interface{}
-	var err error
-
-	if serverID != "" {
-		result, err = deployer.GetRemoteSystemMetrics(ctx, serverID)
-	} else {
-		result, err = deployer.GetSystemMetrics(ctx)
-	}
-
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to get remote system metrics: %v", err)), nil
-	}
-
-	data, _ := json.MarshalIndent(result, "", "  ")
-	return mcp.NewToolResultText(string(data)), nil
-}

--- a/internal/mcp/handler_monitor.go
+++ b/internal/mcp/handler_monitor.go
@@ -95,7 +95,17 @@ func handleGetContainerMetrics(ctx context.Context, deployer Deployer, request m
 	return mcp.NewToolResultText(string(data)), nil
 }
 func handleGetSystemMetrics(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	result, err := deployer.GetSystemMetrics(ctx)
+	serverID := request.GetString("server_id", "")
+
+	var result interface{}
+	var err error
+
+	if serverID != "" {
+		result, err = deployer.GetRemoteSystemMetrics(ctx, serverID)
+	} else {
+		result, err = deployer.GetSystemMetrics(ctx)
+	}
+
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get system metrics: %v", err)), nil
 	}
@@ -116,6 +126,25 @@ func handleListAlertRules(ctx context.Context, deployer Deployer, request mcp.Ca
 	result, err := deployer.ListAlertRules(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list alert rules: %v", err)), nil
+	}
+
+	data, _ := json.MarshalIndent(result, "", "  ")
+	return mcp.NewToolResultText(string(data)), nil
+}
+func handleGetRemoteSystemMetrics(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	serverID := request.GetString("server_id", "")
+
+	var result interface{}
+	var err error
+
+	if serverID != "" {
+		result, err = deployer.GetRemoteSystemMetrics(ctx, serverID)
+	} else {
+		result, err = deployer.GetSystemMetrics(ctx)
+	}
+
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get remote system metrics: %v", err)), nil
 	}
 
 	data, _ := json.MarshalIndent(result, "", "  ")

--- a/internal/mcp/register_monitor.go
+++ b/internal/mcp/register_monitor.go
@@ -46,7 +46,8 @@ func registerMonitorTools(s *server.MCPServer, d Deployer) {
 		return handleGetContainerMetrics(ctx, d, request)
 	})))
 	getSystemMetricsTool := mcp.NewTool("get_system_metrics",
-		mcp.WithDescription("Get system-level metrics (CPU, memory, disk usage)."),
+		mcp.WithDescription("Get system-level metrics (CPU, memory, disk usage, network I/O, disk I/O). Supports remote monitoring via server_id."),
+		mcp.WithString("server_id", mcp.Description("Server ID for remote monitoring (omit for local)")),
 	)
 	s.AddTool(getSystemMetricsTool, withPermissionCheck("get_system_metrics", withValidation("get_system_metrics", getSystemMetricsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return handleGetSystemMetrics(ctx, d, request)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -416,6 +416,10 @@ func (m *mockDeployer) GetSystemMetrics(ctx context.Context) (interface{}, error
 	}, nil
 }
 
+func (m *mockDeployer) GetRemoteSystemMetrics(_ context.Context, _ string) (interface{}, error) {
+	return []interface{}{}, nil
+}
+
 func (m *mockDeployer) ListAlerts(ctx context.Context) (interface{}, error) {
 	if m.listAlertsFn != nil {
 		return m.listAlertsFn(ctx)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -64,6 +64,7 @@ type Deployer interface {
 	HealContainer(ctx context.Context, containerName string) (interface{}, error)
 	GetContainerMetrics(ctx context.Context, containerName string) (interface{}, error)
 	GetSystemMetrics(ctx context.Context) (interface{}, error)
+	GetRemoteSystemMetrics(ctx context.Context, serverID string) (interface{}, error)
 	ListAlerts(ctx context.Context) (interface{}, error)
 	ListAlertRules(ctx context.Context) (interface{}, error)
 	TriggerCIBuild(ctx context.Context, provider, repo, branch string) (interface{}, error)

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,8 @@ const (
 	MetricMemory    MetricType = "memory"
 	MetricDisk      MetricType = "disk"
 	MetricContainer MetricType = "container"
+	MetricNetwork   MetricType = "network"
+	MetricDiskIO    MetricType = "disk_io"
 )
 
 // Metric represents a single metric data point.
@@ -112,6 +115,14 @@ func (c *Collector) CollectSystemMetrics(ctx context.Context) ([]Metric, error) 
 		})
 	}
 
+	// Network I/O metrics
+	networkMetrics := collectNetworkMetrics(ctx, c.executor)
+	metrics = append(metrics, networkMetrics...)
+
+	// Disk I/O metrics
+	diskIOMetrics := collectDiskIOMetrics(ctx, c.executor)
+	metrics = append(metrics, diskIOMetrics...)
+
 	if len(metrics) == 0 {
 		return nil, fmt.Errorf("failed to collect any system metrics")
 	}
@@ -154,7 +165,7 @@ func (c *Collector) CollectContainerMetrics(ctx context.Context, containerName s
 	memStr := strings.TrimSpace(parts[1])
 	memUsed, memUnit := parseMemoryValue(memStr)
 	metrics = append(metrics, Metric{
-		Type:      MetricCPU,
+		Type:      MetricMemory,
 		Name:      "container_memory_used",
 		Value:     memUsed,
 		Unit:      memUnit,
@@ -360,4 +371,167 @@ func parseMemoryValue(s string) (float64, string) {
 	default:
 		return num, "mib"
 	}
+}
+
+// collectNetworkMetrics reads /proc/net/dev and returns per-interface network I/O metrics.
+// Skips the loopback interface ("lo").
+func collectNetworkMetrics(ctx context.Context, executor deployer.CommandExecutor) []Metric {
+	var metrics []Metric
+	now := time.Now()
+
+	out, err := executor.RunCommand(ctx, "cat /proc/net/dev 2>/dev/null")
+	if err != nil || out == "" {
+		return metrics
+	}
+
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.Contains(line, ":") {
+			continue
+		}
+
+		// Split interface name and data
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		iface := strings.TrimSpace(parts[0])
+		if iface == "lo" {
+			continue
+		}
+
+		fields := strings.Fields(parts[1])
+		// Expected fields (at least 16):
+		// receive: bytes, packets, errs, drop, fifo, frame, compressed, multicast
+		// transmit: bytes, packets, errs, drop, fifo, colls, carrier, compressed
+		if len(fields) < 10 {
+			continue
+		}
+
+		recvBytes, _ := strconv.ParseFloat(fields[0], 64)
+		recvPackets, _ := strconv.ParseFloat(fields[1], 64)
+		recvErrors, _ := strconv.ParseFloat(fields[2], 64)
+		txBytes, _ := strconv.ParseFloat(fields[8], 64)
+		txPackets, _ := strconv.ParseFloat(fields[9], 64)
+		txErrors, _ := strconv.ParseFloat(fields[10], 64)
+
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_rx_bytes", iface),
+			Value:     recvBytes,
+			Unit:      "bytes",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_rx_packets", iface),
+			Value:     recvPackets,
+			Unit:      "count",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_rx_errors", iface),
+			Value:     recvErrors,
+			Unit:      "count",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_tx_bytes", iface),
+			Value:     txBytes,
+			Unit:      "bytes",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_tx_packets", iface),
+			Value:     txPackets,
+			Unit:      "count",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricNetwork,
+			Name:      fmt.Sprintf("%s_tx_errors", iface),
+			Value:     txErrors,
+			Unit:      "count",
+			Timestamp: now,
+		})
+	}
+
+	return metrics
+}
+
+// collectDiskIOMetrics reads /proc/diskstats and returns per-device disk I/O metrics.
+// Focuses on main disks (sd[a-z], vd[a-z], nvme[0-9]+) and skips partitions.
+func collectDiskIOMetrics(ctx context.Context, executor deployer.CommandExecutor) []Metric {
+	var metrics []Metric
+	now := time.Now()
+
+	out, err := executor.RunCommand(ctx, "cat /proc/diskstats 2>/dev/null")
+	if err != nil || out == "" {
+		return metrics
+	}
+
+	// Pattern to match main disk devices, not partitions
+	// Matches: sda, vda, xvda, nvme0n1, etc. Skips: sda1, vda2, etc.
+	mainDiskRe := regexp.MustCompile(`^(sd[a-z]|vd[a-z]|xvd[a-z]|nvme\d+n\d+|mmcblk\d+)$`)
+
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		// /proc/diskstats format: major minor name reads_completed reads_merged sectors_read ...
+		// At minimum: major, minor, name, and a few stat fields
+		if len(fields) < 7 {
+			continue
+		}
+
+		devName := fields[2]
+		if !mainDiskRe.MatchString(devName) {
+			continue
+		}
+
+		// Field indices (0-based): 0=major, 1=minor, 2=name
+		// Stats start at index 3:
+		// 3=reads completed, 4=reads merged, 5=sectors read,
+		// 6=ms reading, 7=writes completed, 8=writes merged,
+		// 9=sectors written, 10=ms writing
+		readsCompleted, _ := strconv.ParseFloat(fields[3], 64)
+		sectorsRead, _ := strconv.ParseFloat(fields[5], 64)
+		writesCompleted, _ := strconv.ParseFloat(fields[7], 64)
+		sectorsWritten, _ := strconv.ParseFloat(fields[9], 64)
+
+		metrics = append(metrics, Metric{
+			Type:      MetricDiskIO,
+			Name:      fmt.Sprintf("%s_reads_completed", devName),
+			Value:     readsCompleted,
+			Unit:      "count",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricDiskIO,
+			Name:      fmt.Sprintf("%s_sectors_read", devName),
+			Value:     sectorsRead,
+			Unit:      "sectors",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricDiskIO,
+			Name:      fmt.Sprintf("%s_writes_completed", devName),
+			Value:     writesCompleted,
+			Unit:      "count",
+			Timestamp: now,
+		})
+		metrics = append(metrics, Metric{
+			Type:      MetricDiskIO,
+			Name:      fmt.Sprintf("%s_sectors_written", devName),
+			Value:     sectorsWritten,
+			Unit:      "sectors",
+			Timestamp: now,
+		})
+	}
+
+	return metrics
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/service"
 	webfs "github.com/Yogdunana/deploypilot/web"
 	"github.com/gin-gonic/gin"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 )
 
@@ -31,7 +32,7 @@ type Server struct {
 }
 
 // New creates a new API server with the given address, database, bridge, and config.
-func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService) *Server {
+func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, rdb *redis.Client) *Server {
 	r := gin.Default()
 
 	// Request tracing — must be first middleware
@@ -71,7 +72,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	r.Use(middleware.AuditMiddleware(auditSvc))
 
 	// WebSocket hub
-	wsHub := api.NewWSHub()
+	wsHub := api.NewWSHub(rdb)
 	go wsHub.Run()
 
 	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, nil)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,7 +21,7 @@ func TestServerShutdown(t *testing.T) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	wsHub := api.NewWSHub()
+	wsHub := api.NewWSHub(nil)
 	go wsHub.Run()
 
 	srv := &Server{
@@ -63,7 +63,7 @@ func TestServerShutdown(t *testing.T) {
 }
 
 func TestWSHubClose(t *testing.T) {
-	hub := api.NewWSHub()
+	hub := api.NewWSHub(nil)
 	go hub.Run()
 
 	// Give hub time to start
@@ -85,7 +85,7 @@ func TestWSHubClose(t *testing.T) {
 }
 
 func TestWSHubCloseConcurrency(t *testing.T) {
-	hub := api.NewWSHub()
+	hub := api.NewWSHub(nil)
 	go hub.Run()
 	time.Sleep(50 * time.Millisecond)
 
@@ -105,7 +105,7 @@ func TestServerShutdownContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	r := gin.New()
-	wsHub := api.NewWSHub()
+	wsHub := api.NewWSHub(nil)
 	go wsHub.Run()
 
 	srv := &Server{

--- a/internal/service/monitor_service.go
+++ b/internal/service/monitor_service.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	"github.com/Yogdunana/deploypilot/internal/engine/healer"
 	"github.com/Yogdunana/deploypilot/internal/monitor"
@@ -19,6 +21,23 @@ func (b *Bridge) GetContainerMetrics(ctx context.Context, containerName string) 
 func (b *Bridge) GetSystemMetrics(ctx context.Context) (interface{}, error) {
 	m := b.getMonitor()
 	return m.GetSystemMetrics(ctx)
+}
+
+// ---------- 42b. GetRemoteSystemMetrics ----------
+
+func (b *Bridge) GetRemoteSystemMetrics(ctx context.Context, serverID string) (interface{}, error) {
+	remoteExec, err := b.getRemoteExecutor(ctx, serverID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get remote executor for server %s: %w", serverID, err)
+	}
+	defer func() {
+		if cerr := remoteExec.Close(); cerr != nil {
+			slog.Warn("failed to close remote executor", "error", cerr)
+		}
+	}()
+
+	collector := monitor.NewCollector(remoteExec)
+	return collector.CollectSystemMetrics(ctx)
 }
 
 // ---------- 43. ListAlerts ----------


### PR DESCRIPTION
## Summary

### Phase 3.7 — WebSocket Multi-Instance Broadcast
- WSHub: Redis Pub/Sub support via `deploypilot:ws:broadcast` channel
- WSMessage: `SourceInstance` field prevents message echo
- Graceful fallback: pure local mode when Redis unavailable
- server.go/main.go: pass Redis client to WSHub

### Phase 3.8 — System Monitoring Enhancement
- Network I/O: rx/tx bytes, packets, errors per interface
- Disk I/O: reads/writes completed, sectors read/written
- Remote monitoring: `get_system_metrics` accepts `server_id`
- Bug fix: `container_memory_used` type MetricCPU → MetricMemory

### ai-guide.md — Pitfalls #24-#28
- #24: Sync CREATE TABLE when adding App model fields
- #25: Sync mockDeployer when adding Deployer interface methods
- #26: Go variable scope trap with `if :=`
- #27: Check unused imports after deleting functions
- #28: Redis Pub/Sub echo prevention

Agent-Task: ws-broadcast-monitor-enhance
Agent-Model: SOLO