### PR TITLE
feat(credential): enhance vault with HKDF key derivation and audit logging

### DIFF
--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -322,7 +322,7 @@ func TestCreateCredential_WithUserID_Cov(t *testing.T) {
 	bridge := createTestBridge(t, db)
 
 	r := gin.New()
-	r.POST("/api/v1/credentials", CreateCredential(bridge))
+	r.POST("/api/v1/credentials", CreateCredential(bridge, nil))
 
 	body, _ := json.Marshal(map[string]interface{}{
 		"name":  "test-cred-cov",
@@ -1171,7 +1171,7 @@ func TestCreateCredential_MissingFields(t *testing.T) {
 
 	bridge := createTestBridge(t, db)
 	r := gin.New()
-	r.POST("/api/v1/credentials", CreateCredential(bridge))
+	r.POST("/api/v1/credentials", CreateCredential(bridge, nil))
 
 	// Missing type and value
 	body, _ := json.Marshal(map[string]string{"name": "test"})
@@ -1192,7 +1192,7 @@ func TestUpdateCredential_NotFound(t *testing.T) {
 
 	bridge := createTestBridge(t, db)
 	r := gin.New()
-	r.PUT("/api/v1/credentials/:id", UpdateCredential(bridge))
+	r.PUT("/api/v1/credentials/:id", UpdateCredential(bridge, nil))
 
 	body, _ := json.Marshal(map[string]string{"value": "new-val"})
 	req, _ := http.NewRequest("PUT", "/api/v1/credentials/nonexistent", bytes.NewBuffer(body))
@@ -1985,7 +1985,7 @@ func TestCreateCredential_WithCustomTenant(t *testing.T) {
 
 	bridge := createTestBridge(t, db)
 	r := gin.New()
-	r.POST("/api/v1/credentials", CreateCredential(bridge))
+	r.POST("/api/v1/credentials", CreateCredential(bridge, nil))
 
 	body, _ := json.Marshal(map[string]interface{}{
 		"name":      "custom-cred",
@@ -2531,7 +2531,7 @@ func TestUpdateCredential_Success_Cov(t *testing.T) {
 
 	bridge := createTestBridge(t, db)
 	r := gin.New()
-	r.PUT("/api/v1/credentials/:id", UpdateCredential(bridge))
+	r.PUT("/api/v1/credentials/:id", UpdateCredential(bridge, nil))
 
 	body, _ := json.Marshal(map[string]string{"value": "new-secret"})
 	req, _ := http.NewRequest("PUT", "/api/v1/credentials/some-id", bytes.NewBuffer(body))

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -85,7 +85,7 @@ func ListCredentials(bridge *service.Bridge) gin.HandlerFunc {
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
 // @Router       /credentials [post]
-func CreateCredential(bridge *service.Bridge) gin.HandlerFunc {
+func CreateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input struct {
 			TenantID      string `json:"tenant_id"`
@@ -107,6 +107,20 @@ func CreateCredential(bridge *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
+		// Record audit log
+		if auditSvc != nil {
+			userID, _ := c.Get(string(auth.UserIDKey))
+			uid, _ := userID.(string)
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     uid,
+				Action:       "credential.create",
+				ResourceType: "credential",
+				ResourceID:   fmt.Sprintf("%v", cred),
+				Detail:       map[string]string{"name": input.Name, "type": input.Type},
+			})
+		}
+
 		respondSuccess(c, cred)
 	}
 }
@@ -125,7 +139,7 @@ func CreateCredential(bridge *service.Bridge) gin.HandlerFunc {
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
 // @Router       /credentials/{id} [put]
-func UpdateCredential(bridge *service.Bridge) gin.HandlerFunc {
+func UpdateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 		var input struct {
@@ -141,6 +155,19 @@ func UpdateCredential(bridge *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
+		// Record audit log
+		if auditSvc != nil {
+			userID, _ := c.Get(string(auth.UserIDKey))
+			uid, _ := userID.(string)
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     uid,
+				Action:       "credential.update",
+				ResourceType: "credential",
+				ResourceID:   id,
+			})
+		}
+
 		respondSuccess(c, result)
 	}
 }
@@ -156,13 +183,26 @@ func UpdateCredential(bridge *service.Bridge) gin.HandlerFunc {
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
 // @Router       /credentials/{id} [delete]
-func DeleteCredential(bridge *service.Bridge) gin.HandlerFunc {
+func DeleteCredential(bridge *service.Bridge, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
 		if err := bridge.DeleteCredential(c.Request.Context(), id); err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
+		// Record audit log
+		if auditSvc != nil {
+			userID, _ := c.Get(string(auth.UserIDKey))
+			uid, _ := userID.(string)
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     uid,
+				Action:       "credential.delete",
+				ResourceType: "credential",
+				ResourceID:   id,
+			})
+		}
+
 		respondSuccess(c, gin.H{"message": "credential deleted", "id": id})
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -113,9 +113,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		creds := protected.Group("/credentials")
 		{
 			creds.GET("", ListCredentials(bridge))
-			creds.POST("", CreateCredential(bridge))
-			creds.PUT("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), UpdateCredential(bridge))
-			creds.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), DeleteCredential(bridge))
+			creds.POST("", CreateCredential(bridge, auditSvc))
+			creds.PUT("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), UpdateCredential(bridge, auditSvc))
+			creds.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "credential", "id"), DeleteCredential(bridge, auditSvc))
 			creds.POST("/:id/rotate", auth.RequireResourceAccessCached(bridge, "credential", "id"), RotateCredential(bridge, auditSvc))
 		}
 

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -32,6 +34,20 @@ func NewEncryptionKey() []byte {
 		panic(fmt.Sprintf("failed to generate encryption key: %v", err))
 	}
 	return key
+}
+
+// DeriveKey derives a unique AES-256 key from a master key and a per-credential nonce
+// using HKDF-SHA256. This ensures each credential is encrypted with a different key,
+// providing key isolation — compromising one credential's key does not affect others.
+func DeriveKey(masterKey, nonce []byte) []byte {
+	// Use HKDF with SHA-256 to derive a 32-byte key
+	// info parameter provides context separation (empty here, can be extended)
+	hkdf := hkdf.New(sha256.New, masterKey, nonce, nil)
+	derived := make([]byte, 32)
+	if _, err := io.ReadFull(hkdf, derived); err != nil {
+		panic(fmt.Sprintf("HKDF derivation failed: %v", err))
+	}
+	return derived
 }
 
 // Encrypt encrypts plaintext using AES-256-GCM and returns a base64-encoded ciphertext.

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"encoding/base64"
 	"strings"
+	"bytes"
 	"testing"
 
 	"golang.org/x/crypto/bcrypt"
@@ -472,5 +473,79 @@ func TestCheckPassword_EmptyHash(t *testing.T) {
 func TestCheckPassword_EmptyBoth(t *testing.T) {
 	if CheckPassword("", "") {
 		t.Error("CheckPassword() should return false for empty password and hash")
+	}
+}
+
+func TestDeriveKey_Deterministic(t *testing.T) {
+	masterKey := NewEncryptionKey()
+	nonce := []byte("test-credential-nonce-1")
+
+	key1 := DeriveKey(masterKey, nonce)
+	key2 := DeriveKey(masterKey, nonce)
+
+	if !bytes.Equal(key1, key2) {
+		t.Error("DeriveKey should be deterministic for same inputs")
+	}
+	if len(key1) != 32 {
+		t.Errorf("derived key length = %d, want 32", len(key1))
+	}
+}
+
+func TestDeriveKey_DifferentNonces(t *testing.T) {
+	masterKey := NewEncryptionKey()
+
+	key1 := DeriveKey(masterKey, []byte("nonce-1"))
+	key2 := DeriveKey(masterKey, []byte("nonce-2"))
+
+	if bytes.Equal(key1, key2) {
+		t.Error("different nonces should produce different keys")
+	}
+}
+
+func TestDeriveKey_DifferentMasterKeys(t *testing.T) {
+	nonce := []byte("same-nonce")
+	master1 := NewEncryptionKey()
+	master2 := NewEncryptionKey()
+
+	key1 := DeriveKey(master1, nonce)
+	key2 := DeriveKey(master2, nonce)
+
+	if bytes.Equal(key1, key2) {
+		t.Error("different master keys should produce different derived keys")
+	}
+}
+
+func TestDeriveKey_EncryptDecryptRoundTrip(t *testing.T) {
+	masterKey := NewEncryptionKey()
+	nonce := []byte("round-trip-test")
+
+	derivedKey := DeriveKey(masterKey, nonce)
+
+	plaintext := "secret credential value"
+	ciphertext, err := Encrypt(derivedKey, plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt failed: %v", err)
+	}
+
+	// Decrypt with same derived key should work
+	decrypted, err := Decrypt(derivedKey, ciphertext)
+	if err != nil {
+		t.Fatalf("Decrypt with derived key failed: %v", err)
+	}
+	if decrypted != plaintext {
+		t.Errorf("decrypted = %q, want %q", decrypted, plaintext)
+	}
+
+	// Decrypt with master key should fail
+	_, err = Decrypt(masterKey, ciphertext)
+	if err == nil {
+		t.Error("Decrypt with master key should fail (key isolation)")
+	}
+
+	// Decrypt with different derived key should fail
+	otherKey := DeriveKey(masterKey, []byte("other-nonce"))
+	_, err = Decrypt(otherKey, ciphertext)
+	if err == nil {
+		t.Error("Decrypt with different derived key should fail")
 	}
 }


### PR DESCRIPTION
## Summary

Implements **#130** — Credential Vault enhancements.

## Changes

### HKDF Key Derivation (crypto.go)
- **`DeriveKey(masterKey, nonce)`**: New function using HKDF-SHA256
- Each credential can be encrypted with a unique derived key (master key + per-credential nonce)
- Provides **key isolation**: compromising one credential's key does not affect others
- Backward compatible: existing credentials using direct `Encrypt(masterKey, value)` continue to work

### Audit Logging (credentials.go)
- `CreateCredential` → records `credential.create` audit event
- `UpdateCredential` → records `credential.update` audit event  
- `DeleteCredential` → records `credential.delete` audit event
- All 4 credential mutations now have audit trail (previously only `rotate`)

### Router (router.go)
- Pass `auditSvc` to Create/Update/Delete handlers

### Tests (4 new)
- `TestDeriveKey_Deterministic`: same inputs → same key
- `TestDeriveKey_DifferentNonces`: different nonces → different keys
- `TestDeriveKey_DifferentMasterKeys`: different masters → different keys
- `TestDeriveKey_EncryptDecryptRoundTrip`: full encrypt/decrypt with key isolation verification

Closes #130