### PR TITLE
feat(auth): add Two-Factor Authentication (2FA/TOTP) system

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,5 +116,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-)
+
 	github.com/pquerna/otp v1.4.0
+)

--- a/go.mod
+++ b/go.mod
@@ -117,3 +117,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+	github.com/pquerna/otp v1.4.0

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -52,6 +52,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		id TEXT PRIMARY KEY, tenant_id TEXT, role_id TEXT,
 		username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL,
 		auth_provider TEXT, auth_uid TEXT, avatar_url TEXT,
+		totp_secret TEXT, totp_enabled INTEGER DEFAULT 0, backup_codes TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS credentials (

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -256,6 +256,21 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 			roleName = role.Name
 		}
 
+		// If 2FA is enabled, return a pending token instead of a full JWT
+		if user.TOTPEnabled {
+			pendingToken, err := auth.Generate2FAPendingToken(user.ID, roleName)
+			if err != nil {
+				respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")
+				return
+			}
+			respondSuccess(c, gin.H{
+				"requires_2fa": true,
+				"two_fa_token": pendingToken,
+				"user_id":      user.ID,
+			})
+			return
+		}
+
 		token, err := auth.GenerateToken(user.ID, roleName)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -70,6 +70,15 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			go stateStore.StartCleanup(context.Background(), 5*time.Minute)
 			authGroup.GET("/oauth/:provider", OAuthLogin(oauthSvc, stateStore))
 			authGroup.GET("/oauth/:provider/callback", OAuthCallback(oauthSvc, stateStore))
+			authGroup.POST("/2fa/verify", Verify2FA(db, auditSvc))
+		}
+
+		// 2FA management (requires authentication)
+		twofa := protected.Group("/2fa")
+		{
+			twofa.POST("/setup", Setup2FA(db, auditSvc))
+			twofa.POST("/confirm", Confirm2FA(db, auditSvc))
+			twofa.POST("/disable", Disable2FA(db, auditSvc))
 		}
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -72,14 +72,6 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			authGroup.GET("/oauth/:provider/callback", OAuthCallback(oauthSvc, stateStore))
 			authGroup.POST("/2fa/verify", Verify2FA(db, auditSvc))
 		}
-
-		// 2FA management (requires authentication)
-		twofa := protected.Group("/2fa")
-		{
-			twofa.POST("/setup", Setup2FA(db, auditSvc))
-			twofa.POST("/confirm", Confirm2FA(db, auditSvc))
-			twofa.POST("/disable", Disable2FA(db, auditSvc))
-		}
 	}
 
 	// Protected routes (JWT or API Key)
@@ -279,6 +271,14 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			plugins.POST("/:id/enable", pluginHandler.EnablePlugin())
 			plugins.POST("/:id/disable", pluginHandler.DisablePlugin())
 			plugins.POST("/:id/reload", pluginHandler.ReloadPlugin())
+		}
+
+		// 2FA management (requires authentication)
+		twofa := protected.Group("/2fa")
+		{
+			twofa.POST("/setup", Setup2FA(db, auditSvc))
+			twofa.POST("/confirm", Confirm2FA(db, auditSvc))
+			twofa.POST("/disable", Disable2FA(db, auditSvc))
 		}
 
 		// API Keys (3 endpoints)

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -1,0 +1,279 @@
+package api
+
+
+
+// encryptionKey stores the application encryption key for TOTP secret encryption.
+// Must be set via SetEncryptionKey before any 2FA operations.
+var encryptionKeyVal []byte
+
+// SetEncryptionKey sets the encryption key used for TOTP secret encryption.
+func SetEncryptionKey(key []byte) {
+	encryptionKeyVal = key
+}
+
+// encryptionKey returns the current encryption key.
+func encryptionKey() []byte {
+	return encryptionKeyVal
+}
+
+
+	"encoding/json"
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/crypto"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// Verify2FA handles the second step of 2FA login.
+// It validates the TOTP code (or backup code) and issues a full JWT.
+func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input struct {
+			TwoFAToken string `json:"two_fa_token" binding:"required"`
+			Code       string `json:"code" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+
+		// Parse the pending token
+		claims, err := auth.ParseToken(input.TwoFAToken)
+		if err != nil {
+			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_token")
+			return
+		}
+
+		// Look up user
+		var user model.User
+		if err := db.Where("id = ?", claims.UserID).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_token")
+			return
+		}
+
+		// Try TOTP code first
+		secret, err := crypto.Decrypt(encryptionKey(), user.TOTPSecret)
+		if err != nil || !auth.TOTPValidate(secret, input.Code) {
+			// Try backup codes
+			idx := auth.VerifyBackupCode(user.BackupCodes, input.Code)
+			if idx < 0 {
+				respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_2fa_code")
+				return
+			}
+			// Remove used backup code
+			user.BackupCodes = auth.RemoveBackupCode(user.BackupCodes, idx)
+			db.Save(&user)
+		}
+
+		// Issue full JWT
+		token, err := auth.GenerateToken(user.ID, claims.Role)
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")
+			return
+		}
+
+		// Record audit log
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(user.ID),
+				Username:     user.Username,
+				Action:       "auth.2fa_verify",
+				ResourceType: "user",
+				ResourceID:   user.ID,
+			})
+		}
+
+		respondSuccess(c, gin.H{
+			"user": model.User{
+				ID:       user.ID,
+				TenantID: user.TenantID,
+				RoleID:   user.RoleID,
+				Username: user.Username,
+				Email:    user.Email,
+			},
+			"token": token,
+		})
+	}
+}
+
+// Setup2FA generates a new TOTP secret and backup codes for the user.
+// The user must verify a TOTP code before 2FA is fully enabled.
+func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var user model.User
+		if err := db.Where("id = ?", uid).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		// Generate TOTP secret
+		secret, err := auth.TOTPSecret()
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		// Encrypt the secret for storage
+		encryptedSecret, err := crypto.Encrypt(encryptionKey(), secret)
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		// Generate backup codes
+		plaintextCodes, hashedCodes, err := auth.GenerateBackupCodes()
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		codesJSON, _ := json.Marshal(hashedCodes)
+
+		// Save to user (but don't enable yet — user must verify first)
+		user.TOTPSecret = encryptedSecret
+		user.BackupCodes = string(codesJSON)
+		if err := db.Save(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		// Record audit log
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     user.Username,
+				Action:       "auth.2fa_setup",
+				ResourceType: "user",
+				ResourceID:   uid,
+			})
+		}
+
+		qrURL := auth.TOTPQRCodeURL(secret, user.Username)
+		respondSuccess(c, gin.H{
+			"secret":       secret,
+			"qr_code_url": qrURL,
+			"backup_codes": plaintextCodes,
+		})
+	}
+}
+
+// Confirm2FA enables 2FA after the user verifies a TOTP code.
+func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var input struct {
+			Code string `json:"code" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+
+		var user model.User
+		if err := db.Where("id = ?", uid).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		secret, err := crypto.Decrypt(encryptionKey(), user.TOTPSecret)
+		if err != nil || !auth.TOTPValidate(secret, input.Code) {
+			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_2fa_code")
+			return
+		}
+
+		// Enable 2FA
+		user.TOTPEnabled = true
+		if err := db.Save(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     user.Username,
+				Action:       "auth.2fa_confirm",
+				ResourceType: "user",
+				ResourceID:   uid,
+			})
+		}
+
+		respondSuccess(c, gin.H{"enabled": true})
+	}
+}
+
+// Disable2FA turns off 2FA for the user. Requires current TOTP code verification.
+func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var input struct {
+			Code string `json:"code" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+
+		var user model.User
+		if err := db.Where("id = ?", uid).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		if !user.TOTPEnabled {
+			respondErrori18n(c, http.StatusBadRequest, "error.auth.2fa_not_enabled")
+			return
+		}
+
+		// Verify current TOTP code before disabling
+		secret, err := crypto.Decrypt(encryptionKey(), user.TOTPSecret)
+		if err != nil || !auth.TOTPValidate(secret, input.Code) {
+			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_2fa_code")
+			return
+		}
+
+		// Clear 2FA fields
+		user.TOTPEnabled = false
+		user.TOTPSecret = ""
+		user.BackupCodes = ""
+		if err := db.Save(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if auditSvc != nil {
+			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+				UserID:       parseUserID(uid),
+				Username:     user.Username,
+				Action:       "auth.2fa_disable",
+				ResourceType: "user",
+				ResourceID:   uid,
+			})
+		}
+
+		respondSuccess(c, gin.H{"enabled": false})
+	}
+}

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -1,9 +1,18 @@
 package api
 
+import (
+	"encoding/json"
+	"net/http"
 
+	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/crypto"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
 
-// encryptionKey stores the application encryption key for TOTP secret encryption.
-// Must be set via SetEncryptionKey before any 2FA operations.
+// encryptionKeyVal stores the application encryption key for TOTP secret encryption.
 var encryptionKeyVal []byte
 
 // SetEncryptionKey sets the encryption key used for TOTP secret encryption.
@@ -16,20 +25,7 @@ func encryptionKey() []byte {
 	return encryptionKeyVal
 }
 
-
-	"encoding/json"
-	"net/http"
-
-	"github.com/Yogdunana/deploypilot/internal/auth"
-	"github.com/Yogdunana/deploypilot/internal/crypto"
-	"github.com/Yogdunana/deploypilot/internal/model"
-	"github.com/Yogdunana/deploypilot/internal/service"
-	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
-)
-
 // Verify2FA handles the second step of 2FA login.
-// It validates the TOTP code (or backup code) and issues a full JWT.
 func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input struct {
@@ -41,42 +37,35 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			return
 		}
 
-		// Parse the pending token
 		claims, err := auth.ParseToken(input.TwoFAToken)
 		if err != nil {
 			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_token")
 			return
 		}
 
-		// Look up user
 		var user model.User
 		if err := db.Where("id = ?", claims.UserID).First(&user).Error; err != nil {
 			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_token")
 			return
 		}
 
-		// Try TOTP code first
 		secret, err := crypto.Decrypt(encryptionKey(), user.TOTPSecret)
 		if err != nil || !auth.TOTPValidate(secret, input.Code) {
-			// Try backup codes
 			idx := auth.VerifyBackupCode(user.BackupCodes, input.Code)
 			if idx < 0 {
 				respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_2fa_code")
 				return
 			}
-			// Remove used backup code
 			user.BackupCodes = auth.RemoveBackupCode(user.BackupCodes, idx)
 			db.Save(&user)
 		}
 
-		// Issue full JWT
 		token, err := auth.GenerateToken(user.ID, claims.Role)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")
 			return
 		}
 
-		// Record audit log
 		if auditSvc != nil {
 			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(user.ID),
@@ -100,8 +89,7 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// Setup2FA generates a new TOTP secret and backup codes for the user.
-// The user must verify a TOTP code before 2FA is fully enabled.
+// Setup2FA generates a new TOTP secret and backup codes.
 func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -117,21 +105,18 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			return
 		}
 
-		// Generate TOTP secret
 		secret, err := auth.TOTPSecret()
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
-		// Encrypt the secret for storage
 		encryptedSecret, err := crypto.Encrypt(encryptionKey(), secret)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
-		// Generate backup codes
 		plaintextCodes, hashedCodes, err := auth.GenerateBackupCodes()
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
@@ -140,7 +125,6 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 
 		codesJSON, _ := json.Marshal(hashedCodes)
 
-		// Save to user (but don't enable yet — user must verify first)
 		user.TOTPSecret = encryptedSecret
 		user.BackupCodes = string(codesJSON)
 		if err := db.Save(&user).Error; err != nil {
@@ -148,7 +132,6 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			return
 		}
 
-		// Record audit log
 		if auditSvc != nil {
 			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
@@ -198,7 +181,6 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			return
 		}
 
-		// Enable 2FA
 		user.TOTPEnabled = true
 		if err := db.Save(&user).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
@@ -219,7 +201,7 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// Disable2FA turns off 2FA for the user. Requires current TOTP code verification.
+// Disable2FA turns off 2FA for the user.
 func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -248,14 +230,12 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			return
 		}
 
-		// Verify current TOTP code before disabling
 		secret, err := crypto.Decrypt(encryptionKey(), user.TOTPSecret)
 		if err != nil || !auth.TOTPValidate(secret, input.Code) {
 			respondErrori18n(c, http.StatusUnauthorized, "error.auth.invalid_2fa_code")
 			return
 		}
 
-		// Clear 2FA fields
 		user.TOTPEnabled = false
 		user.TOTPSecret = ""
 		user.BackupCodes = ""

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -50,6 +50,25 @@ func GenerateToken(userID, role string) (string, error) {
 	return token.SignedString(secret)
 }
 
+// Generate2FAPendingToken creates a short-lived JWT (5 minutes) for 2FA verification.
+func Generate2FAPendingToken(userID, role string) (string, error) {
+	claims := &Claims{
+		UserID: userID,
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.New().String(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	secret, err := getJWTSecret()
+	if err != nil {
+		return "", fmt.Errorf("failed to get JWT secret: %w", err)
+	}
+	return token.SignedString(secret)
+}
+
 // ParseToken validates and parses a JWT string, returning the claims.
 func ParseToken(tokenString string) (*Claims, error) {
 	secret, err := getJWTSecret()

--- a/internal/auth/totp.go
+++ b/internal/auth/totp.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 )
 

--- a/internal/auth/totp.go
+++ b/internal/auth/totp.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pquerna/otp/totp"
+)
+
+// TOTPSecret generates a new TOTP secret key.
+func TOTPSecret() (string, error) {
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      "DeployPilot",
+		AccountName: "user",
+		Period:      30,
+		SecretSize:  32,
+		Digits:      otp.DigitsSix,
+		Algorithm:   otp.AlgorithmSHA256,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate TOTP secret: %w", err)
+	}
+	return key.Secret(), nil
+}
+
+// TOTPQRCodeURL generates the otpauth:// URI for QR code scanning.
+func TOTPQRCodeURL(secret, username string) string {
+	return fmt.Sprintf("otpauth://totp/DeployPilot:%s?secret=%s&issuer=DeployPilot&algorithm=SHA256&digits=6&period=30",
+		username, secret)
+}
+
+// TOTPValidate checks if a 6-digit code is valid for the given secret.
+func TOTPValidate(secret, code string) bool {
+	return totp.Validate(code, secret)
+}
+
+// GenerateBackupCodes creates 10 random 8-character backup codes.
+// Returns the plaintext codes for one-time display and their SHA-256 hashes for storage.
+func GenerateBackupCodes() (plaintext []string, hashes []string, err error) {
+	plaintext = make([]string, 10)
+	hashes = make([]string, 10)
+
+	for i := 0; i < 10; i++ {
+		b := make([]byte, 4)
+		if _, err = rand.Read(b); err != nil {
+			return nil, nil, fmt.Errorf("failed to generate backup code: %w", err)
+		}
+		code := hex.EncodeToString(b) // 8 hex chars
+		plaintext[i] = strings.ToUpper(code)
+
+		hash := sha256.Sum256([]byte(strings.ToLower(code)))
+		hashes[i] = hex.EncodeToString(hash[:])
+	}
+
+	return plaintext, hashes, nil
+}
+
+// VerifyBackupCode checks if a plaintext code matches any of the stored hashes.
+// Returns the index of the matched code, or -1 if no match.
+func VerifyBackupCode(storedHashesJSON, code string) int {
+	var hashes []string
+	if err := json.Unmarshal([]byte(storedHashesJSON), &hashes); err != nil {
+		return -1
+	}
+
+	inputHash := sha256.Sum256([]byte(strings.ToLower(code)))
+	inputHashStr := hex.EncodeToString(inputHash[:])
+
+	for i, h := range hashes {
+		if h == inputHashStr {
+			return i
+		}
+	}
+	return -1
+}
+
+// RemoveBackupCode removes a used backup code from the stored hashes.
+func RemoveBackupCode(storedHashesJSON string, index int) string {
+	var hashes []string
+	if err := json.Unmarshal([]byte(storedHashesJSON), &hashes); err != nil {
+		return storedHashesJSON
+	}
+
+	if index < 0 || index >= len(hashes) {
+		return storedHashesJSON
+	}
+
+	// Remove the used code
+	hashes = append(hashes[:index], hashes[index+1:]...)
+	updated, _ := json.Marshal(hashes)
+	return string(updated)
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -500,6 +500,22 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("task_executions", "scheduled_tasks")
 			},
 		},
+		// 202605010002: Add 2FA fields to users table
+		{
+			ID: "202605010002",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&model.User{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				if err := tx.Migrator().DropColumn("users", "totp_secret"); err != nil {
+					return err
+				}
+				if err := tx.Migrator().DropColumn("users", "totp_enabled"); err != nil {
+					return err
+				}
+				return tx.Migrator().DropColumn("users", "backup_codes")
+			},
+		},
 		// 202605010001: Create api_keys table
 		{
 			ID: "202605010001",

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -37,6 +37,9 @@ type User struct {
 	AuthProvider string `gorm:"size:20;index" json:"auth_provider,omitempty"`
 	AuthUID      string `gorm:"size:100;index" json:"auth_uid,omitempty"`
 	AvatarURL    string `gorm:"size:500" json:"avatar_url,omitempty"`
+	TOTPSecret   string    `gorm:"size:256" json:"-"`
+	TOTPEnabled  bool      `gorm:"default:false" json:"totp_enabled"`
+	BackupCodes  string    `gorm:"type:text" json:"-"`
 	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
 	UpdatedAt    time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,6 +78,9 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	// API Key service
 	keySvc := service.NewAPIKeyService(db)
 
+	// Set encryption key for 2FA TOTP secret encryption
+	api.SetEncryptionKey(bridge.EncryptionKey)
+
 	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, nil, keySvc)
 
 	// Serve embedded frontend static files


### PR DESCRIPTION
## Summary

Implements **#128** — Two-Factor Authentication (2FA/TOTP).

## Changes

### TOTP Service (auth/totp.go)
- `TOTPSecret()`: generate TOTP secret using `pquerna/otp`
- `TOTPQRCodeURL()`: generate otpauth:// URI for QR scanning
- `TOTPValidate()`: verify 6-digit code against secret
- `GenerateBackupCodes()`: 10 random 8-char codes + SHA-256 hashes
- `VerifyBackupCode()` / `RemoveBackupCode()`: single-use backup codes

### Two-Step Login Flow
1. `POST /auth/login` → if 2FA enabled, returns `requires_2fa: true` + `two_fa_token` (5-min JWT)
2. `POST /auth/2fa/verify` → validate TOTP or backup code → issue full JWT
3. Backup codes are single-use, automatically removed

### 2FA Management (authenticated endpoints)
- `POST /2fa/setup` → generate TOTP secret + backup codes (not enabled yet)
- `POST /2fa/confirm` → verify TOTP code → enable 2FA
- `POST /2fa/disable` → verify TOTP code → disable 2FA

### Security
- TOTP secrets encrypted with AES-256-GCM before storage
- Backup codes stored as SHA-256 hashes
- All 2FA operations record audit logs
- 2FA pending token expires in 5 minutes

### Model & Migration
- User: `totp_secret`, `totp_enabled`, `backup_codes` fields
- Migration `202605010002`

Closes #128