### PR TITLE
refactor: split Deployer God Interface into 18 sub-interfaces (fixes #116)

### DIFF
--- a/internal/mcp/handler_backup.go
+++ b/internal/mcp/handler_backup.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleBackup(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleBackup(ctx context.Context, d BackupManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	backupID, err := deployer.Backup(ctx, appID)
+	backupID, err := d.Backup(ctx, appID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("backup failed: %v", err)), nil
 	}
@@ -28,13 +28,13 @@ func handleBackup(ctx context.Context, deployer Deployer, request mcp.CallToolRe
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleRestore(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRestore(ctx context.Context, d BackupManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	backupID, err := request.RequireString("backup_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	status, err := deployer.Restore(ctx, backupID)
+	status, err := d.Restore(ctx, backupID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("restore failed: %v", err)), nil
 	}
@@ -53,7 +53,7 @@ func handleRestore(ctx context.Context, deployer Deployer, request mcp.CallToolR
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleBatchBackup(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleBatchBackup(ctx context.Context, d BackupManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appIDsStr, err := request.RequireString("app_ids")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -62,7 +62,7 @@ func handleBatchBackup(ctx context.Context, deployer Deployer, request mcp.CallT
 	if err := json.Unmarshal([]byte(appIDsStr), &appIDs); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid app_ids JSON: %v", err)), nil
 	}
-	res, err := deployer.BatchBackup(ctx, appIDs)
+	res, err := d.BatchBackup(ctx, appIDs)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("batch backup failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_cicd.go
+++ b/internal/mcp/handler_cicd.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleTriggerCIBuild(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleTriggerCIBuild(ctx context.Context, d CICDService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	provider, err := request.RequireString("provider")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -20,7 +20,7 @@ func handleTriggerCIBuild(ctx context.Context, deployer Deployer, request mcp.Ca
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.TriggerCIBuild(ctx, provider, repo, branch)
+	result, err := d.TriggerCIBuild(ctx, provider, repo, branch)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to trigger CI build: %v", err)), nil
 	}
@@ -28,7 +28,7 @@ func handleTriggerCIBuild(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetCIBuildStatus(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetCIBuildStatus(ctx context.Context, d CICDService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	provider, err := request.RequireString("provider")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -38,7 +38,7 @@ func handleGetCIBuildStatus(ctx context.Context, deployer Deployer, request mcp.
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.GetCIBuildStatus(ctx, provider, runID)
+	result, err := d.GetCIBuildStatus(ctx, provider, runID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get CI build status: %v", err)), nil
 	}

--- a/internal/mcp/handler_credential.go
+++ b/internal/mcp/handler_credential.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleCreateCredential(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleCreateCredential(ctx context.Context, d CredentialManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tenantID, err := request.RequireString("tenant_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -24,7 +24,7 @@ func handleCreateCredential(ctx context.Context, deployer Deployer, request mcp.
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	cred, err := deployer.CreateCredential(ctx, tenantID, name, credType, value)
+	cred, err := d.CreateCredential(ctx, tenantID, name, credType, value)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to create credential: %v", err)), nil
 	}
@@ -37,13 +37,13 @@ func handleCreateCredential(ctx context.Context, deployer Deployer, request mcp.
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListCredentials(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListCredentials(ctx context.Context, d CredentialManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tenantID, err := request.RequireString("tenant_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	creds, err := deployer.ListCredentials(ctx, tenantID)
+	creds, err := d.ListCredentials(ctx, tenantID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list credentials: %v", err)), nil
 	}
@@ -55,13 +55,13 @@ func handleListCredentials(ctx context.Context, deployer Deployer, request mcp.C
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDeleteCredential(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeleteCredential(ctx context.Context, d CredentialManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	credID, err := request.RequireString("credential_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if err := deployer.DeleteCredential(ctx, credID); err != nil {
+	if err := d.DeleteCredential(ctx, credID); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to delete credential: %v", err)), nil
 	}
 
@@ -72,7 +72,7 @@ func handleDeleteCredential(ctx context.Context, deployer Deployer, request mcp.
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleUpdateCredential(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleUpdateCredential(ctx context.Context, d CredentialManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	credID, err := request.RequireString("credential_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -81,7 +81,7 @@ func handleUpdateCredential(ctx context.Context, deployer Deployer, request mcp.
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	res, err := deployer.UpdateCredential(ctx, credID, value)
+	res, err := d.UpdateCredential(ctx, credID, value)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("update credential failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_deploy.go
+++ b/internal/mcp/handler_deploy.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleBuildAndDeploy(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	repoURL, err := request.RequireString("repo_url")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -48,7 +48,7 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 		cfg.PushImage = strings.ToLower(v) == "true"
 	}
 
-	result, err := deployer.BuildAndDeploy(ctx, cfg)
+	result, err := d.BuildAndDeploy(ctx, cfg)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("build and deploy failed: %v", err)), nil
 	}
@@ -59,13 +59,13 @@ func handleBuildAndDeploy(ctx context.Context, deployer Deployer, request mcp.Ca
 
 // ---------- Phase 3.1: Compose Handlers ----------
 
-func handleComposeDeploy(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleComposeDeploy(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	output, err := deployer.ComposeDeploy(ctx, appID)
+	output, err := d.ComposeDeploy(ctx, appID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("compose deploy failed: %v", err)), nil
 	}
@@ -79,13 +79,13 @@ func handleComposeDeploy(ctx context.Context, deployer Deployer, request mcp.Cal
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleComposeStop(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleComposeStop(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	output, err := deployer.ComposeStop(ctx, appID)
+	output, err := d.ComposeStop(ctx, appID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("compose stop failed: %v", err)), nil
 	}
@@ -99,13 +99,13 @@ func handleComposeStop(ctx context.Context, deployer Deployer, request mcp.CallT
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleComposePs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleComposePs(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	output, err := deployer.ComposePs(ctx, appID)
+	output, err := d.ComposePs(ctx, appID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("compose ps failed: %v", err)), nil
 	}
@@ -119,7 +119,7 @@ func handleComposePs(ctx context.Context, deployer Deployer, request mcp.CallToo
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleComposeLogs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleComposeLogs(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -128,7 +128,7 @@ func handleComposeLogs(ctx context.Context, deployer Deployer, request mcp.CallT
 	service := request.GetString("service", "")
 	tail := request.GetString("tail", "")
 
-	output, err := deployer.ComposeLogs(ctx, appID, service, tail)
+	output, err := d.ComposeLogs(ctx, appID, service, tail)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("compose logs failed: %v", err)), nil
 	}
@@ -143,7 +143,7 @@ func handleComposeLogs(ctx context.Context, deployer Deployer, request mcp.CallT
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleComposeRestart(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleComposeRestart(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -151,7 +151,7 @@ func handleComposeRestart(ctx context.Context, deployer Deployer, request mcp.Ca
 
 	service := request.GetString("service", "")
 
-	output, err := deployer.ComposeRestart(ctx, appID, service)
+	output, err := d.ComposeRestart(ctx, appID, service)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("compose restart failed: %v", err)), nil
 	}
@@ -165,11 +165,11 @@ func handleComposeRestart(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListImages(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListImages(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID := request.GetString("server_id", "")
 	filter := request.GetString("filter", "")
 
-	output, err := deployer.ListImages(ctx, serverID, filter)
+	output, err := d.ListImages(ctx, serverID, filter)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list images: %v", err)), nil
 	}
@@ -190,11 +190,11 @@ func handleListImages(ctx context.Context, deployer Deployer, request mcp.CallTo
 
 // ---------- Phase 3.5: Preflight Visualization ----------
 
-func handleRunPreflight(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRunPreflight(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID := request.GetString("server_id", "")
 	portMappings := request.GetString("port_mappings", "")
 
-	result, err := deployer.RunPreflightFull(ctx, serverID, portMappings)
+	result, err := d.RunPreflightFull(ctx, serverID, portMappings)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("preflight check failed: %v", err)), nil
 	}
@@ -202,7 +202,7 @@ func handleRunPreflight(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDeployApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeployApp(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	image, err := request.RequireString("image")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -278,7 +278,7 @@ func handleDeployApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 		cfg.Labels = labels
 	}
 
-	status, err := deployer.Deploy(ctx, cfg)
+	status, err := d.Deploy(ctx, cfg)
 	if err != nil {
 		// Check if it's a preflight error for structured output
 		var pfErr PreflightErrorInfo
@@ -309,8 +309,8 @@ func handleDeployApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListApps(ctx context.Context, deployer Deployer, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	apps, err := deployer.ListApps(ctx)
+func handleListApps(ctx context.Context, d ContainerDeployer, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	apps, err := d.ListApps(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list apps: %v", err)), nil
 	}
@@ -324,7 +324,7 @@ func handleListApps(ctx context.Context, deployer Deployer, _ mcp.CallToolReques
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleCreateApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleCreateApp(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -346,7 +346,7 @@ func handleCreateApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 		Environment: request.GetString("environment", "production"),
 	}
 
-	appID, err := deployer.CreateApp(ctx, cfg)
+	appID, err := d.CreateApp(ctx, cfg)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to create app: %v", err)), nil
 	}
@@ -364,13 +364,13 @@ func handleCreateApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDeleteApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeleteApp(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if err := deployer.DeleteApp(ctx, appID); err != nil {
+	if err := d.DeleteApp(ctx, appID); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to delete app: %v", err)), nil
 	}
 
@@ -382,7 +382,7 @@ func handleDeleteApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleRollback(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRollback(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	containerName, err := request.RequireString("container_name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -391,7 +391,7 @@ func handleRollback(ctx context.Context, deployer Deployer, request mcp.CallTool
 	// previous_image is now optional — auto-resolves from deployment history
 	previousImage := request.GetString("previous_image", "")
 
-	status, err := deployer.Rollback(ctx, containerName, previousImage)
+	status, err := d.Rollback(ctx, containerName, previousImage)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("rollback failed: %v", err)), nil
 	}
@@ -415,13 +415,13 @@ func handleRollback(ctx context.Context, deployer Deployer, request mcp.CallTool
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetAppDetail(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetAppDetail(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	detail, err := deployer.GetAppDetail(ctx, appID)
+	detail, err := d.GetAppDetail(ctx, appID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get app detail: %v", err)), nil
 	}
@@ -430,7 +430,7 @@ func handleGetAppDetail(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleUpdateApp(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleUpdateApp(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -445,7 +445,7 @@ func handleUpdateApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 		return mcp.NewToolResultError(fmt.Sprintf("invalid config JSON: %v", err)), nil
 	}
 
-	updated, err := deployer.UpdateApp(ctx, appID, config)
+	updated, err := d.UpdateApp(ctx, appID, config)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to update app: %v", err)), nil
 	}
@@ -454,7 +454,7 @@ func handleUpdateApp(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleCheckDeployReadiness(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleCheckDeployReadiness(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	configStr, err := request.RequireString("app_config")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -463,7 +463,7 @@ func handleCheckDeployReadiness(ctx context.Context, deployer Deployer, request 
 	if err := json.Unmarshal([]byte(configStr), &appConfig); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid app_config JSON: %v", err)), nil
 	}
-	res, err := deployer.CheckDeployReadiness(ctx, appConfig)
+	res, err := d.CheckDeployReadiness(ctx, appConfig)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("readiness check failed: %v", err)), nil
 	}
@@ -471,7 +471,7 @@ func handleCheckDeployReadiness(ctx context.Context, deployer Deployer, request 
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleBatchDeploy(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleBatchDeploy(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appsStr, err := request.RequireString("apps")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -513,7 +513,7 @@ func handleBatchDeploy(ctx context.Context, deployer Deployer, request mcp.CallT
 		ServerIDs:     serverIDs,
 	}
 
-	res, err := deployer.BatchDeployWithConfig(ctx, config)
+	res, err := d.BatchDeployWithConfig(ctx, config)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("batch deploy failed: %v", err)), nil
 	}
@@ -521,13 +521,13 @@ func handleBatchDeploy(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetDeployStatus(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetDeployStatus(ctx context.Context, d ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	containerName, err := request.RequireString("container_name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	status, err := deployer.GetContainerStatus(ctx, containerName)
+	status, err := d.GetContainerStatus(ctx, containerName)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get status: %v", err)), nil
 	}
@@ -543,7 +543,7 @@ func handleGetDeployStatus(ctx context.Context, deployer Deployer, request mcp.C
 	}
 
 	// Add preflight summary from latest deployment record
-	if record, err := deployer.GetLatestDeploymentRecord(ctx, containerName); err == nil && record.PreflightCode != "" {
+	if record, err := d.GetLatestDeploymentRecord(ctx, containerName); err == nil && record.PreflightCode != "" {
 		result["last_preflight"] = map[string]interface{}{
 			"status":  record.Status,
 			"code":    record.PreflightCode,

--- a/internal/mcp/handler_dns.go
+++ b/internal/mcp/handler_dns.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleDNSCreateRecord(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDNSCreateRecord(ctx context.Context, d DNSManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, _ := request.RequireString("domain")
 	recordType, _ := request.RequireString("type")
 	name, _ := request.RequireString("name")
@@ -16,7 +16,7 @@ func handleDNSCreateRecord(ctx context.Context, deployer Deployer, request mcp.C
 		return mcp.NewToolResultError("domain, type, name, and value are required"), nil
 	}
 
-	record, err := deployer.DNSCreateRecord(ctx, domain, recordType, name, value)
+	record, err := d.DNSCreateRecord(ctx, domain, recordType, name, value)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("DNS create failed: %v", err)), nil
 	}
@@ -25,13 +25,13 @@ func handleDNSCreateRecord(ctx context.Context, deployer Deployer, request mcp.C
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDNSDeleteRecord(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDNSDeleteRecord(ctx context.Context, d DNSManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	recordID, err := request.RequireString("record_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if err := deployer.DNSDeleteRecord(ctx, recordID); err != nil {
+	if err := d.DNSDeleteRecord(ctx, recordID); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("DNS delete failed: %v", err)), nil
 	}
 
@@ -39,13 +39,13 @@ func handleDNSDeleteRecord(ctx context.Context, deployer Deployer, request mcp.C
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDNSListRecords(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDNSListRecords(ctx context.Context, d DNSManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, err := request.RequireString("domain")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	records, err := deployer.DNSListRecords(ctx, domain)
+	records, err := d.DNSListRecords(ctx, domain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("DNS list failed: %v", err)), nil
 	}
@@ -54,7 +54,7 @@ func handleDNSListRecords(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleUpdateDNSRecord(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleUpdateDNSRecord(ctx context.Context, d DNSManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, _ := request.RequireString("domain")
 	subdomain, _ := request.RequireString("subdomain")
 	recordType, _ := request.RequireString("type")
@@ -62,7 +62,7 @@ func handleUpdateDNSRecord(ctx context.Context, deployer Deployer, request mcp.C
 	if domain == "" || subdomain == "" || recordType == "" || newValue == "" {
 		return mcp.NewToolResultError("domain, subdomain, type, and new_value are required"), nil
 	}
-	res, err := deployer.UpdateDNSRecord(ctx, domain, subdomain, recordType, newValue)
+	res, err := d.UpdateDNSRecord(ctx, domain, subdomain, recordType, newValue)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("update DNS failed: %v", err)), nil
 	}
@@ -70,7 +70,7 @@ func handleUpdateDNSRecord(ctx context.Context, deployer Deployer, request mcp.C
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleBatchDNS(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleBatchDNS(ctx context.Context, d DNSManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	recordsStr, err := request.RequireString("records")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -79,7 +79,7 @@ func handleBatchDNS(ctx context.Context, deployer Deployer, request mcp.CallTool
 	if err := json.Unmarshal([]byte(recordsStr), &records); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid records JSON: %v", err)), nil
 	}
-	res, err := deployer.BatchDNS(ctx, records)
+	res, err := d.BatchDNS(ctx, records)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("batch DNS failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_k8s.go
+++ b/internal/mcp/handler_k8s.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleListClusters(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListClusters(ctx context.Context, d K8sService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tenantID := request.GetString("tenant_id", "tenant-default")
 
-	clusters, err := deployer.ListClusters(ctx, tenantID)
+	clusters, err := d.ListClusters(ctx, tenantID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list clusters: %v", err)), nil
 	}
@@ -24,7 +24,7 @@ func handleListClusters(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleK8sDeploy(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleK8sDeploy(ctx context.Context, d K8sService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	clusterID, err := request.RequireString("cluster_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -81,7 +81,7 @@ func handleK8sDeploy(ctx context.Context, deployer Deployer, request mcp.CallToo
 
 	cfg.Namespace = request.GetString("namespace", "")
 
-	if err := deployer.K8sDeploy(ctx, clusterID, cfg); err != nil {
+	if err := d.K8sDeploy(ctx, clusterID, cfg); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("k8s deploy failed: %v", err)), nil
 	}
 
@@ -98,13 +98,13 @@ func handleK8sDeploy(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleK8sListDeployments(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleK8sListDeployments(ctx context.Context, d K8sService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	clusterID, err := request.RequireString("cluster_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.K8sListDeployments(ctx, clusterID)
+	result, err := d.K8sListDeployments(ctx, clusterID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list k8s deployments: %v", err)), nil
 	}
@@ -112,7 +112,7 @@ func handleK8sListDeployments(ctx context.Context, deployer Deployer, request mc
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleK8sGetPods(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleK8sGetPods(ctx context.Context, d K8sService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	clusterID, err := request.RequireString("cluster_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -120,7 +120,7 @@ func handleK8sGetPods(ctx context.Context, deployer Deployer, request mcp.CallTo
 
 	labelSelector := request.GetString("label_selector", "")
 
-	result, err := deployer.K8sGetPods(ctx, clusterID, labelSelector)
+	result, err := d.K8sGetPods(ctx, clusterID, labelSelector)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get k8s pods: %v", err)), nil
 	}

--- a/internal/mcp/handler_log.go
+++ b/internal/mcp/handler_log.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleGetAppLogs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetAppLogs(ctx context.Context, d LogService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	containerName, err := request.RequireString("container_name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -17,7 +17,7 @@ func handleGetAppLogs(ctx context.Context, deployer Deployer, request mcp.CallTo
 		_, _ = fmt.Sscanf(t, "%d", &tail)
 	}
 
-	logs, err := deployer.GetContainerLogs(ctx, containerName, tail)
+	logs, err := d.GetContainerLogs(ctx, containerName, tail)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get logs: %v", err)), nil
 	}
@@ -32,7 +32,7 @@ func handleGetAppLogs(ctx context.Context, deployer Deployer, request mcp.CallTo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleSearchAppLogs(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleSearchAppLogs(ctx context.Context, d LogService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	appID, err := request.RequireString("app_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -45,7 +45,7 @@ func handleSearchAppLogs(ctx context.Context, deployer Deployer, request mcp.Cal
 	if l := request.GetString("limit", "50"); l != "" {
 		fmt.Sscanf(l, "%d", &limit)
 	}
-	res, err := deployer.SearchAppLogs(ctx, appID, keyword, limit)
+	res, err := d.SearchAppLogs(ctx, appID, keyword, limit)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("search logs failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_monitor.go
+++ b/internal/mcp/handler_monitor.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleDetectEnv(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDetectEnv(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	level := 2
 	if l := request.GetString("level", "2"); l != "" {
 		_, _ = fmt.Sscanf(l, "%d", &level)
@@ -32,7 +32,7 @@ func handleDetectEnv(ctx context.Context, deployer Deployer, request mcp.CallToo
 		}
 	}
 
-	env, err := deployer.DetectEnv(ctx, level, ports, services)
+	env, err := d.DetectEnv(ctx, level, ports, services)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("environment detection failed: %v", err)), nil
 	}
@@ -45,7 +45,7 @@ func handleDetectEnv(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleHealthCheck(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleHealthCheck(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	target, err := request.RequireString("target")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -53,7 +53,7 @@ func handleHealthCheck(ctx context.Context, deployer Deployer, request mcp.CallT
 
 	healthType := request.GetString("type", "http")
 
-	health, err := deployer.HealthCheck(ctx, target, healthType)
+	health, err := d.HealthCheck(ctx, target, healthType)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("health check failed: %v", err)), nil
 	}
@@ -66,13 +66,13 @@ func handleHealthCheck(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleHealContainer(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleHealContainer(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	containerName, err := request.RequireString("container_name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.HealContainer(ctx, containerName)
+	result, err := d.HealContainer(ctx, containerName)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("heal failed: %v", err)), nil
 	}
@@ -80,13 +80,13 @@ func handleHealContainer(ctx context.Context, deployer Deployer, request mcp.Cal
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetContainerMetrics(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetContainerMetrics(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	containerName, err := request.RequireString("container_name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.GetContainerMetrics(ctx, containerName)
+	result, err := d.GetContainerMetrics(ctx, containerName)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get container metrics: %v", err)), nil
 	}
@@ -94,16 +94,16 @@ func handleGetContainerMetrics(ctx context.Context, deployer Deployer, request m
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetSystemMetrics(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetSystemMetrics(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID := request.GetString("server_id", "")
 
 	var result interface{}
 	var err error
 
 	if serverID != "" {
-		result, err = deployer.GetRemoteSystemMetrics(ctx, serverID)
+		result, err = d.GetRemoteSystemMetrics(ctx, serverID)
 	} else {
-		result, err = deployer.GetSystemMetrics(ctx)
+		result, err = d.GetSystemMetrics(ctx)
 	}
 
 	if err != nil {
@@ -113,8 +113,8 @@ func handleGetSystemMetrics(ctx context.Context, deployer Deployer, request mcp.
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListAlerts(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	result, err := deployer.ListAlerts(ctx)
+func handleListAlerts(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := d.ListAlerts(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list alerts: %v", err)), nil
 	}
@@ -122,8 +122,8 @@ func handleListAlerts(ctx context.Context, deployer Deployer, request mcp.CallTo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListAlertRules(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	result, err := deployer.ListAlertRules(ctx)
+func handleListAlertRules(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := d.ListAlertRules(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list alert rules: %v", err)), nil
 	}
@@ -131,11 +131,11 @@ func handleListAlertRules(ctx context.Context, deployer Deployer, request mcp.Ca
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleQueryMetricHistory(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleQueryMetricHistory(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	metricType := request.GetString("metric_type", "")
 	duration := request.GetString("duration", "1h")
 
-	result, err := deployer.QueryMetricHistory(ctx, metricType, duration)
+	result, err := d.QueryMetricHistory(ctx, metricType, duration)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to query metric history: %v", err)), nil
 	}
@@ -143,14 +143,14 @@ func handleQueryMetricHistory(ctx context.Context, deployer Deployer, request mc
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleQueryAlertHistory(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleQueryAlertHistory(ctx context.Context, d MonitorService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	status := request.GetString("status", "")
 	limit := 50
 	if l := request.GetString("limit", ""); l != "" {
 		_, _ = fmt.Sscanf(l, "%d", &limit)
 	}
 
-	result, err := deployer.QueryAlertHistory(ctx, status, limit)
+	result, err := d.QueryAlertHistory(ctx, status, limit)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to query alert history: %v", err)), nil
 	}

--- a/internal/mcp/handler_notification.go
+++ b/internal/mcp/handler_notification.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleSendNotification(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleSendNotification(ctx context.Context, d NotificationService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	nType, err := request.RequireString("type")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -16,7 +16,7 @@ func handleSendNotification(ctx context.Context, deployer Deployer, request mcp.
 	status, _ := request.RequireString("status")
 	message := request.GetString("message", "")
 
-	result, err := deployer.SendNotification(ctx, nType, appName, server, status, message)
+	result, err := d.SendNotification(ctx, nType, appName, server, status, message)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("notification failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_plugin.go
+++ b/internal/mcp/handler_plugin.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleListPlugins(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListPlugins(ctx context.Context, d PluginService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	provider := request.GetString("provider", "")
 
-	result, err := deployer.ListPlugins(provider)
+	result, err := d.ListPlugins(provider)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list plugins: %v", err)), nil
 	}
@@ -17,7 +17,7 @@ func handleListPlugins(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleManagePlugin(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleManagePlugin(ctx context.Context, d PluginService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	pluginID, err := request.RequireString("plugin_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -27,7 +27,7 @@ func handleManagePlugin(ctx context.Context, deployer Deployer, request mcp.Call
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.PluginOps(pluginID, action)
+	result, err := d.PluginOps(pluginID, action)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("plugin %s failed: %v", action, err)), nil
 	}
@@ -35,13 +35,13 @@ func handleManagePlugin(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetPluginInfo(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetPluginInfo(ctx context.Context, d PluginService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	pluginID, err := request.RequireString("plugin_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.GetPluginInfo(pluginID)
+	result, err := d.GetPluginInfo(pluginID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get plugin info: %v", err)), nil
 	}

--- a/internal/mcp/handler_portforward.go
+++ b/internal/mcp/handler_portforward.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-func handlePortForward(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handlePortForward(ctx context.Context, d PortForwardService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	action, err := request.RequireString("action")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -35,7 +35,7 @@ func handlePortForward(ctx context.Context, deployer Deployer, request mcp.CallT
 	}
 	remoteHost := request.GetString("remote_host", "127.0.0.1")
 
-	output, err := deployer.PortForward(ctx, action, serverID, localPort, remotePort, remoteHost)
+	output, err := d.PortForward(ctx, action, serverID, localPort, remotePort, remoteHost)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("port forward operation failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_registry.go
+++ b/internal/mcp/handler_registry.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleRegistryLogin(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRegistryLogin(ctx context.Context, d RegistryService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	registryID, err := request.RequireString("registry_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -18,7 +18,7 @@ func handleRegistryLogin(ctx context.Context, deployer Deployer, request mcp.Cal
 		"password":     request.GetString("password", ""),
 	}
 
-	result, err := deployer.RegistryOps(registryID, "login", args)
+	result, err := d.RegistryOps(registryID, "login", args)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("registry login failed: %v", err)), nil
 	}
@@ -26,7 +26,7 @@ func handleRegistryLogin(ctx context.Context, deployer Deployer, request mcp.Cal
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handlePushImage(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handlePushImage(ctx context.Context, d RegistryService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	registryID, err := request.RequireString("registry_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -41,7 +41,7 @@ func handlePushImage(ctx context.Context, deployer Deployer, request mcp.CallToo
 		"remote_tag":  request.GetString("remote_tag", ""),
 	}
 
-	result, err := deployer.RegistryOps(registryID, "push", args)
+	result, err := d.RegistryOps(registryID, "push", args)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("push image failed: %v", err)), nil
 	}
@@ -49,7 +49,7 @@ func handlePushImage(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListRegistryTags(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListRegistryTags(ctx context.Context, d RegistryService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	registryID, err := request.RequireString("registry_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -63,7 +63,7 @@ func handleListRegistryTags(ctx context.Context, deployer Deployer, request mcp.
 		"repository": repository,
 	}
 
-	result, err := deployer.RegistryOps(registryID, "list_tags", args)
+	result, err := d.RegistryOps(registryID, "list_tags", args)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("list registry tags failed: %v", err)), nil
 	}
@@ -71,13 +71,13 @@ func handleListRegistryTags(ctx context.Context, deployer Deployer, request mcp.
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handlePingRegistry(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handlePingRegistry(ctx context.Context, d RegistryService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	registryID, err := request.RequireString("registry_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.RegistryOps(registryID, "ping", nil)
+	result, err := d.RegistryOps(registryID, "ping", nil)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("ping registry failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_scheduler.go
+++ b/internal/mcp/handler_scheduler.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-func handleCreateScheduledTask(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleCreateScheduledTask(ctx context.Context, d SchedulerService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -29,7 +29,7 @@ func handleCreateScheduledTask(ctx context.Context, deployer Deployer, request m
 	}
 	serverID := request.GetString("server_id", "")
 
-	result, err := deployer.CreateScheduledTask(ctx, name, cronExpr, taskType, command, serverID)
+	result, err := d.CreateScheduledTask(ctx, name, cronExpr, taskType, command, serverID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to create scheduled task: %v", err)), nil
 	}
@@ -38,8 +38,8 @@ func handleCreateScheduledTask(ctx context.Context, deployer Deployer, request m
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleListScheduledTasks(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	result, err := deployer.ListScheduledTasks(ctx)
+func handleListScheduledTasks(ctx context.Context, d SchedulerService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := d.ListScheduledTasks(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list scheduled tasks: %v", err)), nil
 	}
@@ -48,7 +48,7 @@ func handleListScheduledTasks(ctx context.Context, deployer Deployer, request mc
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleGetTaskExecutions(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetTaskExecutions(ctx context.Context, d SchedulerService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	taskID, err := request.RequireString("task_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -60,7 +60,7 @@ func handleGetTaskExecutions(ctx context.Context, deployer Deployer, request mcp
 		}
 	}
 
-	result, err := deployer.GetTaskExecutions(ctx, taskID, limit)
+	result, err := d.GetTaskExecutions(ctx, taskID, limit)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get task executions: %v", err)), nil
 	}
@@ -69,7 +69,7 @@ func handleGetTaskExecutions(ctx context.Context, deployer Deployer, request mcp
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleToggleScheduledTask(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleToggleScheduledTask(ctx context.Context, d SchedulerService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	taskID, err := request.RequireString("task_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -80,7 +80,7 @@ func handleToggleScheduledTask(ctx context.Context, deployer Deployer, request m
 	}
 	enabled := strings.EqualFold(strings.TrimSpace(enabledStr), "true")
 
-	result, err := deployer.ToggleScheduledTask(ctx, taskID, enabled)
+	result, err := d.ToggleScheduledTask(ctx, taskID, enabled)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to toggle scheduled task: %v", err)), nil
 	}
@@ -89,13 +89,13 @@ func handleToggleScheduledTask(ctx context.Context, deployer Deployer, request m
 	return mcp.NewToolResultText(string(data)), nil
 }
 
-func handleDeleteScheduledTask(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeleteScheduledTask(ctx context.Context, d SchedulerService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	taskID, err := request.RequireString("task_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.DeleteScheduledTask(ctx, taskID)
+	result, err := d.DeleteScheduledTask(ctx, taskID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to delete scheduled task: %v", err)), nil
 	}

--- a/internal/mcp/handler_server.go
+++ b/internal/mcp/handler_server.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleListServers(ctx context.Context, deployer Deployer, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	servers, err := deployer.ListServers(ctx)
+func handleListServers(ctx context.Context, d ServerManager, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	servers, err := d.ListServers(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list servers: %v", err)), nil
 	}
@@ -23,7 +23,7 @@ func handleListServers(ctx context.Context, deployer Deployer, _ mcp.CallToolReq
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleAddServer(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleAddServer(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, err := request.RequireString("name")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -39,7 +39,7 @@ func handleAddServer(ctx context.Context, deployer Deployer, request mcp.CallToo
 	}
 	user := request.GetString("user", "root")
 
-	srv, err := deployer.AddServer(ctx, name, host, port, user)
+	srv, err := d.AddServer(ctx, name, host, port, user)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to add server: %v", err)), nil
 	}
@@ -58,13 +58,13 @@ func handleAddServer(ctx context.Context, deployer Deployer, request mcp.CallToo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleRemoveServer(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRemoveServer(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID, err := request.RequireString("server_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	if err := deployer.RemoveServer(ctx, serverID); err != nil {
+	if err := d.RemoveServer(ctx, serverID); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to remove server: %v", err)), nil
 	}
 
@@ -75,13 +75,13 @@ func handleRemoveServer(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleTestServer(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleTestServer(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID, err := request.RequireString("server_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	testResult, err := deployer.TestServer(ctx, serverID)
+	testResult, err := d.TestServer(ctx, serverID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("server test failed: %v", err)), nil
 	}
@@ -93,13 +93,11 @@ func handleTestServer(ctx context.Context, deployer Deployer, request mcp.CallTo
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDoctor(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDoctor(ctx context.Context, cd ContainerDeployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	checks := []map[string]interface{}{}
 
 	// Check 1: Docker
-	_, dockerErr := deployer.(interface {
-		GetContainerStatus(ctx context.Context, name string) (*ContainerStatus, error)
-	}).GetContainerStatus(ctx, "__doctor_probe__")
+	_, dockerErr := cd.GetContainerStatus(ctx, "__doctor_probe__")
 
 	dockerCheck := map[string]interface{}{"name": "Docker"}
 	if dockerErr != nil {
@@ -134,7 +132,7 @@ func handleDoctor(ctx context.Context, deployer Deployer, request mcp.CallToolRe
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleUpdateServer(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleUpdateServer(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID, err := request.RequireString("server_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -147,7 +145,7 @@ func handleUpdateServer(ctx context.Context, deployer Deployer, request mcp.Call
 	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("invalid config JSON: %v", err)), nil
 	}
-	res, err := deployer.UpdateServer(ctx, serverID, config)
+	res, err := d.UpdateServer(ctx, serverID, config)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("update server failed: %v", err)), nil
 	}
@@ -155,14 +153,14 @@ func handleUpdateServer(ctx context.Context, deployer Deployer, request mcp.Call
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDetectPanel(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDetectPanel(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serverID, err := request.RequireString("server_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	// Use TestServer to verify server connectivity and detect panel
-	_, err = deployer.TestServer(ctx, serverID)
+	_, err = d.TestServer(ctx, serverID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to connect to server %s: %v", serverID, err)), nil
 	}
@@ -176,7 +174,7 @@ func handleDetectPanel(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleExecCommand(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleExecCommand(ctx context.Context, d ServerManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	command, err := request.RequireString("command")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -190,7 +188,7 @@ func handleExecCommand(ctx context.Context, deployer Deployer, request mcp.CallT
 		}
 	}
 
-	output, err := deployer.ExecCommand(ctx, serverID, command, timeout)
+	output, err := d.ExecCommand(ctx, serverID, command, timeout)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("command execution failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_ssl.go
+++ b/internal/mcp/handler_ssl.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleListSSLCertificates(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	result, err := deployer.ListSSLCertificates(ctx)
+func handleListSSLCertificates(ctx context.Context, d SSLService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := d.ListSSLCertificates(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list SSL certificates: %v", err)), nil
 	}
@@ -15,7 +15,7 @@ func handleListSSLCertificates(ctx context.Context, deployer Deployer, request m
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleRequestSSLCertificate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRequestSSLCertificate(ctx context.Context, d SSLService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, err := request.RequireString("domain")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -25,7 +25,7 @@ func handleRequestSSLCertificate(ctx context.Context, deployer Deployer, request
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.RequestSSLCertificate(ctx, domain, email)
+	result, err := d.RequestSSLCertificate(ctx, domain, email)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to request SSL certificate: %v", err)), nil
 	}
@@ -33,13 +33,13 @@ func handleRequestSSLCertificate(ctx context.Context, deployer Deployer, request
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleRenewSSLCertificate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleRenewSSLCertificate(ctx context.Context, d SSLService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, err := request.RequireString("domain")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.RenewSSLCertificate(ctx, domain)
+	result, err := d.RenewSSLCertificate(ctx, domain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to renew SSL certificate: %v", err)), nil
 	}
@@ -47,13 +47,13 @@ func handleRenewSSLCertificate(ctx context.Context, deployer Deployer, request m
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleDeleteSSLCertificate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleDeleteSSLCertificate(ctx context.Context, d SSLService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	domain, err := request.RequireString("domain")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	result, err := deployer.DeleteSSLCertificate(ctx, domain)
+	result, err := d.DeleteSSLCertificate(ctx, domain)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to delete SSL certificate: %v", err)), nil
 	}

--- a/internal/mcp/handler_system.go
+++ b/internal/mcp/handler_system.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleCheckSystemUpdate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	update, err := deployer.CheckSystemUpdate(ctx)
+func handleCheckSystemUpdate(ctx context.Context, d SystemService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	update, err := d.CheckSystemUpdate(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("check update failed: %v", err)), nil
 	}

--- a/internal/mcp/handler_task.go
+++ b/internal/mcp/handler_task.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleGetTaskStatus(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetTaskStatus(ctx context.Context, d TaskManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	taskID, err := request.RequireString("task_id")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	task, err := deployer.GetTaskStatus(ctx, taskID)
+	task, err := d.GetTaskStatus(ctx, taskID)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to get task status: %v", err)), nil
 	}
@@ -21,14 +21,14 @@ func handleGetTaskStatus(ctx context.Context, deployer Deployer, request mcp.Cal
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListTasks(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleListTasks(ctx context.Context, d TaskManager, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	limit := 20
 	if l := request.GetString("limit", "20"); l != "" {
 		fmt.Sscanf(l, "%d", &limit)
 	}
 	statusFilter := request.GetString("status_filter", "")
 
-	tasks, err := deployer.ListTasks(ctx, limit, statusFilter)
+	tasks, err := d.ListTasks(ctx, limit, statusFilter)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("failed to list tasks: %v", err)), nil
 	}

--- a/internal/mcp/handler_template.go
+++ b/internal/mcp/handler_template.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"github.com/mark3labs/mcp-go/mcp"
 )
-func handleListTemplates(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	templates, err := deployer.ListTemplates(ctx)
+func handleListTemplates(ctx context.Context, d TemplateService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	templates, err := d.ListTemplates(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("list templates failed: %v", err)), nil
 	}
@@ -16,13 +16,13 @@ func handleListTemplates(ctx context.Context, deployer Deployer, request mcp.Cal
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetTemplate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetTemplate(ctx context.Context, d TemplateService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	tmplType, err := request.RequireString("type")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	tmpl, err := deployer.GetTemplate(ctx, tmplType)
+	tmpl, err := d.GetTemplate(ctx, tmplType)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("get template failed: %v", err)), nil
 	}
@@ -31,8 +31,8 @@ func handleGetTemplate(ctx context.Context, deployer Deployer, request mcp.CallT
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleListEnvTemplates(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	templates, err := deployer.ListEnvTemplates(ctx)
+func handleListEnvTemplates(ctx context.Context, d TemplateService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	templates, err := d.ListEnvTemplates(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("list env templates failed: %v", err)), nil
 	}
@@ -41,13 +41,13 @@ func handleListEnvTemplates(ctx context.Context, deployer Deployer, request mcp.
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
-func handleGetEnvTemplate(ctx context.Context, deployer Deployer, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func handleGetEnvTemplate(ctx context.Context, d TemplateService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	serviceType, err := request.RequireString("service_type")
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	tmpl, err := deployer.GetEnvTemplate(ctx, serviceType)
+	tmpl, err := d.GetEnvTemplate(ctx, serviceType)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("get env template failed: %v", err)), nil
 	}

--- a/internal/mcp/register_backup.go
+++ b/internal/mcp/register_backup.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerBackupTools registers backup tools.
-func registerBackupTools(s *server.MCPServer, d Deployer) {
+func registerBackupTools(s *server.MCPServer, d BackupManager) {
 	backupTool := mcp.NewTool("backup_database",
 		mcp.WithDescription("Create a backup of an application"),
 		mcp.WithString("app_id",

--- a/internal/mcp/register_cicd.go
+++ b/internal/mcp/register_cicd.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerCICDTools registers cicd tools.
-func registerCICDTools(s *server.MCPServer, d Deployer) {
+func registerCICDTools(s *server.MCPServer, d CICDService) {
 	triggerCITool := mcp.NewTool("trigger_ci_build",
 		mcp.WithDescription("Trigger a CI/CD build for a repository"),
 		mcp.WithString("provider", mcp.Required(), mcp.Description("CI/CD provider type: github-actions")),

--- a/internal/mcp/register_credential.go
+++ b/internal/mcp/register_credential.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerCredentialTools registers credential tools.
-func registerCredentialTools(s *server.MCPServer, d Deployer) {
+func registerCredentialTools(s *server.MCPServer, d CredentialManager) {
 	createCredTool := mcp.NewTool("add_credential",
 		mcp.WithDescription("Create an encrypted credential. The value is encrypted with AES-256-GCM before storage — plaintext never touches the database."),
 		mcp.WithString("tenant_id", mcp.Required(), mcp.Description("Tenant ID")),

--- a/internal/mcp/register_deploy.go
+++ b/internal/mcp/register_deploy.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerDeployTools registers deploy tools.
-func registerDeployTools(s *server.MCPServer, d Deployer) {
+func registerDeployTools(s *server.MCPServer, d ContainerDeployer) {
 	deployTool := mcp.NewTool("deploy_app",
 		mcp.WithDescription("Deploy a Docker container. Use server_id to deploy to a remote server via SSH; omit for local Docker deployment."),
 		mcp.WithString("image",

--- a/internal/mcp/register_dns.go
+++ b/internal/mcp/register_dns.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerDNSTools registers dns tools.
-func registerDNSTools(s *server.MCPServer, d Deployer) {
+func registerDNSTools(s *server.MCPServer, d DNSManager) {
 	dnsCreateTool := mcp.NewTool("add_dns_record",
 		mcp.WithDescription("Create a DNS record"),
 		mcp.WithString("domain", mcp.Required(), mcp.Description("Domain name (e.g. example.com)")),

--- a/internal/mcp/register_k8s.go
+++ b/internal/mcp/register_k8s.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerK8sTools registers k8s tools.
-func registerK8sTools(s *server.MCPServer, d Deployer) {
+func registerK8sTools(s *server.MCPServer, d K8sService) {
 	listClustersTool := mcp.NewTool("list_clusters",
 		mcp.WithDescription("List all Kubernetes clusters"),
 		mcp.WithString("tenant_id", mcp.Description("Tenant ID (default: tenant-default)")),

--- a/internal/mcp/register_log.go
+++ b/internal/mcp/register_log.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerLogTools registers log tools.
-func registerLogTools(s *server.MCPServer, d Deployer) {
+func registerLogTools(s *server.MCPServer, d LogService) {
 	getLogsTool := mcp.NewTool("get_app_logs",
 		mcp.WithDescription("Get logs from a deployed container"),
 		mcp.WithString("container_name",

--- a/internal/mcp/register_monitor.go
+++ b/internal/mcp/register_monitor.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerMonitorTools registers monitor tools.
-func registerMonitorTools(s *server.MCPServer, d Deployer) {
+func registerMonitorTools(s *server.MCPServer, d MonitorService) {
 	detectEnvTool := mcp.NewTool("detect_environment",
 		mcp.WithDescription("Detect server environment (OS, Docker, ports, services)"),
 		mcp.WithString("level",

--- a/internal/mcp/register_notification.go
+++ b/internal/mcp/register_notification.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerNotificationTools registers notification tools.
-func registerNotificationTools(s *server.MCPServer, d Deployer) {
+func registerNotificationTools(s *server.MCPServer, d NotificationService) {
 	sendNotifyTool := mcp.NewTool("send_notification",
 		mcp.WithDescription("Send a deployment notification"),
 		mcp.WithString("type", mcp.Required(), mcp.Description("Notification type: deploy_success, deploy_failed, health_check, rollback")),

--- a/internal/mcp/register_plugin.go
+++ b/internal/mcp/register_plugin.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerPluginTools registers plugin tools.
-func registerPluginTools(s *server.MCPServer, d Deployer) {
+func registerPluginTools(s *server.MCPServer, d PluginService) {
 	listPluginsTool := mcp.NewTool("list_plugins",
 		mcp.WithDescription("List all registered plugins"),
 		mcp.WithString("provider", mcp.Description("Filter by provider type (dns, notify, registry, cicd, server, ssl)")),

--- a/internal/mcp/register_portforward.go
+++ b/internal/mcp/register_portforward.go
@@ -8,7 +8,7 @@ import (
 )
 
 // registerPortForwardTools registers port forwarding tools.
-func registerPortForwardTools(s *server.MCPServer, d Deployer) {
+func registerPortForwardTools(s *server.MCPServer, d PortForwardService) {
 	portForwardTool := mcp.NewTool("port_forward",
 		mcp.WithDescription("Manage SSH port forwards to servers. Actions: create, delete, list."),
 		mcp.WithString("action", mcp.Required(), mcp.Description("Action to perform: 'create', 'delete', or 'list'")),

--- a/internal/mcp/register_registry.go
+++ b/internal/mcp/register_registry.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerRegistryTools registers registry tools.
-func registerRegistryTools(s *server.MCPServer, d Deployer) {
+func registerRegistryTools(s *server.MCPServer, d RegistryService) {
 	registryLoginTool := mcp.NewTool("registry_login",
 		mcp.WithDescription("Authenticate with a container registry"),
 		mcp.WithString("registry_id", mcp.Required(), mcp.Description("Registry ID to authenticate with")),

--- a/internal/mcp/register_scheduler.go
+++ b/internal/mcp/register_scheduler.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerSchedulerTools registers scheduled task tools.
-func registerSchedulerTools(s *server.MCPServer, d Deployer) {
+func registerSchedulerTools(s *server.MCPServer, d SchedulerService) {
 	createScheduledTaskTool := mcp.NewTool("create_scheduled_task",
 		mcp.WithDescription("Create a new cron-based scheduled task. Supports shell commands, health checks, and log cleanup."),
 		mcp.WithString("name",

--- a/internal/mcp/register_server.go
+++ b/internal/mcp/register_server.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerServerTools registers server tools.
-func registerServerTools(s *server.MCPServer, d Deployer) {
+func registerServerTools(s *server.MCPServer, d ServerManager, cd ContainerDeployer) {
 	listServersTool := mcp.NewTool("list_servers",
 		mcp.WithDescription("List all registered servers"),
 	)
@@ -58,7 +58,7 @@ func registerServerTools(s *server.MCPServer, d Deployer) {
 		mcp.WithDescription("Check DeployPilot prerequisites: Docker availability, database connectivity, and SSH configuration."),
 	)
 	s.AddTool(doctorTool, withPermissionCheck("doctor", withValidation("doctor", doctorTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return handleDoctor(ctx, d, request)
+		return handleDoctor(ctx, cd, request)
 	})))
 	execCommandTool := mcp.NewTool("exec_command",
 		mcp.WithDescription("Execute a command on a server. Runs locally if server_id is omitted, or remotely via SSH if server_id is provided."),

--- a/internal/mcp/register_ssl.go
+++ b/internal/mcp/register_ssl.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerSSLTools registers ssl tools.
-func registerSSLTools(s *server.MCPServer, d Deployer) {
+func registerSSLTools(s *server.MCPServer, d SSLService) {
 	listSSLCertsTool := mcp.NewTool("list_ssl_certificates",
 		mcp.WithDescription("List all SSL certificates"),
 	)

--- a/internal/mcp/register_system.go
+++ b/internal/mcp/register_system.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerSystemTools registers system tools.
-func registerSystemTools(s *server.MCPServer, d Deployer) {
+func registerSystemTools(s *server.MCPServer, d SystemService) {
 	checkSysUpdateTool := mcp.NewTool("check_system_update",
 		mcp.WithDescription("Check if a newer version of DeployPilot is available"),
 	)

--- a/internal/mcp/register_task.go
+++ b/internal/mcp/register_task.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerTaskTools registers task tools.
-func registerTaskTools(s *server.MCPServer, d Deployer) {
+func registerTaskTools(s *server.MCPServer, d TaskManager) {
 	getTaskStatusTool := mcp.NewTool("get_task_status",
 		mcp.WithDescription("Get status of an async task"),
 		mcp.WithString("task_id", mcp.Required(), mcp.Description("Task ID")),

--- a/internal/mcp/register_template.go
+++ b/internal/mcp/register_template.go
@@ -7,7 +7,7 @@ import (
 )
 
 // registerTemplateTools registers template tools.
-func registerTemplateTools(s *server.MCPServer, d Deployer) {
+func registerTemplateTools(s *server.MCPServer, d TemplateService) {
 	listTmplTool := mcp.NewTool("list_templates",
 		mcp.WithDescription("List all available application templates"),
 	)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -49,9 +49,9 @@ func NewServer(deployer Deployer) *server.MCPServer {
 		server.WithToolCapabilities(false),
 	)
 
-	// Register tools by domain
+	// Register tools by domain (each receives only its sub-interface, fixes #116)
 	registerDeployTools(s, deployer)
-	registerServerTools(s, deployer)
+	registerServerTools(s, deployer, deployer)
 	registerCredentialTools(s, deployer)
 	registerDNSTools(s, deployer)
 	registerBackupTools(s, deployer)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -84,10 +84,11 @@ type BackupManager interface {
 	BatchBackup(ctx context.Context, appIDs []string) (interface{}, error)
 }
 
-// MonitorService handles metrics, alerts, and health checks.
+// MonitorService handles metrics, alerts, health checks, and container healing.
 type MonitorService interface {
 	DetectEnv(ctx context.Context, level int, ports []int, services []string) (interface{}, error)
 	HealthCheck(ctx context.Context, target, healthType string) (interface{}, error)
+	HealContainer(ctx context.Context, containerName string) (interface{}, error)
 	GetContainerMetrics(ctx context.Context, containerName string) (interface{}, error)
 	GetSystemMetrics(ctx context.Context) (interface{}, error)
 	GetRemoteSystemMetrics(ctx context.Context, serverID string) (interface{}, error)

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -15,101 +15,203 @@ type PreflightErrorInfo interface {
 	PreflightChecks() interface{}
 }
 
-// Deployer abstracts deployment operations for the MCP server.
-type Deployer interface {
+// ============================================================================
+// Sub-interfaces (Interface Segregation, fixes #116)
+// Each sub-interface corresponds to a register_*.go / handler_*.go file pair.
+// ============================================================================
+
+// ContainerDeployer handles container lifecycle, compose, and preflight operations.
+type ContainerDeployer interface {
 	Deploy(ctx context.Context, cfg DeployConfig) (*ContainerStatus, error)
 	GetContainerStatus(ctx context.Context, name string) (*ContainerStatus, error)
 	ListApps(ctx context.Context) ([]ContainerStatus, error)
-	ListServers(ctx context.Context) ([]ServerInfo, error)
 	CreateApp(ctx context.Context, cfg CreateAppConfig) (string, error)
 	DeleteApp(ctx context.Context, appID string) error
 	Stop(ctx context.Context, name string) error
 	Remove(ctx context.Context, name string) error
-	GetContainerLogs(ctx context.Context, name string, tail int) (string, error)
 	Rollback(ctx context.Context, containerName, previousImage string) (*ContainerStatus, error)
-	Backup(ctx context.Context, appID string) (string, error)
-	Restore(ctx context.Context, backupID string) (*ContainerStatus, error)
-	DetectEnv(ctx context.Context, level int, ports []int, services []string) (interface{}, error)
-	HealthCheck(ctx context.Context, target, healthType string) (interface{}, error)
-	AddServer(ctx context.Context, name, host string, port int, user string) (*ServerInfo, error)
-	RemoveServer(ctx context.Context, serverID string) error
-	TestServer(ctx context.Context, serverID string) (interface{}, error)
-	CreateCredential(ctx context.Context, tenantID, name, credType, plainValue string) (interface{}, error)
-	ListCredentials(ctx context.Context, tenantID string) (interface{}, error)
-	DeleteCredential(ctx context.Context, credID string) error
-	DNSCreateRecord(ctx context.Context, domain, recordType, name, value string) (interface{}, error)
-	DNSDeleteRecord(ctx context.Context, recordID string) error
-	DNSListRecords(ctx context.Context, domain string) (interface{}, error)
-	SendNotification(ctx context.Context, nType, appName, server, status, message string) (interface{}, error)
-	ListTemplates(ctx context.Context) (interface{}, error)
-	GetTemplate(ctx context.Context, tmplType string) (interface{}, error)
-	ListEnvTemplates(ctx context.Context) (interface{}, error)
-	GetEnvTemplate(ctx context.Context, serviceType string) (interface{}, error)
-	GetAppDetail(ctx context.Context, appID string) (interface{}, error)
-	UpdateApp(ctx context.Context, appID string, config map[string]interface{}) (interface{}, error)
-	GetTaskStatus(ctx context.Context, taskID string) (interface{}, error)
-	ListTasks(ctx context.Context, limit int, statusFilter string) (interface{}, error)
-	SearchAppLogs(ctx context.Context, appID, keyword string, limit int) (interface{}, error)
-	UpdateDNSRecord(ctx context.Context, domain, subdomain, recordType, newValue string) (interface{}, error)
-	UpdateCredential(ctx context.Context, credID string, value string) (interface{}, error)
-	UpdateServer(ctx context.Context, serverID string, config map[string]interface{}) (interface{}, error)
+	BuildAndDeploy(ctx context.Context, cfg BuildAndDeployConfig) (*BuildAndDeployResult, error)
 	CheckDeployReadiness(ctx context.Context, appConfig map[string]interface{}) (interface{}, error)
 	BatchDeploy(ctx context.Context, apps []map[string]interface{}) (interface{}, error)
 	BatchDeployWithConfig(ctx context.Context, config BatchDeployConfig) (*BatchDeployResult, error)
-	BatchBackup(ctx context.Context, appIDs []string) (interface{}, error)
-	BatchDNS(ctx context.Context, records []map[string]interface{}) (interface{}, error)
-	CheckSystemUpdate(ctx context.Context) (interface{}, error)
-	GetLatestDeploymentRecord(ctx context.Context, containerName string) (*model.DeploymentRecord, error)
-	BuildAndDeploy(ctx context.Context, cfg BuildAndDeployConfig) (*BuildAndDeployResult, error)
+	GetAppDetail(ctx context.Context, appID string) (interface{}, error)
+	UpdateApp(ctx context.Context, appID string, config map[string]interface{}) (interface{}, error)
 	HealContainer(ctx context.Context, containerName string) (interface{}, error)
+	GetLatestDeploymentRecord(ctx context.Context, containerName string) (*model.DeploymentRecord, error)
+	// Compose operations
+	ComposeDeploy(ctx context.Context, appID string) (string, error)
+	ComposeStop(ctx context.Context, appID string) (string, error)
+	ComposePs(ctx context.Context, appID string) (string, error)
+	ComposeLogs(ctx context.Context, appID, service, tail string) (string, error)
+	ComposeRestart(ctx context.Context, appID, service string) (string, error)
+	// Preflight
+	RunPreflightFull(ctx context.Context, serverID string, portMappings string) (interface{}, error)
+	// Server-side operations used by deploy handlers
+	ListImages(ctx context.Context, serverID, filter string) (string, error)
+}
+
+// ServerManager handles server registration and remote execution.
+type ServerManager interface {
+	ListServers(ctx context.Context) ([]ServerInfo, error)
+	AddServer(ctx context.Context, name, host string, port int, user string) (*ServerInfo, error)
+	RemoveServer(ctx context.Context, serverID string) error
+	TestServer(ctx context.Context, serverID string) (interface{}, error)
+	UpdateServer(ctx context.Context, serverID string, config map[string]interface{}) (interface{}, error)
+	ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error)
+}
+
+// CredentialManager handles credential CRUD and rotation.
+type CredentialManager interface {
+	CreateCredential(ctx context.Context, tenantID, name, credType, plainValue string) (interface{}, error)
+	ListCredentials(ctx context.Context, tenantID string) (interface{}, error)
+	DeleteCredential(ctx context.Context, credID string) error
+	UpdateCredential(ctx context.Context, credID string, value string) (interface{}, error)
+}
+
+// DNSManager handles DNS record management.
+type DNSManager interface {
+	DNSCreateRecord(ctx context.Context, domain, recordType, name, value string) (interface{}, error)
+	DNSDeleteRecord(ctx context.Context, recordID string) error
+	DNSListRecords(ctx context.Context, domain string) (interface{}, error)
+	UpdateDNSRecord(ctx context.Context, domain, subdomain, recordType, newValue string) (interface{}, error)
+	BatchDNS(ctx context.Context, records []map[string]interface{}) (interface{}, error)
+}
+
+// BackupManager handles backup and restore operations.
+type BackupManager interface {
+	Backup(ctx context.Context, appID string) (string, error)
+	Restore(ctx context.Context, backupID string) (*ContainerStatus, error)
+	BatchBackup(ctx context.Context, appIDs []string) (interface{}, error)
+}
+
+// MonitorService handles metrics, alerts, and health checks.
+type MonitorService interface {
+	DetectEnv(ctx context.Context, level int, ports []int, services []string) (interface{}, error)
+	HealthCheck(ctx context.Context, target, healthType string) (interface{}, error)
 	GetContainerMetrics(ctx context.Context, containerName string) (interface{}, error)
 	GetSystemMetrics(ctx context.Context) (interface{}, error)
 	GetRemoteSystemMetrics(ctx context.Context, serverID string) (interface{}, error)
 	ListAlerts(ctx context.Context) (interface{}, error)
 	ListAlertRules(ctx context.Context) (interface{}, error)
-	TriggerCIBuild(ctx context.Context, provider, repo, branch string) (interface{}, error)
-	GetCIBuildStatus(ctx context.Context, provider, runID string) (interface{}, error)
+	QueryMetricHistory(ctx context.Context, metricType string, duration string) (interface{}, error)
+	QueryAlertHistory(ctx context.Context, status string, limit int) (interface{}, error)
+}
+
+// LogService handles container and application log retrieval.
+type LogService interface {
+	GetContainerLogs(ctx context.Context, name string, tail int) (string, error)
+	SearchAppLogs(ctx context.Context, appID, keyword string, limit int) (interface{}, error)
+}
+
+// NotificationService handles multi-channel notifications.
+type NotificationService interface {
+	SendNotification(ctx context.Context, nType, appName, server, status, message string) (interface{}, error)
+}
+
+// TemplateService handles deployment and environment templates.
+type TemplateService interface {
+	ListTemplates(ctx context.Context) (interface{}, error)
+	GetTemplate(ctx context.Context, tmplType string) (interface{}, error)
+	ListEnvTemplates(ctx context.Context) (interface{}, error)
+	GetEnvTemplate(ctx context.Context, serviceType string) (interface{}, error)
+}
+
+// TaskManager handles async task status queries.
+type TaskManager interface {
+	GetTaskStatus(ctx context.Context, taskID string) (interface{}, error)
+	ListTasks(ctx context.Context, limit int, statusFilter string) (interface{}, error)
+}
+
+// SSLService handles SSL certificate management.
+type SSLService interface {
 	ListSSLCertificates(ctx context.Context) (interface{}, error)
 	RequestSSLCertificate(ctx context.Context, domain, email string) (interface{}, error)
 	RenewSSLCertificate(ctx context.Context, domain string) (interface{}, error)
 	DeleteSSLCertificate(ctx context.Context, domain string) (interface{}, error)
+}
+
+// CICDService handles CI/CD build operations.
+type CICDService interface {
+	TriggerCIBuild(ctx context.Context, provider, repo, branch string) (interface{}, error)
+	GetCIBuildStatus(ctx context.Context, provider, runID string) (interface{}, error)
+}
+
+// RegistryService handles container registry operations.
+type RegistryService interface {
 	RegistryOps(registryID string, operation string, args map[string]interface{}) (interface{}, error)
-	// Kubernetes cluster management
+}
+
+// PluginService handles plugin lifecycle management.
+type PluginService interface {
+	PluginOps(pluginID string, action string) (interface{}, error)
+	ListPlugins(provider string) (interface{}, error)
+	GetPluginInfo(pluginID string) (interface{}, error)
+}
+
+// K8sService handles Kubernetes cluster and deployment operations.
+type K8sService interface {
 	CreateCluster(ctx context.Context, cluster *model.Cluster) (*model.Cluster, error)
 	GetCluster(ctx context.Context, id string) (*model.Cluster, error)
 	ListClusters(ctx context.Context, tenantID string) ([]model.Cluster, error)
 	UpdateCluster(ctx context.Context, id string, updates map[string]interface{}) (*model.Cluster, error)
 	DeleteCluster(ctx context.Context, id string) error
 	TestClusterConnection(ctx context.Context, id string) (interface{}, error)
-	// Kubernetes deployment operations
 	K8sDeploy(ctx context.Context, clusterID string, app *K8sDeployConfig) error
 	K8sListDeployments(ctx context.Context, clusterID string) (interface{}, error)
 	K8sGetPods(ctx context.Context, clusterID, labelSelector string) (interface{}, error)
-	PluginOps(pluginID string, action string) (interface{}, error)
-	ListPlugins(provider string) (interface{}, error)
-	GetPluginInfo(pluginID string) (interface{}, error)
-	// Phase 3.3: Server operations
-	ExecCommand(ctx context.Context, serverID, command string, timeout int) (string, error)
-	ListImages(ctx context.Context, serverID, filter string) (string, error)
+}
+
+// SystemService handles system-level operations.
+type SystemService interface {
+	CheckSystemUpdate(ctx context.Context) (interface{}, error)
+}
+
+// PortForwardService handles SSH port forwarding.
+type PortForwardService interface {
 	PortForward(ctx context.Context, action, serverID string, localPort, remotePort int, remoteHost string) (string, error)
-	// Phase 3.1: Compose operations
-	ComposeDeploy(ctx context.Context, appID string) (string, error)
-	ComposeStop(ctx context.Context, appID string) (string, error)
-	ComposePs(ctx context.Context, appID string) (string, error)
-	ComposeLogs(ctx context.Context, appID, service, tail string) (string, error)
-	ComposeRestart(ctx context.Context, appID, service string) (string, error)
-	// Phase 3.5: Preflight visualization
-	RunPreflightFull(ctx context.Context, serverID string, portMappings string) (interface{}, error)
-	// Phase 3.9: Monitoring data persistence
-	QueryMetricHistory(ctx context.Context, metricType string, duration string) (interface{}, error)
-	QueryAlertHistory(ctx context.Context, status string, limit int) (interface{}, error)
-	// Phase 3.10: Scheduled task system
+}
+
+// SchedulerService handles scheduled task management.
+type SchedulerService interface {
 	CreateScheduledTask(ctx context.Context, name, cronExpr, taskType, command string, serverID string) (interface{}, error)
 	ListScheduledTasks(ctx context.Context) (interface{}, error)
 	GetTaskExecutions(ctx context.Context, taskID string, limit int) (interface{}, error)
 	ToggleScheduledTask(ctx context.Context, taskID string, enabled bool) (interface{}, error)
 	DeleteScheduledTask(ctx context.Context, taskID string) (interface{}, error)
 }
+
+// ============================================================================
+// Deployer — composed interface for backward compatibility (fixes #116)
+// Embeds all sub-interfaces. Existing code using Deployer continues to work.
+// New code can depend on specific sub-interfaces for better testability.
+// ============================================================================
+
+// Deployer abstracts all deployment operations for the MCP server.
+// It composes all domain-specific sub-interfaces for backward compatibility.
+type Deployer interface {
+	ContainerDeployer
+	ServerManager
+	CredentialManager
+	DNSManager
+	BackupManager
+	MonitorService
+	LogService
+	NotificationService
+	TemplateService
+	TaskManager
+	SSLService
+	CICDService
+	RegistryService
+	PluginService
+	K8sService
+	SystemService
+	PortForwardService
+	SchedulerService
+}
+
+// ============================================================================
+// Value types (unchanged)
+// ============================================================================
 
 // DeployConfig mirrors deployer.DeployConfig to avoid circular imports.
 type DeployConfig struct {
@@ -158,11 +260,11 @@ type BatchDeployConfig struct {
 
 // BatchDeployResult holds the result of a batch deployment.
 type BatchDeployResult struct {
-	Total    int                        `json:"total"`
-	Success  int                        `json:"success"`
-	Failed   int                        `json:"failed"`
-	Results  []BatchDeployItemResult    `json:"results"`
-	Duration float64                    `json:"duration_seconds"`
+	Total    int                     `json:"total"`
+	Success  int                     `json:"success"`
+	Failed   int                     `json:"failed"`
+	Results  []BatchDeployItemResult `json:"results"`
+	Duration float64                 `json:"duration_seconds"`
 }
 
 // BatchDeployItemResult holds the result of a single app deployment within a batch.


### PR DESCRIPTION
## Summary

Split the monolithic `Deployer` interface (~71 methods) into 18 focused sub-interfaces following the Interface Segregation Principle.

### What changed

**18 sub-interfaces defined in `types.go`:**
- `ContainerDeployer` (22 methods) — deploy, compose, preflight
- `ServerManager` (6 methods) — server CRUD, exec
- `CredentialManager` (4 methods) — credential CRUD
- `DNSManager` (5 methods) — DNS record CRUD
- `BackupManager` (3 methods) — backup/restore
- `MonitorService` (9 methods) — metrics, alerts, health
- `LogService` (2 methods) — container/app logs
- `NotificationService` (1 method) — multi-channel notify
- `TemplateService` (4 methods) — deploy/env templates
- `TaskManager` (2 methods) — async task status
- `SSLService` (4 methods) — certificate management
- `CICDService` (2 methods) — CI/CD builds
- `RegistryService` (1 method) — container registry ops
- `PluginService` (3 methods) — plugin lifecycle
- `K8sService` (9 methods) — Kubernetes operations
- `SystemService` (1 method) — system update check
- `PortForwardService` (1 method) — SSH port forwarding
- `SchedulerService` (5 methods) — scheduled tasks

**Backward compatibility:**
- `Deployer` remains as a composed interface embedding all sub-interfaces
- Any code using `Deployer` continues to work unchanged
- `Bridge` struct still satisfies `Deployer` without modification

**Per-domain isolation:**
- Each `register_xxx()` function now receives only its relevant sub-interface
- Each `handle_xxx()` function now receives only its relevant sub-interface
- 72 handler functions updated

### Impact

- ✅ Testability: tests can mock individual sub-interfaces
- ✅ Maintainability: new features only need to implement relevant sub-interface
- ✅ Documentation: each sub-interface is self-documenting
- ⚠️ `mockDeployer` still implements full `Deployer` (split in future PR)

### Files modified: 38
- `types.go` — 18 sub-interfaces + composed Deployer
- `server.go` — updated registerServerTools call
- 18 `register_*.go` — parameter type changes
- 17 `handler_*.go` — 72 function parameter type changes

Fixes #116

Agent-Model: Claude
Agent-Task: Fix #116 God Interface