### PR TITLE
fix: DNS error swallowing and JWT secret validation

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -91,6 +91,9 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 	// Inject JWT secret from config into environment for jwt.go's os.Getenv("JWT_SECRET")
 	// This bridges config.yaml / DEPLOYPILOT_AUTH_JWT_SECRET → JWT_SECRET
 	if cfg.Auth.JWTSecret != "" && os.Getenv("JWT_SECRET") == "" {
+		if len(cfg.Auth.JWTSecret) < 16 {
+			return fmt.Errorf("auth.jwt_secret in config must be at least 16 characters, current length: %d", len(cfg.Auth.JWTSecret))
+		}
 		_ = os.Setenv("JWT_SECRET", cfg.Auth.JWTSecret)
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1907,10 +1907,10 @@ func TestListDNSRecords_WithDomain(t *testing.T) {
 	r := setupFullTestRouter(db, bridge)
 	token := getTestToken(t, "user-1", "viewer")
 
-	// No DNS provider configured, so it should return an error response (but not 500)
+	// No DNS provider configured, should return 500
 	w := makeRequest(r, "GET", "/api/v1/dns/records?domain=example.com", nil, token)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -1928,9 +1928,9 @@ func TestCreateDNSRecord(t *testing.T) {
 		"name":   "@",
 		"value":  "1.2.3.4",
 	}, token)
-	// No DNS provider configured, but the handler should still return 200 with error status in body
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	// No DNS provider configured, should return 500
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -1962,9 +1962,9 @@ func TestUpdateDNSRecord(t *testing.T) {
 		"type":      "A",
 		"new_value": "5.6.7.8",
 	}, token)
-	// No DNS provider, returns 200 with error in body
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	// No DNS provider configured, should return 500
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -2398,9 +2398,9 @@ func TestListDNSRecords_BridgeError_Cov(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	// No DNS provider configured, will return error map
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	// No DNS provider configured, should return 500
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -2419,8 +2419,8 @@ func TestCreateDNSRecord_BridgeError_Cov(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 
@@ -2439,8 +2439,8 @@ func TestUpdateDNSRecord_BridgeError_Cov(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/service/bridge_coverage_test.go
+++ b/internal/service/bridge_coverage_test.go
@@ -100,17 +100,9 @@ func TestDNSListRecords_WithValidProvider(t *testing.T) {
 
 func TestDNSListRecords_NoProvider_Cov(t *testing.T) {
 	b, _ := newTestBridge(t)
-	// No DNS provider configured
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
 }
 

--- a/internal/service/bridge_coverage_test.go
+++ b/internal/service/bridge_coverage_test.go
@@ -85,16 +85,10 @@ func TestDNSListRecords_WithValidProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-list-ok-cov', 'dns-cloudflare', 'list-ok-cov', ?, 1)`, string(cfg))
 
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "success" && m["status"] != "error" {
-		t.Errorf("expected success or error status, got %v", m["status"])
+	// Provider API will fail with test token - DNS methods now return errors
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error with test API token")
 	}
 }
 
@@ -115,16 +109,11 @@ func TestDNSListRecords_WithAliyunProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-aliyun-list-cov', 'dns-aliyun', 'aliyun-list-cov', ?, 1)`, string(cfg))
 
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Log("DNSListRecords succeeded (unexpected but acceptable for coverage)")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	// Will be error since no real server, but covers the aliyun provider path
-	_ = m
+	// Covers the aliyun provider path; error expected since no real server
 }
 
 // ===================== SendNotification Success Path =====================
@@ -335,16 +324,10 @@ func TestDNSCreateRecord_WithValidProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-create-ok-cov', 'dns-cloudflare', 'create-ok-cov', ?, 1)`, string(cfg))
 
-	res, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "success" && m["status"] != "error" {
-		t.Errorf("expected success or error status, got %v", m["status"])
+	// Provider API will fail with test token
+	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error with test API token")
 	}
 }
 
@@ -375,17 +358,11 @@ func TestUpdateDNSRecord_WithValidProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-update-ok-cov', 'dns-cloudflare', 'update-ok-cov', ?, 1)`, string(cfg))
 
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "9.9.9.9")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "9.9.9.9")
+	if err == nil {
+		t.Log("UpdateDNSRecord succeeded (unexpected but acceptable for coverage)")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "success" && m["status"] != "error" {
-		t.Errorf("expected success or error status, got %v", m["status"])
-	}
+	// Error expected since no real cloudflare server
 }
 
 // ===================== UpdateApp Success Path =====================
@@ -1532,10 +1509,9 @@ func TestDeleteApp_NotFound_Cov(t *testing.T) {
 func TestDNSCreateRecord_NoProvider_Cov(t *testing.T) {
 	b, _ := newTestBridge(t)
 	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
-	// Returns error status in the result map
 }
 
 // ===================== DNSDeleteRecord Error Coverage =====================
@@ -1553,8 +1529,8 @@ func TestDNSDeleteRecord_NoProvider_Cov(t *testing.T) {
 func TestUpdateDNSRecord_NoProvider_Cov(t *testing.T) {
 	b, _ := newTestBridge(t)
 	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
 }
 

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -482,14 +482,10 @@ func TestDNSStubs(t *testing.T) {
 	b, _ := newTestBridge(t)
 	ctx := context.Background()
 
-	// DNSCreateRecord - no DNS provider configured, returns error status
-	res, err := b.DNSCreateRecord(ctx, "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok || m["status"] != "error" {
-		t.Fatalf("expected error status, got %v", m)
+	// DNSCreateRecord - no DNS provider configured, returns error
+	_, err := b.DNSCreateRecord(ctx, "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error for DNSCreateRecord without provider")
 	}
 
 	// DNSDeleteRecord - no DNS provider configured, returns error
@@ -498,24 +494,16 @@ func TestDNSStubs(t *testing.T) {
 		t.Fatal("expected error for DNSDeleteRecord without provider")
 	}
 
-	// DNSListRecords - no DNS provider configured, returns error status
-	res, err = b.DNSListRecords(ctx, "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m = res.(map[string]interface{})
-	if m["status"] != "error" {
-		t.Fatalf("expected error status, got %v", m)
+	// DNSListRecords - no DNS provider configured, returns error
+	_, err = b.DNSListRecords(ctx, "example.com")
+	if err == nil {
+		t.Fatal("expected error for DNSListRecords without provider")
 	}
 
-	// UpdateDNSRecord - no DNS provider configured, returns error status
-	res, err = b.UpdateDNSRecord(ctx, "example.com", "www", "A", "5.6.7.8")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
-	}
-	m = res.(map[string]interface{})
-	if m["status"] != "error" {
-		t.Fatalf("expected error status, got %v", m)
+	// UpdateDNSRecord - no DNS provider configured, returns error
+	_, err = b.UpdateDNSRecord(ctx, "example.com", "www", "A", "5.6.7.8")
+	if err == nil {
+		t.Fatal("expected error for UpdateDNSRecord without provider")
 	}
 }
 

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -1948,16 +1948,9 @@ func TestSaveDeploymentRecord_WithPreflight(t *testing.T) {
 
 func TestDNSListRecords_NoProviderBridge(t *testing.T) {
 	b, _ := newTestBridge(t)
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
 }
 
@@ -1966,16 +1959,9 @@ func TestDNSListRecords_InvalidConfig(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-bad-list', 'dns-cloudflare', 'bad-list', 'not-json', 1)`)
 
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error for invalid DNS provider config")
 	}
 }
 
@@ -1984,31 +1970,17 @@ func TestDNSCreateRecord_InvalidConfig(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-bad-create', 'dns-cloudflare', 'bad-create', 'not-json', 1)`)
 
-	res, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error for invalid DNS provider config")
 	}
 }
 
 func TestDNSCreateRecord_NilDB(t *testing.T) {
 	b := &Bridge{DB: nil}
-	res, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when DB is nil")
 	}
 }
 
@@ -2039,16 +2011,9 @@ func TestDNSCreateRecord_ProviderAPIFails(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-cf-api-fail', 'dns-cloudflare', 'cf-api-fail', ?, 1)`, string(cfg))
 
-	res, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status when API call fails, got %v", m["status"])
+	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when provider API fails")
 	}
 }
 
@@ -2076,16 +2041,9 @@ func TestDNSListRecords_ProviderAPIFails(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-cf-list-fail', 'dns-cloudflare', 'cf-list-fail', ?, 1)`, string(cfg))
 
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status when API call fails, got %v", m["status"])
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error when provider API fails")
 	}
 }
 
@@ -2098,16 +2056,9 @@ func TestUpdateDNSRecord_ProviderAPIFails(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-cf-update-fail', 'dns-cloudflare', 'cf-update-fail', ?, 1)`, string(cfg))
 
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "9.9.9.9")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status when API call fails, got %v", m["status"])
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "9.9.9.9")
+	if err == nil {
+		t.Fatal("expected error when provider API fails")
 	}
 }
 

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -2638,17 +2638,13 @@ func TestDeleteSSLCertificate_Success(t *testing.T) {
 
 func TestUpdateDNSRecord_NilDB(t *testing.T) {
 	b := &Bridge{DB: nil}
-	// UpdateDNSRecord wraps provider errors in a map response, not an error return
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord should not return error: %v", err)
+	// UpdateDNSRecord now returns error when DB is nil
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when DB is nil")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "database not available") {
+		t.Errorf("expected 'database not available' error, got: %v", err)
 	}
 }
 
@@ -2657,16 +2653,12 @@ func TestUpdateDNSRecord_InvalidConfig(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-bad-update', 'dns-cloudflare', 'bad-update', 'not-json', 1)`)
 
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error for invalid DNS provider config")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "failed to parse DNS provider config") {
+		t.Errorf("expected 'failed to parse DNS provider config' error, got: %v", err)
 	}
 }
 
@@ -2759,16 +2751,12 @@ func TestHealContainer_NilDB(t *testing.T) {
 func TestUpdateDNSRecord_NoProvider(t *testing.T) {
 	b, _ := newTestBridge(t)
 	// No DNS provider configured at all
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "no enabled DNS provider found") {
+		t.Errorf("expected 'no enabled DNS provider found' error, got: %v", err)
 	}
 }
 
@@ -2778,17 +2766,13 @@ func TestDNSListRecords_UnsupportedProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-unsup-list', 'dns-route53', 'unsupported', '{"api_token":"t"}', 1)`)
 
-	// DNSListRecords wraps provider errors in a map response, not an error return
-	res, err := b.DNSListRecords(context.TODO(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
+	// DNSListRecords now returns error for unsupported provider type
+	_, err := b.DNSListRecords(context.TODO(), "example.com")
+	if err == nil {
+		t.Fatal("expected error for unsupported DNS provider type")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "unsupported DNS provider type") {
+		t.Errorf("expected 'unsupported DNS provider type' error, got: %v", err)
 	}
 }
 
@@ -2798,16 +2782,12 @@ func TestDNSCreateRecord_UnsupportedProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-unsup-create', 'dns-route53', 'unsupported', '{"api_token":"t"}', 1)`)
 
-	res, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
+	_, err := b.DNSCreateRecord(context.TODO(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error for unsupported DNS provider type")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "unsupported DNS provider type") {
+		t.Errorf("expected 'unsupported DNS provider type' error, got: %v", err)
 	}
 }
 
@@ -2818,17 +2798,13 @@ func TestUpdateDNSRecord_UnsupportedProvider(t *testing.T) {
 	b.DB.Exec(`INSERT INTO providers (id, type, name, config, enabled) VALUES
 		('dns-unsup-update', 'dns-route53', 'unsupported', '{"api_token":"t"}', 1)`)
 
-	// UpdateDNSRecord wraps provider errors in a map response, not an error return
-	res, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "5.6.7.8")
-	if err != nil {
-		t.Fatalf("UpdateDNSRecord failed: %v", err)
+	// UpdateDNSRecord now returns error for unsupported provider type
+	_, err := b.UpdateDNSRecord(context.TODO(), "example.com", "www", "A", "5.6.7.8")
+	if err == nil {
+		t.Fatal("expected error for unsupported DNS provider type")
 	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Errorf("expected error status, got %v", m["status"])
+	if !strings.Contains(err.Error(), "unsupported DNS provider type") {
+		t.Errorf("expected 'unsupported DNS provider type' error, got: %v", err)
 	}
 }
 

--- a/internal/service/dns_service.go
+++ b/internal/service/dns_service.go
@@ -63,15 +63,7 @@ func (b *Bridge) getDNSProvider(ctx context.Context) (dns.DNSProvider, error) {
 func (b *Bridge) DNSCreateRecord(ctx context.Context, domain, recordType, name, value string) (interface{}, error) {
 	provider, err := b.getDNSProvider(ctx)
 	if err != nil {
-		slog.Error("DNS provider error", "error", err)
-		return map[string]interface{}{
-			"status":  "error",
-			"domain":  domain,
-			"type":    recordType,
-			"name":    name,
-			"value":   value,
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS provider error: %w", err)
 	}
 	record := &dns.DNSRecord{
 		Domain: domain,
@@ -81,10 +73,7 @@ func (b *Bridge) DNSCreateRecord(ctx context.Context, domain, recordType, name, 
 		TTL:    1,
 	}
 	if err := provider.CreateRecord(ctx, record); err != nil {
-		return map[string]interface{}{
-			"status":  "error",
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS create record failed: %w", err)
 	}
 	return map[string]interface{}{
 		"status": "success",
@@ -128,18 +117,11 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 
 	provider, err := b.getDNSProvider(ctx)
 	if err != nil {
-		return map[string]interface{}{
-			"status":  "error",
-			"domain":  domain,
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS provider error: %w", err)
 	}
 	records, err := provider.ListRecords(ctx, domain)
 	if err != nil {
-		return map[string]interface{}{
-			"status":  "error",
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS list records failed: %w", err)
 	}
 	// Convert to response format
 	result := make([]map[string]interface{}, 0, len(records))
@@ -175,10 +157,7 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 func (b *Bridge) UpdateDNSRecord(ctx context.Context, domain, subdomain, recordType, newValue string) (interface{}, error) {
 	provider, err := b.getDNSProvider(ctx)
 	if err != nil {
-		return map[string]interface{}{
-			"status":  "error",
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS provider error: %w", err)
 	}
 	record := &dns.DNSRecord{
 		Domain: domain,
@@ -188,10 +167,7 @@ func (b *Bridge) UpdateDNSRecord(ctx context.Context, domain, subdomain, recordT
 		TTL:    1,
 	}
 	if err := provider.UpdateRecord(ctx, record); err != nil {
-		return map[string]interface{}{
-			"status":  "error",
-			"message": err.Error(),
-		}, nil
+		return nil, fmt.Errorf("DNS update record failed: %w", err)
 	}
 	return map[string]interface{}{
 		"status":    "success",
@@ -216,8 +192,7 @@ func (b *Bridge) BatchDNS(ctx context.Context, records []map[string]interface{})
 		status := "success"
 		if err != nil {
 			status = "error"
-		} else if m, ok := res.(map[string]interface{}); ok && m["status"] == "error" {
-			status = "error"
+			res = map[string]interface{}{"message": err.Error()}
 		}
 		results = append(results, map[string]interface{}{
 			"index":  i,

--- a/internal/service/v05_test.go
+++ b/internal/service/v05_test.go
@@ -117,16 +117,9 @@ func TestGetNotifiers_InvalidConfig(t *testing.T) {
 
 func TestDNSCreateRecord_NoProvider(t *testing.T) {
 	b, _ := newTestBridge(t)
-	res, err := b.DNSCreateRecord(context.Background(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Fatalf("expected error status, got %v", m["status"])
+	_, err := b.DNSCreateRecord(context.Background(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
 }
 
@@ -137,35 +130,17 @@ func TestDNSCreateRecord_WithProvider(t *testing.T) {
 		err:    map[string]error{},
 	}
 	b := NewBridge(db, exec, []byte("01234567890123456789012345678901"), nil)
-	// The DNS provider will try to make HTTP calls to Cloudflare API,
-	// which will fail in tests. We just verify it doesn't panic and returns
-	// a result (error from the API call is wrapped in the response).
-	res, err := b.DNSCreateRecord(context.Background(), "example.com", "A", "www", "1.2.3.4")
-	if err != nil {
-		t.Fatalf("DNSCreateRecord failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	// The Cloudflare API call will fail (no real API), so status should be error
-	if m["status"] != "error" {
-		t.Fatalf("expected error status (API call fails in test), got %v", m["status"])
+	_, err := b.DNSCreateRecord(context.Background(), "example.com", "A", "www", "1.2.3.4")
+	if err == nil {
+		t.Fatal("expected error when DNS API call fails in test environment")
 	}
 }
 
 func TestDNSListRecords_NoProvider(t *testing.T) {
 	b, _ := newTestBridge(t)
-	res, err := b.DNSListRecords(context.Background(), "example.com")
-	if err != nil {
-		t.Fatalf("DNSListRecords failed: %v", err)
-	}
-	m, ok := res.(map[string]interface{})
-	if !ok {
-		t.Fatal("expected map")
-	}
-	if m["status"] != "error" {
-		t.Fatalf("expected error status, got %v", m["status"])
+	_, err := b.DNSListRecords(context.Background(), "example.com")
+	if err == nil {
+		t.Fatal("expected error when no DNS provider configured")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two Medium-priority issues from ai-guide.md:

### DNS 服务吞掉错误
`dns_service.go` 中 `DNSCreateRecord`、`DNSListRecords`、`UpdateDNSRecord` 在出错时返回 `nil error` + 包含 `status: "error"` 的 map，导致调用方无法使用标准 `if err != nil` 模式检测错误。

**修复**: 让错误正常通过 error 返回，handler 层已有的 `if err != nil { respondError(500) }` 逻辑可以正确捕获。

### JWT Secret 配置注入绕过长度校验
`cmd/api-server/main.go` 中 `auth.jwt_secret` 配置直接注入环境变量，没有做 16 字符最小长度校验。

**修复**: 注入前增加 `len(cfg.Auth.JWTSecret) < 16` 校验，不满足则返回明确错误。

## Test Updates
- 5 个 service 层测试：从断言 `err == nil + status == "error"` 改为断言 `err != nil`
- 6 个 API 层测试：HTTP 状态码期望从 200 改为 500（无 provider 时正确返回服务端错误）