### PR TITLE
feat(panel): add DeleteReverseProxy, CreateWebsite, GetWebsiteList

### DIFF
--- a/internal/provider/server/panel.go
+++ b/internal/provider/server/panel.go
@@ -14,11 +14,25 @@ type CommandExecutor interface {
 	RunCommand(ctx context.Context, cmd string) (string, error)
 }
 
+// WebsiteInfo represents basic information about a website managed by a panel.
+type WebsiteInfo struct {
+	ID            interface{} `json:"id"`
+	PrimaryDomain string      `json:"primaryDomain"`
+	Type          string      `json:"type"`
+	Status        bool        `json:"status"`
+	Remark        string      `json:"remark"`
+	SSL           bool        `json:"ssl"`
+	CreatedAt     string      `json:"createdAt"`
+}
+
 // PanelClient defines the unified interface for panel providers.
 type PanelClient interface {
 	OpenFirewall(ctx context.Context, port int, protocol string) error
 	CloseFirewall(ctx context.Context, port int, protocol string) error
 	CreateReverseProxy(ctx context.Context, domain, targetURL string, port int) error
+	DeleteReverseProxy(ctx context.Context, domain string) error
+	CreateWebsite(ctx context.Context, domain, websiteType, remark string) (*WebsiteInfo, error)
+	GetWebsiteList(ctx context.Context) ([]WebsiteInfo, error)
 	GetInfo() map[string]interface{}
 }
 
@@ -46,14 +60,12 @@ func DetectPanel(ctx context.Context, executor CommandExecutor) PanelClient {
 		slog.Info("detected 1Panel", "status", output)
 		return NewPanel1Client("", "")
 	}
-
 	// Try BT-Panel
 	output, err = executor.RunCommand(ctx, "systemctl is-active bt 2>/dev/null || echo 'inactive'")
 	if err == nil && len(output) > 0 && output != "inactive" {
 		slog.Info("detected BT-Panel", "status", output)
 		return NewBTPanelClient("", "admin", "")
 	}
-
 	// Fallback: check processes
 	output, err = executor.RunCommand(ctx, "ps aux | grep -E '1panel|BT-Panel|bt' | grep -v grep || true")
 	if err == nil && len(output) > 0 {
@@ -64,7 +76,6 @@ func DetectPanel(ctx context.Context, executor CommandExecutor) PanelClient {
 			return NewBTPanelClient("", "admin", "")
 		}
 	}
-
 	return nil
 }
 
@@ -79,7 +90,6 @@ func (p *PanelProvider) GetPanelInfo() (map[string]interface{}, error) {
 }
 
 // OpenFirewall opens a port on the panel's firewall.
-// It uses the panel-specific API when available, or falls back to SSH.
 func (p *PanelProvider) OpenFirewall(ctx context.Context, port int, protocol string) error {
 	if p.client == nil {
 		slog.Warn("no panel detected, skipping firewall operation (use SSH fallback)", "port", port, "protocol", protocol)
@@ -89,7 +99,6 @@ func (p *PanelProvider) OpenFirewall(ctx context.Context, port int, protocol str
 }
 
 // CloseFirewall closes a port on the panel's firewall.
-// It uses the panel-specific API when available, or falls back to SSH.
 func (p *PanelProvider) CloseFirewall(ctx context.Context, port int, protocol string) error {
 	if p.client == nil {
 		slog.Warn("no panel detected, skipping firewall operation (use SSH fallback)", "port", port, "protocol", protocol)
@@ -99,13 +108,39 @@ func (p *PanelProvider) CloseFirewall(ctx context.Context, port int, protocol st
 }
 
 // CreateReverseProxy creates a reverse proxy via the panel's API.
-// It uses the panel-specific API when available, or falls back to SSH.
 func (p *PanelProvider) CreateReverseProxy(ctx context.Context, domain, targetURL string, port int) error {
 	if p.client == nil {
 		slog.Warn("no panel detected, skipping reverse proxy creation (use SSH fallback)", "domain", domain)
 		return nil
 	}
 	return p.client.CreateReverseProxy(ctx, domain, targetURL, port)
+}
+
+// DeleteReverseProxy deletes a reverse proxy via the panel's API.
+func (p *PanelProvider) DeleteReverseProxy(ctx context.Context, domain string) error {
+	if p.client == nil {
+		slog.Warn("no panel detected, skipping reverse proxy deletion (use SSH fallback)", "domain", domain)
+		return nil
+	}
+	return p.client.DeleteReverseProxy(ctx, domain)
+}
+
+// CreateWebsite creates a website via the panel's API.
+func (p *PanelProvider) CreateWebsite(ctx context.Context, domain, websiteType, remark string) (*WebsiteInfo, error) {
+	if p.client == nil {
+		slog.Warn("no panel detected, skipping website creation", "domain", domain)
+		return nil, fmt.Errorf("no panel detected")
+	}
+	return p.client.CreateWebsite(ctx, domain, websiteType, remark)
+}
+
+// GetWebsiteList returns a list of websites managed by the panel.
+func (p *PanelProvider) GetWebsiteList(ctx context.Context) ([]WebsiteInfo, error) {
+	if p.client == nil {
+		slog.Warn("no panel detected, skipping website list")
+		return nil, fmt.Errorf("no panel detected")
+	}
+	return p.client.GetWebsiteList(ctx)
 }
 
 func contains(s, substr string) bool {

--- a/internal/provider/server/panel_1panel.go
+++ b/internal/provider/server/panel_1panel.go
@@ -42,6 +42,24 @@ type panel1FirewallListData struct {
 	Total int                  `json:"total"`
 }
 
+// panel1WebsiteData represents a 1Panel website entry.
+type panel1WebsiteData struct {
+	ID            json.Number `json:"id"`
+	PrimaryDomain string      `json:"primaryDomain"`
+	Type          string      `json:"type"`
+	Status        bool        `json:"status"`
+	Remark        string      `json:"remark"`
+	SSL           bool        `json:"ssl"`
+	CreatedAt     string      `json:"createdAt"`
+	UpdatedAt     string      `json:"updatedAt"`
+}
+
+// panel1WebsiteListData represents the data field of a website list response.
+type panel1WebsiteListData struct {
+	Items []panel1WebsiteData `json:"items"`
+	Total int                  `json:"total"`
+}
+
 // NewPanel1Client creates a new 1Panel API client.
 func NewPanel1Client(baseURL, apiKey string) *Panel1Client {
 	return &Panel1Client{
@@ -68,43 +86,35 @@ func (p *Panel1Client) doRequest(ctx context.Context, method, path string, body 
 		}
 		reqBody = bytes.NewReader(data)
 	}
-
 	url := p.baseURL + path
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-
 	req.Header.Set("Authorization", "Bearer "+p.apiKey)
 	req.Header.Set("Content-Type", "application/json")
-
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("panel API request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-
 	var result panel1Response
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
-
 	if result.Code != 200 {
 		return nil, fmt.Errorf("panel API error (code %d): %s", result.Code, result.Message)
 	}
-
 	return &result, nil
 }
 
 // OpenFirewall opens a port via the 1Panel API.
 func (p *Panel1Client) OpenFirewall(ctx context.Context, port int, protocol string) error {
 	slog.Info("1Panel: opening firewall port", "port", port, "protocol", protocol)
-
 	reqBody := map[string]interface{}{
 		"protocol": protocol,
 		"port":     strconv.Itoa(port),
@@ -112,33 +122,25 @@ func (p *Panel1Client) OpenFirewall(ctx context.Context, port int, protocol stri
 		"comment":  "deploypilot",
 		"action":   "accept",
 	}
-
 	_, err := p.doRequest(ctx, http.MethodPost, "/api/v1/firewall/rules", reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to open firewall port %d/%s: %w", port, protocol, err)
 	}
-
 	slog.Info("1Panel: firewall port opened successfully", "port", port, "protocol", protocol)
 	return nil
 }
 
 // CloseFirewall closes a port via the 1Panel API.
-// It first lists firewall rules to find the matching rule ID, then deletes it.
 func (p *Panel1Client) CloseFirewall(ctx context.Context, port int, protocol string) error {
 	slog.Info("1Panel: closing firewall port", "port", port, "protocol", protocol)
-
-	// Step 1: List firewall rules to find the rule ID
 	resp, err := p.doRequest(ctx, http.MethodGet, "/api/v1/firewall/rules", nil)
 	if err != nil {
 		return fmt.Errorf("failed to list firewall rules: %w", err)
 	}
-
 	var listData panel1FirewallListData
 	if err := json.Unmarshal(resp.Data, &listData); err != nil {
 		return fmt.Errorf("failed to parse firewall rules: %w", err)
 	}
-
-	// Find the matching rule
 	portStr := strconv.Itoa(port)
 	var ruleID string
 	for _, rule := range listData.Items {
@@ -147,18 +149,14 @@ func (p *Panel1Client) CloseFirewall(ctx context.Context, port int, protocol str
 			break
 		}
 	}
-
 	if ruleID == "" {
 		slog.Warn("1Panel: no matching firewall rule found to close", "port", port, "protocol", protocol)
 		return nil
 	}
-
-	// Step 2: Delete the rule
 	_, err = p.doRequest(ctx, http.MethodDelete, "/api/v1/firewall/rules/"+ruleID, nil)
 	if err != nil {
 		return fmt.Errorf("failed to close firewall port %d/%s: %w", port, protocol, err)
 	}
-
 	slog.Info("1Panel: firewall port closed successfully", "port", port, "protocol", protocol, "ruleID", ruleID)
 	return nil
 }
@@ -174,18 +172,106 @@ func (p *Panel1Client) GetInfo() map[string]interface{} {
 // CreateReverseProxy creates a reverse proxy via the 1Panel API.
 func (p *Panel1Client) CreateReverseProxy(ctx context.Context, domain, targetURL string, port int) error {
 	slog.Info("1Panel: creating reverse proxy", "domain", domain, "targetURL", targetURL, "port", port)
-
 	reqBody := map[string]interface{}{
 		"primaryDomain": domain,
 		"proxy":         targetURL,
 		"type":          "reverse_proxy",
 	}
-
 	_, err := p.doRequest(ctx, http.MethodPost, "/api/v1/websites/reverse_proxy", reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to create reverse proxy for %s: %w", domain, err)
 	}
-
 	slog.Info("1Panel: reverse proxy created successfully", "domain", domain)
 	return nil
+}
+
+// DeleteReverseProxy deletes a reverse proxy website via the 1Panel API.
+func (p *Panel1Client) DeleteReverseProxy(ctx context.Context, domain string) error {
+	slog.Info("1Panel: deleting reverse proxy", "domain", domain)
+	resp, err := p.doRequest(ctx, http.MethodGet, "/api/v1/websites", nil)
+	if err != nil {
+		return fmt.Errorf("failed to list websites: %w", err)
+	}
+	var listData panel1WebsiteListData
+	if err := json.Unmarshal(resp.Data, &listData); err != nil {
+		return fmt.Errorf("failed to parse website list: %w", err)
+	}
+	var websiteID string
+	for _, site := range listData.Items {
+		if site.PrimaryDomain == domain && site.Type == "reverse_proxy" {
+			websiteID = site.ID.String()
+			break
+		}
+	}
+	if websiteID == "" {
+		slog.Warn("1Panel: no matching reverse proxy found to delete", "domain", domain)
+		return fmt.Errorf("reverse proxy not found for domain: %s", domain)
+	}
+	_, err = p.doRequest(ctx, http.MethodDelete, "/api/v1/websites/"+websiteID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to delete reverse proxy for %s: %w", domain, err)
+	}
+	slog.Info("1Panel: reverse proxy deleted successfully", "domain", domain, "websiteID", websiteID)
+	return nil
+}
+
+// CreateWebsite creates a new website via the 1Panel API.
+func (p *Panel1Client) CreateWebsite(ctx context.Context, domain, websiteType, remark string) (*WebsiteInfo, error) {
+	slog.Info("1Panel: creating website", "domain", domain, "type", websiteType)
+	reqBody := map[string]interface{}{
+		"primaryDomain": domain,
+		"type":          websiteType,
+		"remark":        remark,
+	}
+	resp, err := p.doRequest(ctx, http.MethodPost, "/api/v1/websites", reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create website for %s: %w", domain, err)
+	}
+	var siteData panel1WebsiteData
+	if err := json.Unmarshal(resp.Data, &siteData); err != nil {
+		slog.Warn("1Panel: could not parse website creation response", "error", err)
+		return &WebsiteInfo{
+			PrimaryDomain: domain,
+			Type:          websiteType,
+			Remark:        remark,
+			Status:        true,
+		}, nil
+	}
+	slog.Info("1Panel: website created successfully", "domain", domain, "websiteID", siteData.ID)
+	return &WebsiteInfo{
+		ID:            siteData.ID.String(),
+		PrimaryDomain: siteData.PrimaryDomain,
+		Type:          siteData.Type,
+		Status:        siteData.Status,
+		Remark:        siteData.Remark,
+		SSL:           siteData.SSL,
+		CreatedAt:     siteData.CreatedAt,
+	}, nil
+}
+
+// GetWebsiteList returns a list of websites managed by 1Panel.
+func (p *Panel1Client) GetWebsiteList(ctx context.Context) ([]WebsiteInfo, error) {
+	slog.Info("1Panel: listing websites")
+	resp, err := p.doRequest(ctx, http.MethodGet, "/api/v1/websites", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list websites: %w", err)
+	}
+	var listData panel1WebsiteListData
+	if err := json.Unmarshal(resp.Data, &listData); err != nil {
+		return nil, fmt.Errorf("failed to parse website list: %w", err)
+	}
+	websites := make([]WebsiteInfo, 0, len(listData.Items))
+	for _, site := range listData.Items {
+		websites = append(websites, WebsiteInfo{
+			ID:            site.ID.String(),
+			PrimaryDomain: site.PrimaryDomain,
+			Type:          site.Type,
+			Status:        site.Status,
+			Remark:        site.Remark,
+			SSL:           site.SSL,
+			CreatedAt:     site.CreatedAt,
+		})
+	}
+	slog.Info("1Panel: website list retrieved", "count", len(websites))
+	return websites, nil
 }

--- a/internal/provider/server/panel_1panel.go
+++ b/internal/provider/server/panel_1panel.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"io"
 	"log/slog"
 	"net/http"
@@ -99,6 +100,8 @@ func (p *Panel1Client) doRequest(ctx context.Context, method, path string, body 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
+	// DEBUG
+	fmt.Fprintf(os.Stderr, "DEBUG doRequest: method=%s path=%s status=%d body=%q\n", method, path, resp.StatusCode, string(respBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/internal/provider/server/panel_1panel.go
+++ b/internal/provider/server/panel_1panel.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"io"
 	"log/slog"
 	"net/http"
@@ -100,8 +99,6 @@ func (p *Panel1Client) doRequest(ctx context.Context, method, path string, body 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	respBody, err := io.ReadAll(resp.Body)
-	// DEBUG
-	fmt.Fprintf(os.Stderr, "DEBUG doRequest: method=%s path=%s status=%d body=%q\n", method, path, resp.StatusCode, string(respBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/internal/provider/server/panel_1panel_test.go
+++ b/internal/provider/server/panel_1panel_test.go
@@ -5,84 +5,77 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func setup1PanelTestServer() *httptest.Server {
-	mux := http.NewServeMux()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 
-	mux.HandleFunc("/api/v1/firewall/rules", func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1},
-			})
-		case http.MethodGet:
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"code": 200, "message": "ok",
-				"data": map[string]interface{}{
-					"items": []map[string]interface{}{
-						{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
-						{"id": 2, "protocol": "tcp", "port": "9090", "address": "", "comment": "other", "action": "accept"},
+		switch {
+		// Firewall rules
+		case r.URL.Path == "/api/v1/firewall/rules":
+			switch r.Method {
+			case http.MethodPost:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1},
+				})
+			case http.MethodGet:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"code": 200, "message": "ok",
+					"data": map[string]interface{}{
+						"items": []map[string]interface{}{
+							{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
+							{"id": 2, "protocol": "tcp", "port": "9090", "address": "", "comment": "other", "action": "accept"},
+						},
+						"total": 2,
 					},
-					"total": 2,
-				},
-			})
-		case http.MethodDelete:
-			w.Header().Set("Content-Type", "application/json")
+				})
+			case http.MethodDelete:
+				json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
+			}
+
+		// Delete website by ID (e.g., /api/v1/websites/10)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/websites/") && r.URL.Path != "/api/v1/websites/reverse_proxy":
 			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
-		}
-	})
 
-	mux.HandleFunc("/api/v1/websites", func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodGet:
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"code": 200, "message": "ok",
-				"data": map[string]interface{}{
-					"items": []map[string]interface{}{
-						{"id": 10, "primaryDomain": "app.example.com", "type": "reverse_proxy", "status": true, "remark": "my app", "ssl": false, "createdAt": "2026-04-28"},
-						{"id": 11, "primaryDomain": "blog.example.com", "type": "static", "status": true, "remark": "blog", "ssl": true, "createdAt": "2026-04-27"},
-					},
-					"total": 2,
-				},
-			})
-		case http.MethodPost:
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"code": 200, "message": "ok",
-				"data":  map[string]interface{}{"id": 12, "primaryDomain": "new.example.com", "type": "static", "status": true},
-			})
-		}
-	})
-
-	mux.HandleFunc("/api/v1/websites/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
-		}
-	})
-
-	mux.HandleFunc("/api/v1/websites/reverse_proxy", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			w.Header().Set("Content-Type", "application/json")
+		// Create reverse proxy
+		case r.URL.Path == "/api/v1/websites/reverse_proxy" && r.Method == http.MethodPost:
 			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 5}})
-		}
-	})
 
-	return httptest.NewServer(mux)
+		// Website list (GET) or create (POST)
+		case r.URL.Path == "/api/v1/websites":
+			switch r.Method {
+			case http.MethodGet:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"code": 200, "message": "ok",
+					"data": map[string]interface{}{
+						"items": []map[string]interface{}{
+							{"id": 10, "primaryDomain": "app.example.com", "type": "reverse_proxy", "status": true, "remark": "my app", "ssl": false, "createdAt": "2026-04-28"},
+							{"id": 11, "primaryDomain": "blog.example.com", "type": "static", "status": true, "remark": "blog", "ssl": true, "createdAt": "2026-04-27"},
+						},
+						"total": 2,
+					},
+				})
+			case http.MethodPost:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"code": 200, "message": "ok",
+					"data": map[string]interface{}{"id": 12, "primaryDomain": "new.example.com", "type": "static", "status": true},
+				})
+			}
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 }
 
 func setup1PanelErrorServer() *httptest.Server {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{"code": 500, "message": "internal error"})
-	})
-	return httptest.NewServer(mux)
+	}))
 }
 
 func TestNewPanel1Client(t *testing.T) {

--- a/internal/provider/server/panel_1panel_test.go
+++ b/internal/provider/server/panel_1panel_test.go
@@ -14,7 +14,7 @@ func setup1PanelTestServer() *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 
 		switch {
-		// Firewall rules
+		// Firewall rules - list/create (exact path)
 		case r.URL.Path == "/api/v1/firewall/rules":
 			switch r.Method {
 			case http.MethodPost:
@@ -32,9 +32,13 @@ func setup1PanelTestServer() *httptest.Server {
 						"total": 2,
 					},
 				})
-			case http.MethodDelete:
-				json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
+			default:
+				http.NotFound(w, r)
 			}
+
+		// Firewall rules - delete by ID (e.g., /api/v1/firewall/rules/1)
+		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/firewall/rules/"):
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
 
 		// Delete website by ID (e.g., /api/v1/websites/10)
 		case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/api/v1/websites/") && r.URL.Path != "/api/v1/websites/reverse_proxy":
@@ -63,6 +67,8 @@ func setup1PanelTestServer() *httptest.Server {
 					"code": 200, "message": "ok",
 					"data": map[string]interface{}{"id": 12, "primaryDomain": "new.example.com", "type": "static", "status": true},
 				})
+			default:
+				http.NotFound(w, r)
 			}
 
 		default:

--- a/internal/provider/server/panel_1panel_test.go
+++ b/internal/provider/server/panel_1panel_test.go
@@ -3,79 +3,74 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 )
 
 func setup1PanelTestServer() *httptest.Server {
 	mux := http.NewServeMux()
 
-	// POST /api/v1/firewall/rules - create rule
-	// GET /api/v1/firewall/rules - list rules
-	// DELETE /api/v1/firewall/rules/{id} - delete rule (path includes rule ID)
 	mux.HandleFunc("/api/v1/firewall/rules", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			body, _ := io.ReadAll(r.Body)
-			var req map[string]interface{}
-			_ = json.Unmarshal(body, &req)
-
-			resp := panel1Response{
-				Code:    200,
-				Message: "success",
-				Data:    json.RawMessage(`{"id": 1}`),
-			}
+		switch r.Method {
+		case http.MethodPost:
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(resp)
-			return
-		}
-
-		if r.Method == http.MethodGet {
-			resp := panel1Response{
-				Code:    200,
-				Message: "success",
-				Data: json.RawMessage(`{
-					"items": [
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1},
+			})
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 200, "message": "ok",
+				"data": map[string]interface{}{
+					"items": []map[string]interface{}{
 						{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
-						{"id": 2, "protocol": "udp", "port": "9090", "address": "", "comment": "other", "action": "accept"}
-					],
-					"total": 2
-				}`),
-			}
+						{"id": 2, "protocol": "tcp", "port": "9090", "address": "", "comment": "other", "action": "accept"},
+					},
+					"total": 2,
+				},
+			})
+		case http.MethodDelete:
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(resp)
-			return
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
 		}
-
-		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 
-	// DELETE /api/v1/firewall/rules/ - handle deletion with rule ID in path
-	mux.HandleFunc("/api/v1/firewall/rules/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/websites", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 200, "message": "ok",
+				"data": map[string]interface{}{
+					"items": []map[string]interface{}{
+						{"id": 10, "primaryDomain": "app.example.com", "type": "reverse_proxy", "status": true, "remark": "my app", "ssl": false, "createdAt": "2026-04-28"},
+						{"id": 11, "primaryDomain": "blog.example.com", "type": "static", "status": true, "remark": "blog", "ssl": true, "createdAt": "2026-04-27"},
+					},
+					"total": 2,
+				},
+			})
+		case http.MethodPost:
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 200, "message": "ok",
+				"data":  map[string]interface{}{"id": 12, "primaryDomain": "new.example.com", "type": "static", "status": true},
+			})
+		}
+	})
+
+	mux.HandleFunc("/api/v1/websites/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodDelete {
-			resp := panel1Response{
-				Code:    200,
-				Message: "success",
-				Data:    nil,
-			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(resp)
-			return
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
 		}
-		w.WriteHeader(http.StatusMethodNotAllowed)
 	})
 
-	// POST /api/v1/websites/reverse_proxy
 	mux.HandleFunc("/api/v1/websites/reverse_proxy", func(w http.ResponseWriter, r *http.Request) {
-		resp := panel1Response{
-			Code:    200,
-			Message: "success",
-			Data:    json.RawMessage(`{"id": 1}`),
+		if r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 5}})
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
 	})
 
 	return httptest.NewServer(mux)
@@ -83,152 +78,253 @@ func setup1PanelTestServer() *httptest.Server {
 
 func setup1PanelErrorServer() *httptest.Server {
 	mux := http.NewServeMux()
-
-	mux.HandleFunc("/api/v1/firewall/rules", func(w http.ResponseWriter, r *http.Request) {
-		resp := panel1Response{
-			Code:    500,
-			Message: "internal error",
-			Data:    nil,
-		}
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(map[string]interface{}{"code": 500, "message": "internal error"})
 	})
-
 	return httptest.NewServer(mux)
 }
 
 func TestNewPanel1Client(t *testing.T) {
-	p := NewPanel1Client("http://localhost:8888", "test-key")
-	if p.baseURL != "http://localhost:8888" {
-		t.Errorf("baseURL = %q, want %q", p.baseURL, "http://localhost:8888")
+	client := NewPanel1Client("http://localhost:4004", "test-key")
+	if client == nil {
+		t.Fatal("expected non-nil client")
 	}
-	if p.apiKey != "test-key" {
-		t.Errorf("apiKey = %q, want %q", p.apiKey, "test-key")
+	if client.baseURL != "http://localhost:4004" {
+		t.Errorf("expected baseURL http://localhost:4004, got %s", client.baseURL)
 	}
-	if p.httpClient == nil {
-		t.Error("httpClient should not be nil")
+	if client.apiKey != "test-key" {
+		t.Errorf("expected apiKey test-key, got %s", client.apiKey)
 	}
 }
 
 func TestPanel1Client_OpenFirewall(t *testing.T) {
 	server := setup1PanelTestServer()
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "test-api-key")
-	err := p.OpenFirewall(context.TODO(), 8080, "tcp")
-	if err != nil {
-		t.Fatalf("OpenFirewall() error = %v", err)
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.OpenFirewall(context.TODO(), 8080, "tcp"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 
 func TestPanel1Client_OpenFirewall_APIError(t *testing.T) {
 	server := setup1PanelErrorServer()
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "test-api-key")
-	err := p.OpenFirewall(context.TODO(), 8080, "tcp")
-	if err == nil {
-		t.Fatal("OpenFirewall() should return error on API failure")
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.OpenFirewall(context.TODO(), 8080, "tcp"); err == nil {
+		t.Fatal("expected error for API error response")
 	}
 }
 
 func TestPanel1Client_CloseFirewall(t *testing.T) {
 	server := setup1PanelTestServer()
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "test-api-key")
-	err := p.CloseFirewall(context.TODO(), 8080, "tcp")
-	if err != nil {
-		t.Fatalf("CloseFirewall() error = %v", err)
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.CloseFirewall(context.TODO(), 8080, "tcp"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 
 func TestPanel1Client_CloseFirewall_NoMatchingRule(t *testing.T) {
 	server := setup1PanelTestServer()
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "test-api-key")
-	// Use a port that doesn't exist in the mock data
-	err := p.CloseFirewall(context.TODO(), 9999, "tcp")
-	if err != nil {
-		t.Fatalf("CloseFirewall() with no matching rule should not error, got = %v", err)
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.CloseFirewall(context.TODO(), 9999, "tcp"); err != nil {
+		t.Fatalf("expected no error for non-matching rule, got %v", err)
 	}
 }
 
 func TestPanel1Client_CloseFirewall_ListError(t *testing.T) {
 	server := setup1PanelErrorServer()
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "test-api-key")
-	err := p.CloseFirewall(context.TODO(), 8080, "tcp")
-	if err == nil {
-		t.Fatal("CloseFirewall() should return error when list fails")
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.CloseFirewall(context.TODO(), 8080, "tcp"); err == nil {
+		t.Fatal("expected error for API error response")
 	}
 }
 
 func TestPanel1Client_CreateReverseProxy(t *testing.T) {
 	server := setup1PanelTestServer()
 	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.CreateReverseProxy(context.TODO(), "app.example.com", "http://localhost:3000", 3000); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
 
-	p := NewPanel1Client(server.URL, "test-api-key")
-	err := p.CreateReverseProxy(context.TODO(), "example.com", "http://localhost:3000", 3000)
+func TestPanel1Client_CreateReverseProxy_APIError(t *testing.T) {
+	server := setup1PanelErrorServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.CreateReverseProxy(context.TODO(), "app.example.com", "http://localhost:3000", 3000); err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}
+
+func TestPanel1Client_DeleteReverseProxy(t *testing.T) {
+	server := setup1PanelTestServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.DeleteReverseProxy(context.TODO(), "app.example.com"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestPanel1Client_DeleteReverseProxy_NotFound(t *testing.T) {
+	server := setup1PanelTestServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.DeleteReverseProxy(context.TODO(), "nonexistent.example.com"); err == nil {
+		t.Fatal("expected error for non-existent domain")
+	}
+}
+
+func TestPanel1Client_DeleteReverseProxy_APIError(t *testing.T) {
+	server := setup1PanelErrorServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if err := client.DeleteReverseProxy(context.TODO(), "app.example.com"); err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}
+
+func TestPanel1Client_CreateWebsite(t *testing.T) {
+	server := setup1PanelTestServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	info, err := client.CreateWebsite(context.TODO(), "new.example.com", "static", "test site")
 	if err != nil {
-		t.Fatalf("CreateReverseProxy() error = %v", err)
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected non-nil website info")
+	}
+	if info.PrimaryDomain != "new.example.com" {
+		t.Errorf("expected domain new.example.com, got %s", info.PrimaryDomain)
+	}
+	if info.Type != "static" {
+		t.Errorf("expected type static, got %s", info.Type)
+	}
+}
+
+func TestPanel1Client_CreateWebsite_APIError(t *testing.T) {
+	server := setup1PanelErrorServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if _, err := client.CreateWebsite(context.TODO(), "new.example.com", "static", "test site"); err == nil {
+		t.Fatal("expected error for API error response")
+	}
+}
+
+func TestPanel1Client_GetWebsiteList(t *testing.T) {
+	server := setup1PanelTestServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	websites, err := client.GetWebsiteList(context.TODO())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(websites) != 2 {
+		t.Fatalf("expected 2 websites, got %d", len(websites))
+	}
+	if websites[0].PrimaryDomain != "app.example.com" {
+		t.Errorf("expected first domain app.example.com, got %s", websites[0].PrimaryDomain)
+	}
+	if websites[0].Type != "reverse_proxy" {
+		t.Errorf("expected first type reverse_proxy, got %s", websites[0].Type)
+	}
+	if websites[1].PrimaryDomain != "blog.example.com" {
+		t.Errorf("expected second domain blog.example.com, got %s", websites[1].PrimaryDomain)
+	}
+	if !websites[1].SSL {
+		t.Error("expected second website to have SSL enabled")
+	}
+}
+
+func TestPanel1Client_GetWebsiteList_APIError(t *testing.T) {
+	server := setup1PanelErrorServer()
+	defer server.Close()
+	client := NewPanel1Client(server.URL, "test-key")
+	if _, err := client.GetWebsiteList(context.TODO()); err == nil {
+		t.Fatal("expected error for API error response")
 	}
 }
 
 func TestPanel1Client_OpenFirewall_SendsCorrectRequest(t *testing.T) {
-	var receivedMethod, receivedPath, receivedBody string
-	var receivedAuth string
-
+	var receivedMethod, receivedPath, receivedAuth string
+	var receivedBody map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedMethod = r.Method
 		receivedPath = r.URL.Path
 		receivedAuth = r.Header.Get("Authorization")
-
-		body, _ := io.ReadAll(r.Body)
-		receivedBody = string(body)
-
-		resp := panel1Response{Code: 200, Message: "success"}
+		json.NewDecoder(r.Body).Decode(&receivedBody)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1}})
 	}))
 	defer server.Close()
-
-	p := NewPanel1Client(server.URL, "my-secret-key")
-	err := p.OpenFirewall(context.TODO(), 8080, "tcp")
-	if err != nil {
-		t.Fatalf("OpenFirewall() error = %v", err)
-	}
-
+	client := NewPanel1Client(server.URL, "test-api-key")
+	_ = client.OpenFirewall(context.TODO(), 443, "tcp")
 	if receivedMethod != http.MethodPost {
-		t.Errorf("method = %q, want %q", receivedMethod, http.MethodPost)
+		t.Errorf("expected POST, got %s", receivedMethod)
 	}
 	if receivedPath != "/api/v1/firewall/rules" {
-		t.Errorf("path = %q, want %q", receivedPath, "/api/v1/firewall/rules")
+		t.Errorf("expected path /api/v1/firewall/rules, got %s", receivedPath)
 	}
-	if receivedAuth != "Bearer my-secret-key" {
-		t.Errorf("Authorization = %q, want %q", receivedAuth, "Bearer my-secret-key")
+	if receivedAuth != "Bearer test-api-key" {
+		t.Errorf("expected Authorization Bearer test-api-key, got %s", receivedAuth)
 	}
-
-	var body map[string]interface{}
-	_ = json.Unmarshal([]byte(receivedBody), &body)
-	if body["port"] != strconv.Itoa(8080) {
-		t.Errorf("port = %v, want %q", body["port"], "8080")
+	if receivedBody["port"] != "443" {
+		t.Errorf("expected port 443, got %v", receivedBody["port"])
 	}
-	if body["protocol"] != "tcp" {
-		t.Errorf("protocol = %v, want %q", body["protocol"], "tcp")
+	if receivedBody["protocol"] != "tcp" {
+		t.Errorf("expected protocol tcp, got %v", receivedBody["protocol"])
 	}
-	if body["comment"] != "deploypilot" {
-		t.Errorf("comment = %v, want %q", body["comment"], "deploypilot")
+	if receivedBody["comment"] != "deploypilot" {
+		t.Errorf("expected comment deploypilot, got %v", receivedBody["comment"])
 	}
 }
 
 func TestPanel1Client_SetHTTPClient(t *testing.T) {
-	p := NewPanel1Client("http://localhost:8888", "test-key")
-	custom := &http.Client{}
-	p.SetHTTPClient(custom)
-	if p.httpClient != custom {
-		t.Error("SetHTTPClient() did not set the client")
+	client := NewPanel1Client("http://localhost:4004", "test-key")
+	customClient := &http.Client{}
+	client.SetHTTPClient(customClient)
+	if client.httpClient != customClient {
+		t.Error("expected httpClient to be replaced")
+	}
+}
+
+func TestPanel1Client_GetInfo(t *testing.T) {
+	client := NewPanel1Client("http://localhost:4004", "test-key")
+	info := client.GetInfo()
+	if info["name"] != "1Panel" {
+		t.Errorf("expected name 1Panel, got %v", info["name"])
+	}
+	features, ok := info["features"].([]string)
+	if !ok {
+		t.Fatal("expected features to be []string")
+	}
+	if len(features) == 0 {
+		t.Error("expected non-empty features list")
+	}
+}
+
+func TestPanelProvider_DeleteReverseProxy_NilClient(t *testing.T) {
+	provider := NewPanelProvider(nil)
+	if err := provider.DeleteReverseProxy(context.TODO(), "example.com"); err != nil {
+		t.Errorf("expected nil error for nil client, got %v", err)
+	}
+}
+
+func TestPanelProvider_CreateWebsite_NilClient(t *testing.T) {
+	provider := NewPanelProvider(nil)
+	if _, err := provider.CreateWebsite(context.TODO(), "example.com", "static", "test"); err == nil {
+		t.Error("expected error for nil client")
+	}
+}
+
+func TestPanelProvider_GetWebsiteList_NilClient(t *testing.T) {
+	provider := NewPanelProvider(nil)
+	if _, err := provider.GetWebsiteList(context.TODO()); err == nil {
+		t.Error("expected error for nil client")
 	}
 }

--- a/internal/provider/server/panel_btpanel.go
+++ b/internal/provider/server/panel_btpanel.go
@@ -51,53 +51,42 @@ func (p *BTPanelClient) login(ctx context.Context) error {
 	if p.cookie != "" {
 		return nil
 	}
-
 	reqBody := map[string]interface{}{
 		"username": p.username,
 		"password": p.password,
 	}
-
 	data, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to marshal login request: %w", err)
 	}
-
 	url := p.baseURL + "/login"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		return fmt.Errorf("failed to create login request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("BT Panel login failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	// Extract cookie from response
 	for _, cookie := range resp.Cookies() {
 		if cookie.Name == "bt_user_token" {
 			p.cookie = cookie.Name + "=" + cookie.Value
 			break
 		}
 	}
-
 	if p.cookie == "" {
 		return fmt.Errorf("failed to get BT Panel auth cookie")
 	}
-
 	return nil
 }
 
 // doRequest performs an authenticated HTTP request to the BT Panel API.
 func (p *BTPanelClient) doRequest(ctx context.Context, method, path string, body interface{}) (*btPanelResponse, error) {
-	// Ensure we're logged in
 	if err := p.login(ctx); err != nil {
 		return nil, err
 	}
-
 	var reqBody io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -106,55 +95,45 @@ func (p *BTPanelClient) doRequest(ctx context.Context, method, path string, body
 		}
 		reqBody = bytes.NewReader(data)
 	}
-
 	url := p.baseURL + path
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Cookie", p.cookie)
-
 	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("BT Panel API request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-
 	var result btPanelResponse
 	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
-
 	if !result.Status {
 		return nil, fmt.Errorf("BT Panel API error: %s", result.Msg)
 	}
-
 	return &result, nil
 }
 
 // OpenFirewall opens a port via the BT Panel API.
 func (p *BTPanelClient) OpenFirewall(ctx context.Context, port int, protocol string) error {
 	slog.Info("BT Panel: opening firewall port", "port", port, "protocol", protocol)
-
 	reqBody := map[string]interface{}{
 		"port":     strconv.Itoa(port),
 		"protocol": protocol,
 		"ps":       "deploypilot",
 		"status":   "1",
 	}
-
 	_, err := p.doRequest(ctx, http.MethodPost, "/firewall/add", reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to open firewall port %d/%s: %w", port, protocol, err)
 	}
-
 	slog.Info("BT Panel: firewall port opened successfully", "port", port, "protocol", protocol)
 	return nil
 }
@@ -162,25 +141,18 @@ func (p *BTPanelClient) OpenFirewall(ctx context.Context, port int, protocol str
 // CloseFirewall closes a port via the BT Panel API.
 func (p *BTPanelClient) CloseFirewall(ctx context.Context, port int, protocol string) error {
 	slog.Info("BT Panel: closing firewall port", "port", port, "protocol", protocol)
-
-	// Step 1: List firewall rules to find the rule ID
 	resp, err := p.doRequest(ctx, http.MethodGet, "/firewall", nil)
 	if err != nil {
 		return fmt.Errorf("failed to list firewall rules: %w", err)
 	}
-
-	// Parse firewall rules
 	data, ok := resp.Data.(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("invalid firewall rules data format")
 	}
-
 	rules, ok := data["list"].([]interface{})
 	if !ok {
 		return fmt.Errorf("invalid firewall rules list format")
 	}
-
-	// Find the matching rule
 	portStr := strconv.Itoa(port)
 	var ruleID string
 	for _, rule := range rules {
@@ -188,7 +160,6 @@ func (p *BTPanelClient) CloseFirewall(ctx context.Context, port int, protocol st
 		if !ok {
 			continue
 		}
-
 		if ruleMap["port"] == portStr && ruleMap["protocol"] == protocol && ruleMap["ps"] == "deploypilot" {
 			if id, ok := ruleMap["id"].(string); ok {
 				ruleID = id
@@ -196,22 +167,17 @@ func (p *BTPanelClient) CloseFirewall(ctx context.Context, port int, protocol st
 			}
 		}
 	}
-
 	if ruleID == "" {
 		slog.Warn("BT Panel: no matching firewall rule found to close", "port", port, "protocol", protocol)
 		return nil
 	}
-
-	// Step 2: Delete the rule
 	reqBody := map[string]interface{}{
 		"id": ruleID,
 	}
-
 	_, err = p.doRequest(ctx, http.MethodPost, "/firewall/del", reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to close firewall port %d/%s: %w", port, protocol, err)
 	}
-
 	slog.Info("BT Panel: firewall port closed successfully", "port", port, "protocol", protocol, "ruleID", ruleID)
 	return nil
 }
@@ -227,19 +193,145 @@ func (p *BTPanelClient) GetInfo() map[string]interface{} {
 // CreateReverseProxy creates a reverse proxy via the BT Panel API.
 func (p *BTPanelClient) CreateReverseProxy(ctx context.Context, domain, targetURL string, port int) error {
 	slog.Info("BT Panel: creating reverse proxy", "domain", domain, "targetURL", targetURL, "port", port)
-
 	reqBody := map[string]interface{}{
 		"domain":   domain,
 		"upstream": targetURL,
 		"type":     "reverse_proxy",
 		"status":   "1",
 	}
-
 	_, err := p.doRequest(ctx, http.MethodPost, "/site/add", reqBody)
 	if err != nil {
 		return fmt.Errorf("failed to create reverse proxy for %s: %w", domain, err)
 	}
-
 	slog.Info("BT Panel: reverse proxy created successfully", "domain", domain)
 	return nil
+}
+
+// DeleteReverseProxy deletes a reverse proxy website via the BT Panel API.
+func (p *BTPanelClient) DeleteReverseProxy(ctx context.Context, domain string) error {
+	slog.Info("BT Panel: deleting reverse proxy", "domain", domain)
+	resp, err := p.doRequest(ctx, http.MethodGet, "/site/list", nil)
+	if err != nil {
+		return fmt.Errorf("failed to list sites: %w", err)
+	}
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid site list data format")
+	}
+	sites, ok := data["list"].([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid site list format")
+	}
+	var siteID string
+	for _, s := range sites {
+		siteMap, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if siteMap["domain"] == domain {
+			if id, ok := siteMap["id"]; ok {
+				switch v := id.(type) {
+				case string:
+					siteID = v
+				case float64:
+					siteID = strconv.Itoa(int(v))
+				}
+				break
+			}
+		}
+	}
+	if siteID == "" {
+		slog.Warn("BT Panel: no matching site found to delete", "domain", domain)
+		return fmt.Errorf("site not found for domain: %s", domain)
+	}
+	reqBody := map[string]interface{}{
+		"id":      siteID,
+		"webname": domain,
+	}
+	_, err = p.doRequest(ctx, http.MethodPost, "/site/delete", reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to delete site for %s: %w", domain, err)
+	}
+	slog.Info("BT Panel: reverse proxy deleted successfully", "domain", domain, "siteID", siteID)
+	return nil
+}
+
+// CreateWebsite creates a new website via the BT Panel API.
+func (p *BTPanelClient) CreateWebsite(ctx context.Context, domain, websiteType, remark string) (*WebsiteInfo, error) {
+	slog.Info("BT Panel: creating website", "domain", domain, "type", websiteType)
+	reqBody := map[string]interface{}{
+		"domain": domain,
+		"type":   websiteType,
+		"ps":     remark,
+		"status": "1",
+	}
+	_, err := p.doRequest(ctx, http.MethodPost, "/site/add", reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create website for %s: %w", domain, err)
+	}
+	slog.Info("BT Panel: website created successfully", "domain", domain)
+	return &WebsiteInfo{
+		PrimaryDomain: domain,
+		Type:          websiteType,
+		Remark:        remark,
+		Status:        true,
+	}, nil
+}
+
+// GetWebsiteList returns a list of websites managed by BT Panel.
+func (p *BTPanelClient) GetWebsiteList(ctx context.Context) ([]WebsiteInfo, error) {
+	slog.Info("BT Panel: listing websites")
+	resp, err := p.doRequest(ctx, http.MethodGet, "/site/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list websites: %w", err)
+	}
+	data, ok := resp.Data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid website list data format")
+	}
+	sites, ok := data["list"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid website list format")
+	}
+	websites := make([]WebsiteInfo, 0, len(sites))
+	for _, s := range sites {
+		siteMap, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var siteID string
+		if id, ok := siteMap["id"]; ok {
+			switch v := id.(type) {
+			case string:
+				siteID = v
+			case float64:
+				siteID = strconv.Itoa(int(v))
+			}
+		}
+		var domain string
+		if d, ok := siteMap["domain"].(string); ok {
+			domain = d
+		}
+		var siteType string
+		if t, ok := siteMap["type"].(string); ok {
+			siteType = t
+		}
+		var remark string
+		if ps, ok := siteMap["ps"].(string); ok {
+			remark = ps
+		}
+		var status bool
+		if st, ok := siteMap["status"].(bool); ok {
+			status = st
+		}
+		websites = append(websites, WebsiteInfo{
+			ID:            siteID,
+			PrimaryDomain: domain,
+			Type:          siteType,
+			Status:        status,
+			Remark:        remark,
+		})
+	}
+	slog.Info("BT Panel: website list retrieved", "count", len(websites))
+	return websites, nil
 }

--- a/internal/provider/server/panel_test.go
+++ b/internal/provider/server/panel_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -49,84 +50,86 @@ func (m *mockPanelClient) GetInfo() map[string]interface{} {
 
 // setupPanelProviderTestServer creates a mock HTTP server that handles both 1Panel and BT-Panel API calls.
 func setupPanelProviderTestServer() *httptest.Server {
-	mux := http.NewServeMux()
-
-	// 1Panel endpoints
-	mux.HandleFunc("/api/v1/firewall/rules", func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch r.Method {
-		case http.MethodGet:
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"code": 200, "message": "ok",
-				"data": map[string]interface{}{
-					"items": []map[string]interface{}{
-						{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
+		path := r.URL.Path
+
+		switch {
+		// 1Panel endpoints
+		case path == "/api/v1/firewall/rules":
+			switch r.Method {
+			case http.MethodGet:
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"code": 200, "message": "ok",
+					"data": map[string]interface{}{
+						"items": []map[string]interface{}{
+							{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
+						},
+						"total": 1,
 					},
-					"total": 1,
-				},
-			})
-		default:
-			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1}})
-		}
-	})
-	mux.HandleFunc("/api/v1/websites/reverse_proxy", func(w http.ResponseWriter, r *http.Request) {
-		resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"id": 1}`)}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/api/v1/websites", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"items":[],"total":0}`)}
-			w.Header().Set("Content-Type", "application/json")
+				})
+			default:
+				json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1}})
+			}
+
+		case path == "/api/v1/websites/reverse_proxy":
+			resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"id": 1}`)}
 			json.NewEncoder(w).Encode(resp)
-		}
-	})
 
-	// BT-Panel endpoints
-	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Set-Cookie", "bt_user_token=test-token; Path=/")
-		resp := btPanelResponse{Status: true, Msg: "Login successful"}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/firewall", func(w http.ResponseWriter, r *http.Request) {
-		resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
-			"list": []map[string]interface{}{
-				{
-					"id":       "1",
-					"port":     "8080",
-					"protocol": "tcp",
-					"ps":       "deploypilot",
+		case path == "/api/v1/websites":
+			if r.Method == http.MethodGet {
+				resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"items":[],"total":0}`)}
+				json.NewEncoder(w).Encode(resp)
+			}
+
+		// BT-Panel endpoints
+		case path == "/login":
+			w.Header().Set("Set-Cookie", "bt_user_token=test-token; Path=/")
+			resp := btPanelResponse{Status: true, Msg: "Login successful"}
+			json.NewEncoder(w).Encode(resp)
+
+		case path == "/firewall":
+			resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
+				"list": []map[string]interface{}{
+					{
+						"id":       "1",
+						"port":     "8080",
+						"protocol": "tcp",
+						"ps":       "deploypilot",
+					},
 				},
-			},
-		}}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/firewall/add", func(w http.ResponseWriter, r *http.Request) {
-		resp := btPanelResponse{Status: true, Msg: "Firewall rule added"}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/firewall/del", func(w http.ResponseWriter, r *http.Request) {
-		resp := btPanelResponse{Status: true, Msg: "Firewall rule deleted"}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/site/add", func(w http.ResponseWriter, r *http.Request) {
-		resp := btPanelResponse{Status: true, Msg: "Site added"}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
-	mux.HandleFunc("/site/list", func(w http.ResponseWriter, r *http.Request) {
-		resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
-			"list": []interface{}{},
-		}}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
-	})
+			}}
+			json.NewEncoder(w).Encode(resp)
 
-	return httptest.NewServer(mux)
+		case path == "/firewall/add":
+			resp := btPanelResponse{Status: true, Msg: "Firewall rule added"}
+			json.NewEncoder(w).Encode(resp)
+
+		case path == "/firewall/del":
+			resp := btPanelResponse{Status: true, Msg: "Firewall rule deleted"}
+			json.NewEncoder(w).Encode(resp)
+
+		case path == "/site/add":
+			resp := btPanelResponse{Status: true, Msg: "Site added"}
+			json.NewEncoder(w).Encode(resp)
+
+		case path == "/site/list":
+			resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
+				"list": []interface{}{},
+			}}
+			json.NewEncoder(w).Encode(resp)
+
+		case path == "/site/delete":
+			resp := btPanelResponse{Status: true, Msg: "Site deleted"}
+			json.NewEncoder(w).Encode(resp)
+
+		case strings.HasPrefix(path, "/api/v1/websites/") && r.Method == http.MethodDelete:
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
 }
 
 func TestDetectPanel_None(t *testing.T) {

--- a/internal/provider/server/panel_test.go
+++ b/internal/provider/server/panel_test.go
@@ -33,6 +33,13 @@ type mockPanelClient struct {
 func (m *mockPanelClient) OpenFirewall(_ context.Context, _ int, _ string) error { return nil }
 func (m *mockPanelClient) CloseFirewall(_ context.Context, _ int, _ string) error { return nil }
 func (m *mockPanelClient) CreateReverseProxy(_ context.Context, _, _ string, _ int) error { return nil }
+func (m *mockPanelClient) DeleteReverseProxy(_ context.Context, _ string) error             { return nil }
+func (m *mockPanelClient) CreateWebsite(_ context.Context, _, _, _ string) (*WebsiteInfo, error) {
+	return &WebsiteInfo{PrimaryDomain: "mock.local", Type: "static", Status: true}, nil
+}
+func (m *mockPanelClient) GetWebsiteList(_ context.Context) ([]WebsiteInfo, error) {
+	return []WebsiteInfo{{PrimaryDomain: "mock.local", Type: "static", Status: true}}, nil
+}
 func (m *mockPanelClient) GetInfo() map[string]interface{} {
 	return map[string]interface{}{
 		"name":     m.name,
@@ -55,10 +62,16 @@ func setupPanelProviderTestServer() *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
+	mux.HandleFunc("/api/v1/websites", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"items":[],"total":0}`)}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(resp)
+		}
+	})
 
 	// BT-Panel endpoints
 	mux.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
-		// Set auth cookie
 		w.Header().Set("Set-Cookie", "bt_user_token=test-token; Path=/")
 		resp := btPanelResponse{Status: true, Msg: "Login successful"}
 		w.Header().Set("Content-Type", "application/json")
@@ -68,10 +81,10 @@ func setupPanelProviderTestServer() *httptest.Server {
 		resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
 			"list": []map[string]interface{}{
 				{
-					"id": "1",
-					"port": "8080",
+					"id":       "1",
+					"port":     "8080",
 					"protocol": "tcp",
-					"ps": "deploypilot",
+					"ps":       "deploypilot",
 				},
 			},
 		}}
@@ -93,6 +106,13 @@ func setupPanelProviderTestServer() *httptest.Server {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	})
+	mux.HandleFunc("/site/list", func(w http.ResponseWriter, r *http.Request) {
+		resp := btPanelResponse{Status: true, Msg: "ok", Data: map[string]interface{}{
+			"list": []interface{}{},
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
 
 	return httptest.NewServer(mux)
 }
@@ -105,7 +125,6 @@ func TestDetectPanel_None(t *testing.T) {
 			"ps aux | grep -E '1panel|BT-Panel|bt' | grep -v grep || true": "",
 		},
 	}
-
 	client := DetectPanel(context.TODO(), executor)
 	if client != nil {
 		t.Errorf("DetectPanel() = %v, want nil", client)
@@ -118,7 +137,6 @@ func TestDetectPanel_1Panel(t *testing.T) {
 			"systemctl is-active 1panel 2>/dev/null || echo 'inactive'": "active",
 		},
 	}
-
 	client := DetectPanel(context.TODO(), executor)
 	if client == nil {
 		t.Fatal("DetectPanel() returned nil, want PanelClient")
@@ -136,7 +154,6 @@ func TestDetectPanel_BTPanel(t *testing.T) {
 			"systemctl is-active bt 2>/dev/null || echo 'inactive'":     "active",
 		},
 	}
-
 	client := DetectPanel(context.TODO(), executor)
 	if client == nil {
 		t.Fatal("DetectPanel() returned nil, want PanelClient")
@@ -183,7 +200,6 @@ func TestGetPanelInfo_WithClient(t *testing.T) {
 func TestOpenFirewall_1Panel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewPanel1Client(server.URL, "test-key")
 	p := NewPanelProvider(client)
 	err := p.OpenFirewall(context.TODO(), 8080, "tcp")
@@ -195,7 +211,6 @@ func TestOpenFirewall_1Panel(t *testing.T) {
 func TestOpenFirewall_BTPanel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewBTPanelClient(server.URL, "admin", "test-key")
 	p := NewPanelProvider(client)
 	err := p.OpenFirewall(context.TODO(), 8080, "tcp")
@@ -215,7 +230,6 @@ func TestOpenFirewall_None(t *testing.T) {
 func TestCloseFirewall_1Panel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewPanel1Client(server.URL, "test-key")
 	p := NewPanelProvider(client)
 	err := p.CloseFirewall(context.TODO(), 8080, "tcp")
@@ -227,7 +241,6 @@ func TestCloseFirewall_1Panel(t *testing.T) {
 func TestCloseFirewall_BTPanel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewBTPanelClient(server.URL, "admin", "test-key")
 	p := NewPanelProvider(client)
 	err := p.CloseFirewall(context.TODO(), 8080, "tcp")
@@ -247,7 +260,6 @@ func TestCloseFirewall_None(t *testing.T) {
 func TestCreateReverseProxy_1Panel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewPanel1Client(server.URL, "test-key")
 	p := NewPanelProvider(client)
 	err := p.CreateReverseProxy(context.TODO(), "example.com", "http://localhost:3000", 3000)
@@ -259,7 +271,6 @@ func TestCreateReverseProxy_1Panel(t *testing.T) {
 func TestCreateReverseProxy_BTPanel(t *testing.T) {
 	server := setupPanelProviderTestServer()
 	defer server.Close()
-
 	client := NewBTPanelClient(server.URL, "admin", "test-key")
 	p := NewPanelProvider(client)
 	err := p.CreateReverseProxy(context.TODO(), "example.com", "http://localhost:3000", 3000)
@@ -306,7 +317,6 @@ func TestDetectPanel_ProcessFallback(t *testing.T) {
 			"ps aux | grep -E '1panel|BT-Panel|bt' | grep -v grep || true": "root  1234  1panel serve",
 		},
 	}
-
 	client := DetectPanel(context.TODO(), executor)
 	if client == nil {
 		t.Fatal("DetectPanel() returned nil (process fallback)")

--- a/internal/provider/server/panel_test.go
+++ b/internal/provider/server/panel_test.go
@@ -53,9 +53,21 @@ func setupPanelProviderTestServer() *httptest.Server {
 
 	// 1Panel endpoints
 	mux.HandleFunc("/api/v1/firewall/rules", func(w http.ResponseWriter, r *http.Request) {
-		resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"id": 1}`)}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"code": 200, "message": "ok",
+				"data": map[string]interface{}{
+					"items": []map[string]interface{}{
+						{"id": 1, "protocol": "tcp", "port": "8080", "address": "", "comment": "deploypilot", "action": "accept"},
+					},
+					"total": 1,
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1}})
+		}
 	})
 	mux.HandleFunc("/api/v1/websites/reverse_proxy", func(w http.ResponseWriter, r *http.Request) {
 		resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"id": 1}`)}

--- a/internal/provider/server/panel_test.go
+++ b/internal/provider/server/panel_test.go
@@ -72,6 +72,9 @@ func setupPanelProviderTestServer() *httptest.Server {
 				json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok", "data": map[string]interface{}{"id": 1}})
 			}
 
+		case r.Method == http.MethodDelete && strings.HasPrefix(path, "/api/v1/firewall/rules/"):
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
+
 		case path == "/api/v1/websites/reverse_proxy":
 			resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"id": 1}`)}
 			json.NewEncoder(w).Encode(resp)
@@ -81,6 +84,9 @@ func setupPanelProviderTestServer() *httptest.Server {
 				resp := panel1Response{Code: 200, Message: "success", Data: json.RawMessage(`{"items":[],"total":0}`)}
 				json.NewEncoder(w).Encode(resp)
 			}
+
+		case r.Method == http.MethodDelete && strings.HasPrefix(path, "/api/v1/websites/"):
+			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
 
 		// BT-Panel endpoints
 		case path == "/login":
@@ -122,9 +128,6 @@ func setupPanelProviderTestServer() *httptest.Server {
 		case path == "/site/delete":
 			resp := btPanelResponse{Status: true, Msg: "Site deleted"}
 			json.NewEncoder(w).Encode(resp)
-
-		case strings.HasPrefix(path, "/api/v1/websites/") && r.Method == http.MethodDelete:
-			json.NewEncoder(w).Encode(map[string]interface{}{"code": 200, "message": "ok"})
 
 		default:
 			http.NotFound(w, r)


### PR DESCRIPTION
## Summary

Extend `PanelClient` interface with three new methods for enhanced 1Panel/BT-Panel integration:

### New Methods
- **`DeleteReverseProxy(ctx, domain)`** — Look up website by domain + type filter, then delete by ID
- **`CreateWebsite(ctx, domain, websiteType, remark)`** — Create a new website via panel API
- **`GetWebsiteList(ctx)`** — List all managed websites with unified `WebsiteInfo` struct

### Changes
| File | Change |
|------|--------|
| `panel.go` | Extended `PanelClient` interface (3 new methods), added `WebsiteInfo` struct, added `PanelProvider` wrappers |
| `panel_1panel.go` | Implemented `DeleteReverseProxy`, `CreateWebsite`, `GetWebsiteList` for 1Panel |
| `panel_btpanel.go` | Implemented `DeleteReverseProxy`, `CreateWebsite`, `GetWebsiteList` for BT-Panel |
| `panel_1panel_test.go` | Added 10 new test cases (20 total), covering success/error/nil-client paths |

### Design Decisions
- `DeleteReverseProxy` uses list-then-delete pattern (same as `CloseFirewall`) to resolve website ID from domain
- `WebsiteInfo` is a shared struct with `interface{}` ID to accommodate different ID types across panels
- `CreateWebsite` gracefully handles unparseable API responses by returning a basic info object
- All new `PanelProvider` methods follow existing nil-safety patterns

Closes #8