### PR TITLE
feat(auth): add API Key management system

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -178,7 +178,7 @@ func setupFullTestRouter(db *gorm.DB, bridge *service.Bridge) *gin.Engine {
 	go wsHub.Run()
 	auditSvc := service.NewAuditService(db)
 	backupSvc := backup.New(backup.Config{BackupDir: os.TempDir()}, db, "sqlite", "")
-	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc)
+	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc, nil)
 	return r
 }
 

--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// ListAPIKeys returns all API keys for the authenticated user.
+func ListAPIKeys(keySvc *service.APIKeyService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		keys, err := keySvc.List(c.Request.Context(), uid)
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+		respondSuccess(c, keys)
+	}
+}
+
+// CreateAPIKey generates a new API key and returns it (raw key shown only once).
+func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var input struct {
+			Name          string   `json:"name" binding:"required"`
+			Scopes        []string `json:"scopes"`
+			ExpiresInDays int      `json:"expires_in_days"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+
+		if len(input.Scopes) == 0 {
+			input.Scopes = []string{"read"}
+		}
+
+		apiKey, rawKey, err := keySvc.Create(c.Request.Context(), uid, "tenant-default", input.Name, input.Scopes, input.ExpiresInDays)
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     uid,
+				Action:       "apikey.create",
+				ResourceType: "apikey",
+				ResourceID:   apiKey.ID,
+				Detail:       map[string]string{"name": input.Name, "prefix": apiKey.KeyPrefix},
+			})
+		}
+
+		respondSuccess(c, gin.H{
+			"id":         apiKey.ID,
+			"name":       apiKey.Name,
+			"key":        rawKey,
+			"key_prefix": apiKey.KeyPrefix,
+			"scopes":     input.Scopes,
+			"expires_at": apiKey.ExpiresAt,
+			"created_at": apiKey.CreatedAt,
+		})
+	}
+}
+
+// DeleteAPIKey revokes an API key.
+func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		keyID := c.Param("id")
+		if err := keySvc.Delete(c.Request.Context(), keyID, uid); err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     uid,
+				Action:       "apikey.delete",
+				ResourceType: "apikey",
+				ResourceID:   keyID,
+			})
+		}
+
+		respondSuccess(c, gin.H{"message": "API key revoked", "id": keyID})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -17,7 +17,7 @@ import (
 )
 
 // RegisterRoutes registers all API routes on the given Gin engine.
-func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service) {
+func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService) {
 	// Swagger documentation — only accessible in development mode.
 	// In production, the endpoint is disabled to prevent information leakage.
 	if os.Getenv("DEPLOYPILOT_ENV") == "development" || os.Getenv("GIN_MODE") == "debug" {
@@ -73,8 +73,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		}
 	}
 
-	// Protected routes
+	// Protected routes (JWT or API Key)
 	protected := api.Group("")
+	protected.Use(auth.APIKeyMiddleware(keySvc))
 	protected.Use(auth.AuthMiddleware(blacklist))
 	{
 		// Apps (12 endpoints)
@@ -269,6 +270,14 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			plugins.POST("/:id/enable", pluginHandler.EnablePlugin())
 			plugins.POST("/:id/disable", pluginHandler.DisablePlugin())
 			plugins.POST("/:id/reload", pluginHandler.ReloadPlugin())
+		}
+
+		// API Keys (3 endpoints)
+		apiKeys := protected.Group("/api-keys")
+		{
+			apiKeys.GET("", ListAPIKeys(keySvc))
+			apiKeys.POST("", CreateAPIKey(keySvc, auditSvc))
+			apiKeys.DELETE("/:id", DeleteAPIKey(keySvc, auditSvc))
 		}
 	}
 }

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -1,0 +1,66 @@
+package auth
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// APIKeyMiddleware validates API keys from the X-API-Key header or
+// Authorization: Bearer dp_xxx header. On success, it sets the same
+// context keys as AuthMiddleware (UserIDKey, RoleKey) so downstream
+// middleware works seamlessly.
+func APIKeyMiddleware(keySvc *service.APIKeyService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawKey := extractAPIKey(c)
+		if rawKey == "" {
+			c.Next()
+			return
+		}
+
+		// Only process keys with our prefix
+		if !strings.HasPrefix(rawKey, "dp_") {
+			c.Next()
+			return
+		}
+
+		apiKey, err := keySvc.Validate(c.Request.Context(), rawKey)
+		if err != nil {
+			slog.Debug("API key validation failed", "error", err)
+			c.Next()
+			return
+		}
+
+		// Set user identity in context (same keys as JWT middleware)
+		c.Set(string(UserIDKey), apiKey.UserID)
+		c.Set(string(RoleKey), "dev") // API keys get dev-level access by default
+		c.Set("auth_method", "api_key")
+		c.Next()
+	}
+}
+
+// extractAPIKey extracts the API key from X-API-Key header or Authorization header.
+func extractAPIKey(c *gin.Context) string {
+	// Try X-API-Key header first
+	if key := c.GetHeader("X-API-Key"); key != "" {
+		return strings.TrimSpace(key)
+	}
+
+	// Try Authorization: Bearer dp_xxx
+	authHeader := c.GetHeader("Authorization")
+	if authHeader == "" {
+		return ""
+	}
+
+	parts := strings.SplitN(authHeader, " ", 2)
+	if len(parts) == 2 && strings.EqualFold(parts[0], "bearer") {
+		key := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(key, "dp_") {
+			return key
+		}
+	}
+
+	return ""
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -500,6 +500,16 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("task_executions", "scheduled_tasks")
 			},
 		},
+		// 202605010001: Create api_keys table
+		{
+			ID: "202605010001",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&model.APIKey{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("api_keys")
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/model/apikey.go
+++ b/internal/model/apikey.go
@@ -1,0 +1,24 @@
+package model
+
+import "time"
+
+// APIKey represents a programmable API key for authentication.
+// The raw key is only shown once at creation time; only the SHA-256 hash is stored.
+type APIKey struct {
+	ID         string     `gorm:"primaryKey" json:"id"`
+	TenantID   string     `gorm:"index" json:"tenant_id"`
+	UserID     string     `gorm:"index" json:"user_id"`
+	Name       string     `gorm:"not null;size:100" json:"name"`
+	KeyHash    string     `gorm:"uniqueIndex;not null;size:64" json:"-"`
+	KeyPrefix  string     `gorm:"size:10;not null" json:"key_prefix"`
+	Scopes     string     `gorm:"type:text" json:"scopes"`
+	ExpiresAt  *time.Time `gorm:"index" json:"expires_at,omitempty"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt  time.Time  `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt  time.Time  `gorm:"autoUpdateTime" json:"updated_at"`
+
+	Tenant Tenant `gorm:"foreignKey:TenantID" json:"tenant,omitempty"`
+	User   User   `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+func (APIKey) TableName() string { return "api_keys" }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -75,7 +75,10 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	wsHub := api.NewWSHub(rdb)
 	go wsHub.Run()
 
-	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, nil)
+	// API Key service
+	keySvc := service.NewAPIKeyService(db)
+
+	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, nil, keySvc)
 
 	// Serve embedded frontend static files
 	serveStaticFiles(r)

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"gorm.io/gorm"
+)
+
+// APIKeyService handles API key CRUD and validation.
+type APIKeyService struct {
+	DB *gorm.DB
+}
+
+// NewAPIKeyService creates a new APIKeyService.
+func NewAPIKeyService(db *gorm.DB) *APIKeyService {
+	return &APIKeyService{DB: db}
+}
+
+// Create generates a new API key. Returns the APIKey model and the raw key (shown only once).
+func (s *APIKeyService) Create(ctx context.Context, userID, tenantID, name string, scopes []string, expiresInDays int) (*model.APIKey, string, error) {
+	// Generate random key: dp_ + 32 hex chars = 35 chars total
+	rawBytes := make([]byte, 16)
+	if _, err := rand.Read(rawBytes); err != nil {
+		return nil, "", fmt.Errorf("failed to generate key: %w", err)
+	}
+	rawKey := "dp_" + hex.EncodeToString(rawBytes)
+
+	// Hash the key for storage
+	hash := sha256.Sum256([]byte(rawKey))
+	keyHash := hex.EncodeToString(hash[:])
+
+	// Prefix for identification (first 10 chars)
+	prefix := rawKey[:10]
+	if len(prefix) > 10 {
+		prefix = prefix[:10]
+	}
+
+	// Serialize scopes
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal scopes: %w", err)
+	}
+
+	apiKey := &model.APIKey{
+		ID:        generateID(),
+		TenantID:  tenantID,
+		UserID:    userID,
+		Name:      name,
+		KeyHash:   keyHash,
+		KeyPrefix: prefix,
+		Scopes:    string(scopesJSON),
+	}
+
+	if expiresInDays > 0 {
+		expires := time.Now().AddDate(0, 0, expiresInDays)
+		apiKey.ExpiresAt = &expires
+	}
+
+	if err := s.DB.WithContext(ctx).Create(apiKey).Error; err != nil {
+		return nil, "", fmt.Errorf("failed to create API key: %w", err)
+	}
+
+	slog.Info("API key created", "id", apiKey.ID, "prefix", prefix, "name", name, "user_id", userID)
+	return apiKey, rawKey, nil
+}
+
+// Validate checks if a raw API key is valid and not expired.
+// On success, it updates LastUsedAt and returns the APIKey.
+func (s *APIKeyService) Validate(ctx context.Context, rawKey string) (*model.APIKey, error) {
+	hash := sha256.Sum256([]byte(rawKey))
+	keyHash := hex.EncodeToString(hash[:])
+
+	var apiKey model.APIKey
+	if err := s.DB.WithContext(ctx).Where("key_hash = ?", keyHash).First(&apiKey).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid API key")
+		}
+		return nil, fmt.Errorf("failed to query API key: %w", err)
+	}
+
+	// Check expiration
+	if apiKey.ExpiresAt != nil && apiKey.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("API key expired")
+	}
+
+	// Update last used time (fire-and-forget)
+	now := time.Now()
+	s.DB.WithContext(ctx).Model(&apiKey).Update("last_used_at", now)
+
+	return &apiKey, nil
+}
+
+// List returns all API keys for a given user.
+func (s *APIKeyService) List(ctx context.Context, userID string) ([]model.APIKey, error) {
+	var keys []model.APIKey
+	if err := s.DB.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Find(&keys).Error; err != nil {
+		return nil, fmt.Errorf("failed to list API keys: %w", err)
+	}
+	return keys, nil
+}
+
+// Delete removes an API key by ID. Only the owner can delete their own keys.
+func (s *APIKeyService) Delete(ctx context.Context, keyID, userID string) error {
+	result := s.DB.WithContext(ctx).
+		Where("id = ? AND user_id = ?", keyID, userID).
+		Delete(&model.APIKey{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete API key: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+	slog.Info("API key deleted", "id", keyID, "user_id", userID)
+	return nil
+}
+
+// ParseScopes parses the JSON scopes string into a slice.
+func ParseScopes(scopesJSON string) []string {
+	var scopes []string
+	if err := json.Unmarshal([]byte(scopesJSON), &scopes); err != nil {
+		return nil
+	}
+	return scopes
+}
+
+// HasScope checks if the given scopes contain the required scope.
+func HasScope(scopes []string, required string) bool {
+	for _, s := range scopes {
+		if strings.EqualFold(s, required) || s == "admin" {
+			return true
+		}
+	}
+	return false
+}
+
+// generateID generates a random ID for API keys.
+func generateID() string {
+	b := make([]byte, 12)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -130,7 +130,7 @@ func (s *APIKeyService) Delete(ctx context.Context, keyID, userID string) error 
 // generateAPIKeyID generates a random hex ID for API keys.
 func generateAPIKeyID() string {
 	b := make([]byte, 12)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil { panic("failed to generate ID: " + err.Error()) }
 	return hex.EncodeToString(b)
 }
 

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -52,7 +52,7 @@ func (s *APIKeyService) Create(ctx context.Context, userID, tenantID, name strin
 	}
 
 	apiKey := &model.APIKey{
-		ID:        generateID(),
+		ID:        generateAPIKeyID(),
 		TenantID:  tenantID,
 		UserID:    userID,
 		Name:      name,
@@ -127,6 +127,13 @@ func (s *APIKeyService) Delete(ctx context.Context, keyID, userID string) error 
 	return nil
 }
 
+// generateAPIKeyID generates a random hex ID for API keys.
+func generateAPIKeyID() string {
+	b := make([]byte, 12)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
 // ParseScopes parses the JSON scopes string into a slice.
 func ParseScopes(scopesJSON string) []string {
 	var scopes []string
@@ -146,9 +153,3 @@ func HasScope(scopes []string, required string) bool {
 	return false
 }
 
-// generateID generates a random ID for API keys.
-func generateID() string {
-	b := make([]byte, 12)
-	rand.Read(b)
-	return hex.EncodeToString(b)
-}

--- a/internal/service/apikey_service_test.go
+++ b/internal/service/apikey_service_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func setupAPIKeyTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := db.AutoMigrate(&model.APIKey{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	return db
+}
+
+func TestAPIKeyService_Create(t *testing.T) {
+	db := setupAPIKeyTestDB(t)
+	svc := NewAPIKeyService(db)
+
+	apiKey, rawKey, err := svc.Create(context.TODO(), "user-1", "tenant-default", "test-key", []string{"read", "write"}, 30)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if rawKey == "" {
+		t.Fatal("rawKey is empty")
+	}
+	if len(rawKey) != 35 { // "dp_" + 32 hex chars
+		t.Errorf("rawKey length = %d, want 35", len(rawKey))
+	}
+	if apiKey.KeyPrefix != rawKey[:10] {
+		t.Errorf("KeyPrefix = %q, want %q", apiKey.KeyPrefix, rawKey[:10])
+	}
+	if apiKey.KeyHash == "" {
+		t.Error("KeyHash is empty")
+	}
+	if apiKey.Name != "test-key" {
+		t.Errorf("Name = %q, want 'test-key'", apiKey.Name)
+	}
+	if apiKey.ExpiresAt == nil {
+		t.Error("ExpiresAt should be set for 30-day expiry")
+	}
+}
+
+func TestAPIKeyService_CreateNoExpiry(t *testing.T) {
+	db := setupAPIKeyTestDB(t)
+	svc := NewAPIKeyService(db)
+
+	apiKey, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "permanent-key", []string{"read"}, 0)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if apiKey.ExpiresAt != nil {
+		t.Error("ExpiresAt should be nil for no-expiry key")
+	}
+}
+
+func TestAPIKeyService_Validate(t *testing.T) {
+	db := setupAPIKeyTestDB(t)
+	svc := NewAPIKeyService(db)
+
+	_, rawKey, err := svc.Create(context.TODO(), "user-1", "tenant-default", "test-key", []string{"read"}, 0)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Valid key should pass
+	apiKey, err := svc.Validate(context.TODO(), rawKey)
+	if err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if apiKey.UserID != "user-1" {
+		t.Errorf("UserID = %q, want 'user-1'", apiKey.UserID)
+	}
+
+	// Invalid key should fail
+	_, err = svc.Validate(context.TODO(), "dp_invalidkey123456789012345678")
+	if err == nil {
+		t.Error("Validate() should fail for invalid key")
+	}
+}
+
+func TestAPIKeyService_List(t *testing.T) {
+	db := setupAPIKeyTestDB(t)
+	svc := NewAPIKeyService(db)
+
+	for i := 0; i < 3; i++ {
+		_, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "key-"+string(rune('A'+i)), []string{"read"}, 0)
+		if err != nil {
+			t.Fatalf("Create() error = %v", err)
+		}
+	}
+	// Create key for different user
+	_, _, _ = svc.Create(context.TODO(), "user-2", "tenant-default", "other-key", []string{"read"}, 0)
+
+	keys, err := svc.List(context.TODO(), "user-1")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(keys) != 3 {
+		t.Errorf("len(keys) = %d, want 3", len(keys))
+	}
+}
+
+func TestAPIKeyService_Delete(t *testing.T) {
+	db := setupAPIKeyTestDB(t)
+	svc := NewAPIKeyService(db)
+
+	apiKey, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "to-delete", []string{"read"}, 0)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	// Owner can delete
+	err = svc.Delete(context.TODO(), apiKey.ID, "user-1")
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	// Verify deleted
+	_, err = svc.Validate(context.TODO(), "dp_anything")
+	if err == nil {
+		t.Error("key should be deleted")
+	}
+
+	// Different user cannot delete
+	apiKey2, _, _ := svc.Create(context.TODO(), "user-2", "tenant-default", "other", []string{"read"}, 0)
+	err = svc.Delete(context.TODO(), apiKey2.ID, "user-1")
+	if err == nil {
+		t.Error("Delete() should fail for non-owner")
+	}
+}
+
+func TestParseScopes(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{`["read","write"]`, []string{"read", "write"}},
+		{`["admin"]`, []string{"admin"}},
+		{`invalid`, nil},
+		{``, nil},
+	}
+	for _, tt := range tests {
+		got := ParseScopes(tt.input)
+		if len(got) != len(tt.want) {
+			t.Errorf("ParseScopes(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestHasScope(t *testing.T) {
+	if !HasScope([]string{"read", "write"}, "read") {
+		t.Error("should have read scope")
+	}
+	if !HasScope([]string{"admin"}, "anything") {
+		t.Error("admin scope should grant everything")
+	}
+	if HasScope([]string{"read"}, "write") {
+		t.Error("should not have write scope")
+	}
+}


### PR DESCRIPTION
## Summary

Implements **#129** — API Key Management.

## Changes

### Model
- **`APIKey`** struct: id, tenant_id, user_id, name, key_hash (SHA-256), key_prefix, scopes (JSON), expires_at, last_used_at
- Key format: `dp_` prefix + 32 hex chars
- Migration `202605010001`

### Service
- **`APIKeyService`**: Create, Validate, List, Delete
- Raw key shown only once at creation; only SHA-256 hash stored
- Validate checks hash + expiration, updates `last_used_at`
- Delete enforces owner-only deletion
- `ParseScopes`/`HasScope` utility functions

### Auth Middleware
- **`APIKeyMiddleware`**: validates `X-API-Key` header or `Authorization: Bearer dp_xxx`
- Sets same context keys as JWT middleware → downstream middleware works seamlessly
- Runs before `AuthMiddleware` — JWT takes priority if both present
- API keys default to dev-level access

### API Endpoints
- `GET /api/v1/api-keys` — list current user's keys
- `POST /api/v1/api-keys` — create new key (returns raw key once)
- `DELETE /api/v1/api-keys/:id` — revoke key
- All mutations record audit logs

### Tests (7 new)
- Create, CreateNoExpiry, Validate, List, Delete (owner + non-owner), ParseScopes, HasScope

Closes #129