### PR TITLE
security: fix command injection, gitleaks bypass, SSH root fallback (#113, #114, #115, #33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,6 @@ jobs:
           fetch-depth: 0
 
       - name: Gitleaks scan
-        continue-on-error: true
         uses: gitleaks/gitleaks-action@v2
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
 
       - name: Gitleaks scan
         uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: Build

--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -38,7 +38,7 @@ func (b *Bridge) Backup(ctx context.Context, appID string) (string, error) {
 	// Attempt a docker-based backup: exec into the container and create a timestamped archive
 	timestamp := time.Now().Format("20060102-150405")
 	backupFile := fmt.Sprintf("/tmp/backup-%s-%s.tar.gz", containerName, timestamp)
-	cmd := fmt.Sprintf("docker exec %s sh -c 'tar czf - /app /data 2>/dev/null' > %s 2>/dev/null || echo 'no_backup_paths'", containerName, backupFile)
+	cmd := fmt.Sprintf("docker exec %s sh -c 'tar czf - /app /data 2>/dev/null' > %s 2>/dev/null || echo 'no_backup_paths'", shellQuote(containerName), shellQuote(backupFile))
 	out, err := b.Executor.RunCommand(ctx, cmd)
 	if err != nil {
 		slog.Warn("backup: container exec failed (may be expected)", "error", err, "output", out)

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -205,6 +205,7 @@ func (b *Bridge) getRemoteExecutor(ctx context.Context, serverID string) (*sshCl
 		username = os.Getenv("DEPLOYPILOT_SSH_DEFAULT_USER")
 	}
 	if username == "" {
+		slog.Warn("SSH username not configured, falling back to root (configure DEPLOYPILOT_SSH_DEFAULT_USER or set server username)", "serverID", serverID)
 		username = "root"
 	}
 	cfg := server.Config{
@@ -677,7 +678,7 @@ func (b *Bridge) ExecCommand(ctx context.Context, serverID, command string, time
 func (b *Bridge) ListImages(ctx context.Context, serverID, filter string) (string, error) {
 	dockerCmd := `docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}"`
 	if filter != "" {
-		dockerCmd += " | grep " + filter
+		dockerCmd += " | grep " + shellQuote(filter)
 	}
 
 	execCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -763,6 +764,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 			username = os.Getenv("DEPLOYPILOT_SSH_DEFAULT_USER")
 		}
 		if username == "" {
+			slog.Warn("SSH username not configured for port forward, falling back to root", "serverID", serverID)
 			username = "root"
 		}
 
@@ -821,7 +823,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 		}
 
 		// Kill the SSH tunnel process
-		killCmd := fmt.Sprintf("pkill -f 'ssh.*-L %d:%s:%d'", localPort, entry.RemoteHost, entry.RemotePort)
+		killCmd := fmt.Sprintf("pkill -f 'ssh.*-L %d:%s:%d'", localPort, shellQuote(entry.RemoteHost), entry.RemotePort)
 		if _, err := b.Executor.RunCommand(ctx, killCmd); err != nil {
 			slog.Warn("failed to kill SSH tunnel process", "error", err)
 		}


### PR DESCRIPTION
## Summary

Batch security fixes addressing 4 issues from code review:

### 🔒 #113 Critical: Command injection in ListImages
- `filter` parameter was directly concatenated into shell command
- **Fix**: Use `shellQuote()` to sanitize the filter parameter

### 🔒 #114 Critical: Gitleaks secret scanning non-blocking
- `continue-on-error: true` made secret scanning a no-op
- **Fix**: Removed `continue-on-error` from Gitleaks step
- **Note**: `govulncheck` and `npm audit` retain `continue-on-error` (documented reasons)

### ⚠️ #115 High: SSH silent root fallback
- SSH connections silently defaulted to `root` without any logging
- **Fix**: Added `slog.Warn` when falling back to root in both `getRemoteExecutor` and `PortForward`

### 🔧 #33 Medium: shellQuote gaps
- `backup_service.go:41` — `containerName` and `backupFile` not quoted
- `bridge.go:826` — `RemoteHost` in pkill command not quoted
- **Fix**: Added `shellQuote()` to all unescaped shell parameters

## Test Plan

- [ ] Verify CI passes (Build, Test, Lint, Gitleaks now blocks)
- [ ] Verify `ListImages` with special characters in filter
- [ ] Verify SSH warning logs appear when username is empty
- [ ] Verify backup/restore with container names containing spaces

Agent-Model: Claude
Agent-Decision: Batch related security fixes for efficiency
Agent-Task: Fix critical and high security issues
Agent-Limitation: Govulncheck and npm audit continue-on-error retained