### PR TITLE
feat(mcp): add session context memory and list_recent_operations tool

### DIFF
--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -11,6 +11,8 @@ type ContextEntry struct {
 	Tool     string    `json:"tool"`
 	Args     string    `json:"args,omitempty"`
 	Result   string    `json:"result,omitempty"`
+	Success  bool      `json:"success"`
+	Error    string    `json:"error,omitempty"`
 	Duration string    `json:"duration,omitempty"`
 	Time     time.Time `json:"time"`
 }
@@ -30,11 +32,16 @@ type SessionContext struct {
 func NewSessionContext(sessionID string) *SessionContext {
 	return &SessionContext{
 		entries:    list.New(),
-		maxEntries: 20,
+		maxEntries: 50,
 		maxMemory:  10 * 1024 * 1024, // 10MB
 		lastAccess: time.Now(),
 		sessionID:  sessionID,
 	}
+}
+
+// entrySize computes the approximate byte size of a ContextEntry.
+func entrySize(e ContextEntry) int64 {
+	return int64(len(e.Tool) + len(e.Args) + len(e.Result) + len(e.Error) + len(e.Duration))
 }
 
 // AddEntry adds an operation to the context history.
@@ -48,26 +55,26 @@ func (sc *SessionContext) AddEntry(entry ContextEntry) {
 	for sc.entries.Len() >= sc.maxEntries {
 		if front := sc.entries.Front(); front != nil {
 			if e, ok := front.Value.(ContextEntry); ok {
-				sc.currentSize -= int64(len(e.Tool) + len(e.Args) + len(e.Result) + len(e.Duration))
+				sc.currentSize -= entrySize(e)
 			}
 			sc.entries.Remove(front)
 		}
 	}
 
-	entrySize := int64(len(entry.Tool) + len(entry.Args) + len(entry.Result) + len(entry.Duration))
+	es := entrySize(entry)
 
 	// Evict for memory too
-	for sc.currentSize+entrySize > sc.maxMemory && sc.entries.Len() > 0 {
+	for sc.currentSize+es > sc.maxMemory && sc.entries.Len() > 0 {
 		if front := sc.entries.Front(); front != nil {
 			if e, ok := front.Value.(ContextEntry); ok {
-				sc.currentSize -= int64(len(e.Tool) + len(e.Args) + len(e.Result) + len(e.Duration))
+				sc.currentSize -= entrySize(e)
 			}
 			sc.entries.Remove(front)
 		}
 	}
 
 	sc.entries.PushBack(entry)
-	sc.currentSize += entrySize
+	sc.currentSize += es
 }
 
 // GetEntries returns all entries (most recent last).

--- a/internal/mcp/context_test.go
+++ b/internal/mcp/context_test.go
@@ -14,8 +14,8 @@ func TestNewSessionContext(t *testing.T) {
 	if sc.sessionID != "test-session" {
 		t.Errorf("sessionID = %q, want %q", sc.sessionID, "test-session")
 	}
-	if sc.maxEntries != 20 {
-		t.Errorf("maxEntries = %d, want 20", sc.maxEntries)
+	if sc.maxEntries != 50 {
+		t.Errorf("maxEntries = %d, want 50", sc.maxEntries)
 	}
 	if sc.maxMemory != 10*1024*1024 {
 		t.Errorf("maxMemory = %d, want %d", sc.maxMemory, 10*1024*1024)
@@ -100,8 +100,8 @@ func TestGetSummary(t *testing.T) {
 	if summary["entries"] != 2 {
 		t.Errorf("summary[entries] = %v, want 2", summary["entries"])
 	}
-	if summary["max_entries"] != 20 {
-		t.Errorf("summary[max_entries] = %v, want 20", summary["max_entries"])
+	if summary["max_entries"] != 50 {
+		t.Errorf("summary[max_entries] = %v, want 50", summary["max_entries"])
 	}
 }
 

--- a/internal/mcp/handler_system.go
+++ b/internal/mcp/handler_system.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
 func handleCheckSystemUpdate(ctx context.Context, d SystemService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	update, err := d.CheckSystemUpdate(ctx)
 	if err != nil {
@@ -15,17 +17,43 @@ func handleCheckSystemUpdate(ctx context.Context, d SystemService, request mcp.C
 	data, _ := json.MarshalIndent(result, "", "  ")
 	return mcp.NewToolResultText(string(data)), nil
 }
+
 func handleGetContext(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	sessionID := "default" // In production, extract from session
+	sessionID := "default"
 	session := contextManager.GetOrCreateSession(sessionID)
 	entries := session.GetEntries()
 	summary := session.GetSummary()
 
-	result := fmt.Sprintf("Session: %s\nEntries: %d\nMemory: %d bytes\nLast access: %s\n\nRecent operations:\n",
-		summary["session_id"], summary["entries"], summary["memory_usage"], summary["last_access"])
-	for i, e := range entries {
-		result += fmt.Sprintf("%d. [%s] %s (%s)\n", i+1, e.Time.Format("15:04:05"), e.Tool, e.Duration)
+	type opEntry struct {
+		Tool     string `json:"tool"`
+		Success  bool   `json:"success"`
+		Error    string `json:"error,omitempty"`
+		Duration string `json:"duration,omitempty"`
+		Time     string `json:"time"`
 	}
 
-	return mcp.NewToolResultText(result), nil
+	ops := make([]opEntry, 0, len(entries))
+	for _, e := range entries {
+		ops = append(ops, opEntry{
+			Tool:     e.Tool,
+			Success:  e.Success,
+			Error:    e.Error,
+			Duration: e.Duration,
+			Time:     e.Time.Format("15:04:05"),
+		})
+	}
+
+	result := map[string]interface{}{
+		"session_id":   summary["session_id"],
+		"total_ops":    len(entries),
+		"memory_usage": summary["memory_usage"],
+		"last_access":  fmt.Sprintf("%v", summary["last_access"]),
+		"operations":   ops,
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
 }

--- a/internal/mcp/permissions.go
+++ b/internal/mcp/permissions.go
@@ -13,6 +13,7 @@ var ToolPermissions = map[string]int{
 	"query_metric_history": 1, "query_alert_history": 1,
 	"get_ci_build_status": 1, "list_ssl_certificates": 1,
 	"get_context": 1, "detect_panel": 1,
+	"list_recent_operations": 1,
 	"list_clusters": 1, "k8s_list_deployments": 1, "k8s_get_pods": 1,
 	// Dev-level (operations)
 	"deploy_app": 2, "create_app": 2, "update_app": 2,
@@ -50,6 +51,7 @@ var ToolPermissions = map[string]int{
 	"delete_scheduled_task": 3,
 	// Owner-level (system)
 	"update_user_role": 4, "delete_user": 4,
+	"clear_context": 2,
 }
 
 // RoleLevels maps role names to numeric levels.

--- a/internal/mcp/register_context.go
+++ b/internal/mcp/register_context.go
@@ -1,0 +1,117 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// registerContextTools registers session context and operation history tools.
+func registerContextTools(s *server.MCPServer) {
+	listOpsTool := mcp.NewTool("list_recent_operations",
+		mcp.WithDescription("List recent MCP operations in the current session. Returns operation history with tool name, arguments, result status, and timing. Useful for understanding what actions have been taken and providing context for follow-up commands like rollback."),
+		mcp.WithString("tool_filter", mcp.Description("Optional filter: only show operations for this tool name (e.g., 'deploy_app', 'rollback_app'). If empty, shows all operations.")),
+		mcp.WithNumber("limit", mcp.Description("Maximum number of operations to return (default: 10, max: 50).")),
+	)
+	s.AddTool(listOpsTool, withPermissionCheck("list_recent_operations", withValidation("list_recent_operations", listOpsTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleListRecentOperations(request)
+	})))
+
+	clearContextTool := mcp.NewTool("clear_context",
+		mcp.WithDescription("Clear the current MCP session's operation history. Useful for starting fresh in a long conversation."),
+	)
+	s.AddTool(clearContextTool, withPermissionCheck("clear_context", withValidation("clear_context", clearContextTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleClearContext(request)
+	})))
+}
+
+// handleListRecentOperations returns recent operations from the session context.
+func handleListRecentOperations(request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sessionID := "default"
+	session := contextManager.GetOrCreateSession(sessionID)
+	entries := session.GetEntries()
+
+	// Apply optional tool filter
+	toolFilter := request.GetString("tool_filter", "")
+	if toolFilter != "" {
+		filtered := make([]ContextEntry, 0)
+		for _, e := range entries {
+			if e.Tool == toolFilter {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	// Apply limit (default 10, max 50)
+	limit := 10
+	if limitVal := request.GetString("limit", ""); limitVal != "" {
+		if n, err := fmt.Sscanf(limitVal, "%d", &limit); err == nil && n == 1 {
+			if limit > 50 {
+				limit = 50
+			}
+			if limit < 1 {
+				limit = 1
+			}
+		}
+	}
+
+	// Return most recent first (reverse order)
+	start := len(entries) - limit
+	if start < 0 {
+		start = 0
+	}
+	recent := make([]ContextEntry, 0, len(entries)-start)
+	for i := len(entries) - 1; i >= start; i-- {
+		recent = append(recent, entries[i])
+	}
+
+	// Build response
+	type operationEntry struct {
+		Index    int       `json:"index"`
+		Tool     string    `json:"tool"`
+		Args     string    `json:"args,omitempty"`
+		Success  bool      `json:"success"`
+		Error    string    `json:"error,omitempty"`
+		Duration string    `json:"duration,omitempty"`
+		Time     time.Time `json:"time"`
+	}
+
+	ops := make([]operationEntry, 0, len(recent))
+	for i, e := range recent {
+		ops = append(ops, operationEntry{
+			Index:    len(recent) - i,
+			Tool:     e.Tool,
+			Args:     e.Args,
+			Success:  e.Success,
+			Error:    e.Error,
+			Duration: e.Duration,
+			Time:     e.Time,
+		})
+	}
+
+	result := map[string]interface{}{
+		"total":    len(entries),
+		"returned": len(ops),
+		"filter":   toolFilter,
+		"operations": ops,
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+// handleClearContext clears the current session's operation history.
+func handleClearContext(_ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	sessionID := "default"
+	session := contextManager.GetOrCreateSession(sessionID)
+	session.Clear()
+	return mcp.NewToolResultText("Session context cleared. Operation history has been reset."), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -26,9 +28,9 @@ func RoleFromContext(ctx context.Context) string {
 	return ""
 }
 
-// withPermissionCheck wraps a tool handler with a permission check.
-// If the user's role (from context) does not meet the minimum requirement,
-// a permission denied error is returned.
+// withPermissionCheck wraps a tool handler with a permission check and
+// automatic operation history recording. Each tool invocation is recorded
+// in the session context for later retrieval via list_recent_operations.
 func withPermissionCheck(toolName string, handler server.ToolHandlerFunc) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		userRole := RoleFromContext(ctx)
@@ -37,8 +39,76 @@ func withPermissionCheck(toolName string, handler server.ToolHandlerFunc) server
 			slog.Warn("permission denied for tool", "tool", toolName, "role", userRole, "required", RequiredRoleName(required))
 			return mcp.NewToolResultError(fmt.Sprintf("permission denied: %s requires role %s or higher, current role: %s", toolName, RequiredRoleName(required), userRole)), nil
 		}
-		return handler(ctx, request)
+
+		// Record operation start time
+		start := time.Now()
+
+		// Extract arguments as JSON string for history
+		args := ""
+		if params := request.Params; params != nil && len(params.Arguments) > 0 {
+			if argBytes, err := json.Marshal(params.Arguments); err == nil {
+				args = string(argBytes)
+			}
+		}
+
+		// Execute the actual handler
+		result, err := handler(ctx, request)
+
+		// Compute duration
+		duration := time.Since(start)
+
+		// Record the operation in session context
+		recordOperation(toolName, args, result, err, duration)
+
+		return result, err
 	}
+}
+
+// recordOperation adds an operation entry to the session context.
+func recordOperation(toolName, args string, result *mcp.CallToolResult, err error, duration time.Duration) {
+	// Skip recording for context management tools to avoid noise
+	switch toolName {
+	case "list_recent_operations", "clear_context", "get_context":
+		return
+	}
+
+	sessionID := "default"
+	session := contextManager.GetOrCreateSession(sessionID)
+
+	entry := ContextEntry{
+		Tool:     toolName,
+		Args:     args,
+		Duration: duration.Round(time.Millisecond).String(),
+		Time:     time.Now(),
+		Success:  err == nil,
+	}
+
+	if err != nil {
+		entry.Error = err.Error()
+	}
+
+	if result != nil && result.IsError {
+		entry.Success = false
+		// Extract error text from result
+		if content := result.Content; len(content) > 0 {
+			if textContent, ok := content[0].(mcp.TextContent); ok {
+				entry.Error = textContent.Text
+			}
+		}
+	}
+
+	// Truncate result to avoid excessive memory usage
+	if result != nil && len(result.Content) > 0 {
+		if textContent, ok := result.Content[0].(mcp.TextContent); ok {
+			resultText := textContent.Text
+			if len(resultText) > 500 {
+				resultText = resultText[:500] + "..."
+			}
+			entry.Result = resultText
+		}
+	}
+
+	session.AddEntry(entry)
 }
 
 // NewServer creates a new MCP server with deploy tools registered.
@@ -68,6 +138,7 @@ func NewServer(deployer Deployer) *server.MCPServer {
 	registerSystemTools(s, deployer)
 	registerPortForwardTools(s, deployer)
 	registerSchedulerTools(s, deployer)
+	registerContextTools(s)
 
 	return s
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -45,8 +45,8 @@ func withPermissionCheck(toolName string, handler server.ToolHandlerFunc) server
 
 		// Extract arguments as JSON string for history
 		args := ""
-		if params := request.Params; params != nil && len(params.Arguments) > 0 {
-			if argBytes, err := json.Marshal(params.Arguments); err == nil {
+		if argMap, ok := request.Params.Arguments.(map[string]any); ok && len(argMap) > 0 {
+			if argBytes, err := json.Marshal(argMap); err == nil {
 				args = string(argBytes)
 			}
 		}
@@ -89,7 +89,6 @@ func recordOperation(toolName, args string, result *mcp.CallToolResult, err erro
 
 	if result != nil && result.IsError {
 		entry.Success = false
-		// Extract error text from result
 		if content := result.Content; len(content) > 0 {
 			if textContent, ok := content[0].(mcp.TextContent); ok {
 				entry.Error = textContent.Text

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2743,8 +2743,8 @@ func TestHandleGetContext(t *testing.T) {
 		t.Errorf("handleGetContext should not return error, got: %v", result)
 	}
 	text := result.Content[0].(mcp.TextContent).Text
-	if !strings.Contains(text, "Session:") {
-		t.Errorf("expected 'Session:' in output, got: %s", text)
+	if !strings.Contains(text, "session_id") {
+		t.Errorf("expected 'session_id' in output, got: %s", text)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements **#9** — MCP session context memory for operation history.

## Changes

### New MCP Tools
- **`list_recent_operations`** — Returns recent tool invocations in the current session with tool name, arguments, success/error status, duration, and timestamp. Supports `tool_filter` (e.g., `deploy_app`) and `limit` (default 10, max 50) parameters.
- **`clear_context`** — Resets the current session's operation history.

### Auto-Recording Middleware
- `withPermissionCheck` now automatically records every tool invocation to the session context
- Records: tool name, arguments (JSON), success/error status, result preview (truncated to 500 chars), duration
- Skips recording for context management tools (`list_recent_operations`, `clear_context`, `get_context`) to avoid noise

### Enhanced Session Context
- `ContextEntry` gains `Success bool` and `Error string` fields
- `maxEntries` increased from 20 → 50 for richer history
- `get_context` tool now returns success/error status per operation

### RBAC
- `list_recent_operations`: level 1 (all roles)
- `clear_context`: level 2 (viewer+)

## Test Plan
- [x] Unit tests for `SessionContext` updated (maxEntries 50)
- [x] Existing test suite passes
- [ ] CI checks pass

Closes #9