### PR TITLE
refactor: move global mutable state into Bridge struct (fixes #117)

### DIFF
--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -47,9 +47,9 @@ func (b *Bridge) Backup(ctx context.Context, appID string) (string, error) {
 	slog.Info("backup completed", "app_id", appID, "container", containerName, "backup_id", backupID, "file", backupFile)
 
 	// Store backup-to-app mapping for Restore
-	backupMu.Lock()
-	backupApps[backupID] = appID
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps[backupID] = appID
+	b.backupMu.Unlock()
 
 	return backupID, nil
 }
@@ -62,9 +62,9 @@ func (b *Bridge) Restore(ctx context.Context, backupID string) (*mcp.ContainerSt
 	}
 
 	// Look up the appID from the backup mapping
-	backupMu.RLock()
-	appID, ok := backupApps[backupID]
-	backupMu.RUnlock()
+	b.backupMu.RLock()
+	appID, ok := b.backupApps[backupID]
+	b.backupMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("backup %s not found", backupID)
 	}

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -81,6 +81,19 @@ type Bridge struct {
 	BFProtector   *bruteforce.Protector
 	Cache         Cache                    // general-purpose cache (Redis or in-memory)
 	Scheduler     *Scheduler               // scheduled task system
+
+	// Task tracking (moved from package-level globals, Issue #117)
+	taskMu      sync.RWMutex
+	tasks       map[string]*taskInfo
+	taskCounter int64
+
+	// Backup tracking (moved from package-level globals, Issue #117)
+	backupMu   sync.RWMutex
+	backupApps map[string]string // backupID -> appID
+
+	// Port forwarding (moved from package-level globals, Issue #117)
+	portForwardMu sync.RWMutex
+	portForwards  map[string]*portForwardEntry
 }
 
 // TunnelManager defines the interface for agent reverse tunnel management.
@@ -106,6 +119,9 @@ func NewBridge(db *gorm.DB, executor deployer.CommandExecutor, encryptionKey []b
 		EventBus:      eventBus,
 		ConfirmStore:  confirm.NewStore(),
 		BFProtector:   bruteforce.New(bruteforce.DefaultConfig()),
+		tasks:         make(map[string]*taskInfo),
+		backupApps:    make(map[string]string),
+		portForwards:  make(map[string]*portForwardEntry),
 	}
 }
 
@@ -712,25 +728,19 @@ type portForwardEntry struct {
 	Command    string
 }
 
-// portForwardMu protects portForwards map.
-var portForwardMu sync.RWMutex
-
-// portForwards stores active port forwards keyed by "serverID:localPort".
-var portForwards = make(map[string]*portForwardEntry)
-
 func (b *Bridge) PortForward(ctx context.Context, action, serverID string, localPort, remotePort int, remoteHost string) (string, error) {
 	switch action {
 	case "list":
-		portForwardMu.RLock()
-		defer portForwardMu.RUnlock()
-		if len(portForwards) == 0 {
+		b.portForwardMu.RLock()
+		defer b.portForwardMu.RUnlock()
+		if len(b.portForwards) == 0 {
 			return "No active port forwards.", nil
 		}
 		var lines []string
-		for key, pf := range portForwards {
+		for key, pf := range b.portForwards {
 			lines = append(lines, fmt.Sprintf("  %s -> server=%s remote=%s:%d (key=%s)", pf.Command, pf.ServerID, pf.RemoteHost, pf.RemotePort, key))
 		}
-		return fmt.Sprintf("Active port forwards (%d):\n%s", len(portForwards), strings.Join(lines, "\n")), nil
+		return fmt.Sprintf("Active port forwards (%d):\n%s", len(b.portForwards), strings.Join(lines, "\n")), nil
 
 	case "create":
 		if serverID == "" {
@@ -744,10 +754,10 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 		}
 
 		key := fmt.Sprintf("%s:%d", serverID, localPort)
-		portForwardMu.Lock()
-		defer portForwardMu.Unlock()
+		b.portForwardMu.Lock()
+		defer b.portForwardMu.Unlock()
 
-		if _, exists := portForwards[key]; exists {
+		if _, exists := b.portForwards[key]; exists {
 			return "", fmt.Errorf("port forward already exists for %s (local port %d is already in use)", key, localPort)
 		}
 
@@ -795,7 +805,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 			cancel()
 		}()
 
-		portForwards[key] = &portForwardEntry{
+		b.portForwards[key] = &portForwardEntry{
 			ServerID:   serverID,
 			LocalPort:  localPort,
 			RemotePort: remotePort,
@@ -814,10 +824,10 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 		}
 
 		key := fmt.Sprintf("%s:%d", serverID, localPort)
-		portForwardMu.Lock()
-		defer portForwardMu.Unlock()
+		b.portForwardMu.Lock()
+		defer b.portForwardMu.Unlock()
 
-		entry, exists := portForwards[key]
+		entry, exists := b.portForwards[key]
 		if !exists {
 			return "", fmt.Errorf("port forward not found for %s", key)
 		}
@@ -828,7 +838,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 			slog.Warn("failed to kill SSH tunnel process", "error", err)
 		}
 
-		delete(portForwards, key)
+		delete(b.portForwards, key)
 		return fmt.Sprintf("Port forward deleted: %s", key), nil
 
 	default:

--- a/internal/service/bridge_coverage_test.go
+++ b/internal/service/bridge_coverage_test.go
@@ -722,8 +722,8 @@ func TestGetTemplate_NotFound_Cov(t *testing.T) {
 
 func TestGetTaskStatus_Found_Cov(t *testing.T) {
 	b, _ := newTestBridge(t)
-	taskID := createTask("test-cov")
-	updateTask(taskID, "success", 100, "done")
+	taskID := b.createTask("test-cov")
+	b.updateTask(taskID, "success", 100, "done")
 
 	res, err := b.GetTaskStatus(context.TODO(), taskID)
 	if err != nil {
@@ -738,9 +738,9 @@ func TestGetTaskStatus_Found_Cov(t *testing.T) {
 	}
 
 	// Clean up to avoid interfering with other tests
-	taskMu.Lock()
-	delete(tasks, taskID)
-	taskMu.Unlock()
+	b.taskMu.Lock()
+	delete(b.tasks, taskID)
+	b.taskMu.Unlock()
 }
 
 // ===================== GetLatestDeploymentRecord Coverage =====================

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -1756,9 +1756,9 @@ func TestRestore_BackupExists_AppFound(t *testing.T) {
 	})
 
 	// Insert backup mapping
-	backupMu.Lock()
-	backupApps["restore-backup-id"] = id
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["restore-backup-id"] = id
+	b.backupMu.Unlock()
 
 	exec.output["docker stop restore-app-container"] = ""
 	exec.output["docker rm -f restore-app-container"] = ""
@@ -2299,14 +2299,14 @@ func TestRestore_WithEnvVars(t *testing.T) {
 		"env_vars":        `{"FOO":"bar"}`,
 	})
 
-	backupMu.Lock()
-	backupApps["restore-env-backup-id"] = id
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["restore-env-backup-id"] = id
+	b.backupMu.Unlock()
 
 	defer func() {
-		backupMu.Lock()
-		delete(backupApps, "restore-env-backup-id")
-		backupMu.Unlock()
+		b.backupMu.Lock()
+		delete(b.backupApps, "restore-env-backup-id")
+		b.backupMu.Unlock()
 	}()
 
 	exec.output["docker stop restore-env-container"] = ""
@@ -2334,14 +2334,14 @@ func TestRestore_DeployFails(t *testing.T) {
 		"current_version": "nginx:alpine",
 	})
 
-	backupMu.Lock()
-	backupApps["restore-deploy-fail-backup"] = id
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["restore-deploy-fail-backup"] = id
+	b.backupMu.Unlock()
 
 	defer func() {
-		backupMu.Lock()
-		delete(backupApps, "restore-deploy-fail-backup")
-		backupMu.Unlock()
+		b.backupMu.Lock()
+		delete(b.backupApps, "restore-deploy-fail-backup")
+		b.backupMu.Unlock()
 	}()
 
 	exec.output["docker stop restore-deploy-fail-container"] = ""
@@ -2365,14 +2365,14 @@ func TestRestore_FallbackImage(t *testing.T) {
 		"current_version": "",
 	})
 
-	backupMu.Lock()
-	backupApps["restore-fallback-backup"] = id
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["restore-fallback-backup"] = id
+	b.backupMu.Unlock()
 
 	defer func() {
-		backupMu.Lock()
-		delete(backupApps, "restore-fallback-backup")
-		backupMu.Unlock()
+		b.backupMu.Lock()
+		delete(b.backupApps, "restore-fallback-backup")
+		b.backupMu.Unlock()
 	}()
 
 	exec.output["docker stop restore-fallback-container"] = ""
@@ -2401,14 +2401,14 @@ func TestRestore_ContainerNameFallback(t *testing.T) {
 		"current_version": "nginx:alpine",
 	})
 
-	backupMu.Lock()
-	backupApps["restore-cn-fallback-backup"] = id
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["restore-cn-fallback-backup"] = id
+	b.backupMu.Unlock()
 
 	defer func() {
-		backupMu.Lock()
-		delete(backupApps, "restore-cn-fallback-backup")
-		backupMu.Unlock()
+		b.backupMu.Lock()
+		delete(b.backupApps, "restore-cn-fallback-backup")
+		b.backupMu.Unlock()
 	}()
 
 	exec.output["docker stop restore-cn-fallback"] = ""
@@ -2738,14 +2738,14 @@ func TestRestore_BackupNotFound(t *testing.T) {
 func TestRestore_AppNotFound_OrphanBackup(t *testing.T) {
 	b, _ := newTestBridge(t)
 	// Insert a backup mapping to a nonexistent app
-	backupMu.Lock()
-	backupApps["orphan-backup-id-2"] = "nonexistent-app-id-2"
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["orphan-backup-id-2"] = "nonexistent-app-id-2"
+	b.backupMu.Unlock()
 
 	defer func() {
-		backupMu.Lock()
-		delete(backupApps, "orphan-backup-id-2")
-		backupMu.Unlock()
+		b.backupMu.Lock()
+		delete(b.backupApps, "orphan-backup-id-2")
+		b.backupMu.Unlock()
 	}()
 
 	_, err := b.Restore(context.TODO(), "orphan-backup-id-2")
@@ -2871,10 +2871,10 @@ func TestBatchDNS_MultipleRecords(t *testing.T) {
 func TestListTasks_WithStatusFilter(t *testing.T) {
 	b, _ := newTestBridge(t)
 	// Create tasks with different statuses
-	id1 := createTask("deploy")
-	updateTask(id1, "success", 100, "done")
-	id2 := createTask("deploy")
-	updateTask(id2, "failed", 100, "error")
+	id1 := b.createTask("deploy")
+	b.updateTask(id1, "success", 100, "done")
+	id2 := b.createTask("deploy")
+	b.updateTask(id2, "failed", 100, "error")
 
 	result, err := b.ListTasks(context.TODO(), 10, "success")
 	if err != nil {
@@ -2899,7 +2899,7 @@ func TestListTasks_WithLimit(t *testing.T) {
 	b, _ := newTestBridge(t)
 	// Create multiple tasks
 	for i := 0; i < 5; i++ {
-		createTask("deploy")
+		b.createTask("deploy")
 	}
 
 	result, err := b.ListTasks(context.TODO(), 2, "")

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -19,13 +19,13 @@ import (
 
 // DeployAsync starts a deploy in a goroutine and returns a task ID immediately.
 func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID string) (taskID string, err error) {
-	taskID = createTask("deploy")
+	taskID = b.createTask("deploy")
 	traceID := tracing.TraceIDFromContext(ctx)
-	updateTask(taskID, "running", 0, "deploy started")
+	b.updateTask(taskID, "running", 0, "deploy started")
 	go func() {
 		cs, deployErr := b.Deploy(ctx, cfg)
 		if deployErr != nil {
-			updateTask(taskID, "failed", 100, deployErr.Error())
+			b.updateTask(taskID, "failed", 100, deployErr.Error())
 			b.EventBus.Publish(DeployEvent{
 				TaskID:    taskID,
 				AppID:     appID,
@@ -37,7 +37,7 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 				TraceID:   traceID,
 			})
 		} else {
-			updateTask(taskID, "success", 100, "deploy completed")
+			b.updateTask(taskID, "success", 100, "deploy completed")
 			b.EventBus.Publish(DeployEvent{
 				TaskID:    taskID,
 				AppID:     appID,
@@ -48,11 +48,11 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 				Timestamp: time.Now().Format(time.RFC3339),
 				TraceID:   traceID,
 			})
-			taskMu.Lock()
-			if t, ok := tasks[taskID]; ok {
+			b.taskMu.Lock()
+			if t, ok := b.tasks[taskID]; ok {
 				t.Result = cs
 			}
-			taskMu.Unlock()
+			b.taskMu.Unlock()
 		}
 	}()
 	return taskID, nil

--- a/internal/service/eventbus_test.go
+++ b/internal/service/eventbus_test.go
@@ -224,25 +224,27 @@ func TestInMemoryEventBus_Close(t *testing.T) {
 }
 
 func TestUpdateTask(t *testing.T) {
+	bridge := NewBridge(nil, nil, nil, nil)
+
 	// Reset tasks for test
-	taskMu.Lock()
-	oldTasks := tasks
-	oldCounter := taskCounter
-	tasks = make(map[string]*taskInfo)
-	taskCounter = 0
-	taskMu.Unlock()
+	bridge.taskMu.Lock()
+	oldTasks := bridge.tasks
+	oldCounter := bridge.taskCounter
+	bridge.tasks = make(map[string]*taskInfo)
+	bridge.taskCounter = 0
+	bridge.taskMu.Unlock()
 
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskCounter = oldCounter
-		taskMu.Unlock()
+		bridge.taskMu.Lock()
+		bridge.tasks = oldTasks
+		bridge.taskCounter = oldCounter
+		bridge.taskMu.Unlock()
 	}()
 
-	id := createTask("test")
-	updateTask(id, "running", 50, "halfway done")
+	id := bridge.createTask("test")
+	bridge.updateTask(id, "running", 50, "halfway done")
 
-	task := getTask(id)
+	task := bridge.getTask(id)
 	if task == nil {
 		t.Fatal("getTask returned nil")
 	}
@@ -257,32 +259,34 @@ func TestUpdateTask(t *testing.T) {
 	}
 
 	// Update non-existent task should not panic
-	updateTask("nonexistent", "failed", 100, "error")
+	bridge.updateTask("nonexistent", "failed", 100, "error")
 }
 
 func TestGetTask(t *testing.T) {
-	taskMu.Lock()
-	oldTasks := tasks
-	oldCounter := taskCounter
-	tasks = make(map[string]*taskInfo)
-	taskCounter = 0
-	taskMu.Unlock()
+	bridge := NewBridge(nil, nil, nil, nil)
+
+	bridge.taskMu.Lock()
+	oldTasks := bridge.tasks
+	oldCounter := bridge.taskCounter
+	bridge.tasks = make(map[string]*taskInfo)
+	bridge.taskCounter = 0
+	bridge.taskMu.Unlock()
 
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskCounter = oldCounter
-		taskMu.Unlock()
+		bridge.taskMu.Lock()
+		bridge.tasks = oldTasks
+		bridge.taskCounter = oldCounter
+		bridge.taskMu.Unlock()
 	}()
 
 	// Non-existent task
-	task := getTask("nonexistent")
+	task := bridge.getTask("nonexistent")
 	if task != nil {
 		t.Error("expected nil for non-existent task")
 	}
 
-	id := createTask("test")
-	task = getTask(id)
+	id := bridge.createTask("test")
+	task = bridge.getTask(id)
 	if task == nil {
 		t.Fatal("expected non-nil task")
 	}

--- a/internal/service/task_service.go
+++ b/internal/service/task_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 )
 
@@ -20,21 +19,12 @@ type taskInfo struct {
 	UpdatedAt time.Time   `json:"updated_at"`
 }
 
-var (
-	taskMu      sync.RWMutex
-	tasks       = make(map[string]*taskInfo)
-	taskCounter int64
-
-	backupMu   sync.RWMutex
-	backupApps = make(map[string]string) // backupID -> appID
-)
-
-func createTask(taskType string) string {
-	taskMu.Lock()
-	defer taskMu.Unlock()
-	taskCounter++
-	id := fmt.Sprintf("task-%d", taskCounter)
-	tasks[id] = &taskInfo{
+func (b *Bridge) createTask(taskType string) string {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	b.taskCounter++
+	id := fmt.Sprintf("task-%d", b.taskCounter)
+	b.tasks[id] = &taskInfo{
 		ID:        id,
 		Type:      taskType,
 		Status:    "pending",
@@ -46,10 +36,10 @@ func createTask(taskType string) string {
 }
 
 // updateTask updates the status of an existing task.
-func updateTask(id, status string, progress int, message string) {
-	taskMu.Lock()
-	defer taskMu.Unlock()
-	if t, ok := tasks[id]; ok {
+func (b *Bridge) updateTask(id, status string, progress int, message string) {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	if t, ok := b.tasks[id]; ok {
 		t.Status = status
 		t.Progress = progress
 		t.Message = message
@@ -58,10 +48,10 @@ func updateTask(id, status string, progress int, message string) {
 }
 
 // getTask returns a copy of the task info for the given task ID.
-func getTask(id string) *taskInfo {
-	taskMu.RLock()
-	defer taskMu.RUnlock()
-	if t, ok := tasks[id]; ok {
+func (b *Bridge) getTask(id string) *taskInfo {
+	b.taskMu.RLock()
+	defer b.taskMu.RUnlock()
+	if t, ok := b.tasks[id]; ok {
 		cp := *t
 		return &cp
 	}
@@ -71,9 +61,9 @@ func getTask(id string) *taskInfo {
 // ---------- 27. GetTaskStatus ----------
 
 func (b *Bridge) GetTaskStatus(ctx context.Context, taskID string) (interface{}, error) {
-	taskMu.RLock()
-	defer taskMu.RUnlock()
-	t, ok := tasks[taskID]
+	b.taskMu.RLock()
+	defer b.taskMu.RUnlock()
+	t, ok := b.tasks[taskID]
 	if !ok {
 		return map[string]interface{}{
 			"task_id": taskID,
@@ -87,11 +77,11 @@ func (b *Bridge) GetTaskStatus(ctx context.Context, taskID string) (interface{},
 // ---------- 28. ListTasks ----------
 
 func (b *Bridge) ListTasks(ctx context.Context, limit int, statusFilter string) (interface{}, error) {
-	taskMu.RLock()
-	defer taskMu.RUnlock()
+	b.taskMu.RLock()
+	defer b.taskMu.RUnlock()
 
 	result := make([]*taskInfo, 0)
-	for _, t := range tasks {
+	for _, t := range b.tasks {
 		if statusFilter != "" && t.Status != statusFilter {
 			continue
 		}

--- a/internal/service/v05_test.go
+++ b/internal/service/v05_test.go
@@ -255,9 +255,9 @@ func TestRestore_BackupExists_AppGone(t *testing.T) {
 	b := NewBridge(db, exec, []byte("01234567890123456789012345678901"), nil)
 
 	// Manually insert a backup mapping for a nonexistent app
-	backupMu.Lock()
-	backupApps["backup-orphan"] = "nonexistent-app-id"
-	backupMu.Unlock()
+	b.backupMu.Lock()
+	b.backupApps["backup-orphan"] = "nonexistent-app-id"
+	b.backupMu.Unlock()
 
 	_, err := b.Restore(context.Background(), "backup-orphan")
 	if err == nil {
@@ -284,7 +284,7 @@ func TestGetTaskStatus_NotFound(t *testing.T) {
 
 func TestGetTaskStatus_Found(t *testing.T) {
 	b, _ := newTestBridge(t)
-	id := createTask("deploy")
+	id := b.createTask("deploy")
 	result, err := b.GetTaskStatus(context.Background(), id)
 	if err != nil {
 		t.Fatalf("GetTaskStatus failed: %v", err)
@@ -305,18 +305,18 @@ func TestGetTaskStatus_Found(t *testing.T) {
 }
 
 func TestListTasks_Empty(t *testing.T) {
+	b, _ := newTestBridge(t)
 	// Clear tasks for this test
-	taskMu.Lock()
-	oldTasks := tasks
-	tasks = make(map[string]*taskInfo)
-	taskMu.Unlock()
+	b.taskMu.Lock()
+	oldTasks := b.tasks
+	b.tasks = make(map[string]*taskInfo)
+	b.taskMu.Unlock()
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskMu.Unlock()
+		b.taskMu.Lock()
+		b.tasks = oldTasks
+		b.taskMu.Unlock()
 	}()
 
-	b, _ := newTestBridge(t)
 	result, err := b.ListTasks(context.Background(), 10, "")
 	if err != nil {
 		t.Fatalf("ListTasks failed: %v", err)
@@ -338,37 +338,36 @@ func TestListTasks_Empty(t *testing.T) {
 }
 
 func TestListTasks_WithFilter(t *testing.T) {
+	b, _ := newTestBridge(t)
 	// Clear tasks and add known tasks
-	taskMu.Lock()
-	oldTasks := tasks
-	oldCounter := taskCounter
-	tasks = make(map[string]*taskInfo)
-	taskCounter = 0
-	taskMu.Unlock()
+	b.taskMu.Lock()
+	oldTasks := b.tasks
+	oldCounter := b.taskCounter
+	b.tasks = make(map[string]*taskInfo)
+	b.taskCounter = 0
+	b.taskMu.Unlock()
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskCounter = oldCounter
-		taskMu.Unlock()
+		b.taskMu.Lock()
+		b.tasks = oldTasks
+		b.taskCounter = oldCounter
+		b.taskMu.Unlock()
 	}()
 
-	id1 := createTask("deploy")
+	id1 := b.createTask("deploy")
 	// Mark id1 as success
-	taskMu.Lock()
-	if t, ok := tasks[id1]; ok {
+	b.taskMu.Lock()
+	if t, ok := b.tasks[id1]; ok {
 		t.Status = "success"
 	}
-	taskMu.Unlock()
+	b.taskMu.Unlock()
 
-	id2 := createTask("backup")
+	id2 := b.createTask("backup")
 	// Mark id2 as failed
-	taskMu.Lock()
-	if t, ok := tasks[id2]; ok {
+	b.taskMu.Lock()
+	if t, ok := b.tasks[id2]; ok {
 		t.Status = "failed"
 	}
-	taskMu.Unlock()
-
-	b, _ := newTestBridge(t)
+	b.taskMu.Unlock()
 
 	// Filter by "success"
 	result, err := b.ListTasks(context.Background(), 10, "success")
@@ -425,22 +424,23 @@ func TestListTasks_WithFilter(t *testing.T) {
 }
 
 func TestCreateTask(t *testing.T) {
+	b, _ := newTestBridge(t)
 	// Save and restore state
-	taskMu.Lock()
-	oldTasks := tasks
-	oldCounter := taskCounter
-	tasks = make(map[string]*taskInfo)
-	taskCounter = 0
-	taskMu.Unlock()
+	b.taskMu.Lock()
+	oldTasks := b.tasks
+	oldCounter := b.taskCounter
+	b.tasks = make(map[string]*taskInfo)
+	b.taskCounter = 0
+	b.taskMu.Unlock()
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskCounter = oldCounter
-		taskMu.Unlock()
+		b.taskMu.Lock()
+		b.tasks = oldTasks
+		b.taskCounter = oldCounter
+		b.taskMu.Unlock()
 	}()
 
-	id1 := createTask("deploy")
-	id2 := createTask("backup")
+	id1 := b.createTask("deploy")
+	id2 := b.createTask("backup")
 
 	if id1 == id2 {
 		t.Fatal("expected unique task IDs")
@@ -452,28 +452,29 @@ func TestCreateTask(t *testing.T) {
 		t.Fatalf("expected task-2, got %s", id2)
 	}
 
-	taskMu.RLock()
-	if len(tasks) != 2 {
-		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	b.taskMu.RLock()
+	if len(b.tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(b.tasks))
 	}
-	taskMu.RUnlock()
+	b.taskMu.RUnlock()
 }
 
 // ===================== Concurrency Tests =====================
 
 func TestTaskTracker_Concurrent(t *testing.T) {
+	b, _ := newTestBridge(t)
 	// Save and restore state
-	taskMu.Lock()
-	oldTasks := tasks
-	oldCounter := taskCounter
-	tasks = make(map[string]*taskInfo)
-	taskCounter = 0
-	taskMu.Unlock()
+	b.taskMu.Lock()
+	oldTasks := b.tasks
+	oldCounter := b.taskCounter
+	b.tasks = make(map[string]*taskInfo)
+	b.taskCounter = 0
+	b.taskMu.Unlock()
 	defer func() {
-		taskMu.Lock()
-		tasks = oldTasks
-		taskCounter = oldCounter
-		taskMu.Unlock()
+		b.taskMu.Lock()
+		b.tasks = oldTasks
+		b.taskCounter = oldCounter
+		b.taskMu.Unlock()
 	}()
 
 	var wg sync.WaitGroup
@@ -481,16 +482,16 @@ func TestTaskTracker_Concurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			createTask("concurrent-test")
+			b.createTask("concurrent-test")
 		}()
 	}
 	wg.Wait()
 
-	taskMu.RLock()
-	if len(tasks) != 100 {
-		t.Fatalf("expected 100 tasks, got %d", len(tasks))
+	b.taskMu.RLock()
+	if len(b.tasks) != 100 {
+		t.Fatalf("expected 100 tasks, got %d", len(b.tasks))
 	}
-	taskMu.RUnlock()
+	b.taskMu.RUnlock()
 }
 
 // ===================== Email Notifier Config Test =====================


### PR DESCRIPTION
## Summary

Move all package-level global mutable variables into the `Bridge` struct to fix memory leaks, test isolation issues, and multi-instance incompatibility.

### Changes

**Global variables removed:**
- `taskMu` / `tasks` / `taskCounter` (task_service.go)
- `backupMu` / `backupApps` (task_service.go)
- `portForwardMu` / `portForwards` (bridge.go)

**Bridge struct additions:**
- 8 new fields: 3 mutexes + 3 maps + 1 counter + 1 port forward map
- `NewBridge()` initializes all maps

**Function changes:**
- `createTask()` / `updateTask()` / `getTask()`: package functions → Bridge methods
- All callers updated to use `b.createTask()` / `b.updateTask()` etc.

**Files modified (8):**
- `bridge.go` — struct + constructor + PortForward method
- `task_service.go` — removed globals, functions → methods
- `deploy_service.go` — `b.createTask` / `b.updateTask` / `b.tasks`
- `backup_service.go` — `b.backupMu` / `b.backupApps`
- `v05_test.go` — Bridge instance field access
- `eventbus_test.go` — Bridge instance field access
- `bridge_test.go` — `b.backupMu` / `b.backupApps` / `b.createTask` / `b.updateTask`
- `bridge_coverage_test.go` — `b.taskMu` / `b.tasks` / `b.createTask` / `b.updateTask`

### Impact

- ✅ Memory leak fixed: tasks map is now per-Bridge instance
- ✅ Test isolation: each test can create its own Bridge
- ✅ Multi-instance compatible: no shared global state
- ⚠️ `backupApps` still in-memory (persist to DB in future PR)

Fixes #117

Agent-Model: Claude
Agent-Decision: Move globals into struct for proper encapsulation
Agent-Task: Fix #117 global mutable state issues