### PR TITLE
fix(ci): remove continue-on-error from frontend dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,6 @@ jobs:
         run: npm ci
 
       - name: Run npm audit
-        continue-on-error: true
         working-directory: web
         run: npm audit --audit-level=high
 


### PR DESCRIPTION
## Summary

Remove `continue-on-error: true` from the frontend dependency audit step (`npm audit --audit-level=high`).

Security scans should block CI when high-severity vulnerabilities are found, not silently pass.

**Kept** `continue-on-error` on `govulncheck` — its findings require Go 1.24+ to resolve (tracked as M-14 in ai-guide.md).

## Risk

Low. If `npm audit` currently reports high-severity findings, this change will make CI fail until they are resolved. Current `package-lock.json` should be clean.