### PR TITLE
feat(monitor): add typed event bus, alert-notification linkage, and Bark channel

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -149,6 +149,7 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 
 	// Initialize event bus, token blacklist, and cache (Redis if available, otherwise in-memory)
 	var eventBus service.EventBus
+	var typedBus service.TypedEventBus
 	var tokenBlacklist auth.TokenBlacklist
 	var cache service.Cache
 	var rdb *redis.Client
@@ -161,16 +162,19 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		if err := rdb.Ping(context.Background()).Err(); err != nil {
 			slog.Warn("Redis unavailable, falling back to in-memory implementations", "error", err)
 			eventBus = service.NewInMemoryEventBus()
+			typedBus = service.NewInMemoryTypedEventBus()
 			tokenBlacklist = auth.NewMemoryTokenBlacklist()
 			cache = service.NewMemoryCache("dp:")
 		} else {
 			eventBus = service.NewRedisEventBus(rdb)
+			typedBus = service.NewRedisTypedEventBus(rdb, "")
 			tokenBlacklist = auth.NewRedisTokenBlacklist(rdb)
 			cache = service.NewRedisCache(rdb, "dp:")
-			slog.Info("using Redis for event bus, token blacklist, and cache")
+			slog.Info("using Redis for event bus, typed event bus, token blacklist, and cache")
 		}
 	} else {
 		eventBus = service.NewInMemoryEventBus()
+		typedBus = service.NewInMemoryTypedEventBus()
 		tokenBlacklist = auth.NewMemoryTokenBlacklist()
 		cache = service.NewMemoryCache("dp:")
 	}
@@ -181,6 +185,7 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 
 	bridge := service.NewBridge(db, executor, encKey, eventBus)
 	bridge.SetCache(cache)
+	bridge.SetTypedBus(typedBus)
 	bridge.TunnelManager = tunnelManager
 	bridge.UpgradeSvc = service.NewUpgradeService("")
 
@@ -278,6 +283,11 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 	if eventBus != nil {
 		if err := eventBus.Close(); err != nil {
 			slog.Warn("event bus close error", "error", err)
+		}
+	}
+	if typedBus != nil {
+		if err := typedBus.Close(); err != nil {
+			slog.Warn("typed event bus close error", "error", err)
 		}
 	}
 

--- a/internal/api/monitor_alert_rules.go
+++ b/internal/api/monitor_alert_rules.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// CreateAlertRule creates a new alert rule.
+// POST /api/v1/monitor/alert-rules
+func CreateAlertRule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var rule model.AlertRuleRecord
+		if err := c.ShouldBindJSON(&rule); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+
+		svc := service.NewAlertRuleService(db)
+		if err := svc.CreateAlertRule(&rule); err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{"data": rule})
+	}
+}
+
+// UpdateAlertRule updates an existing alert rule.
+// PUT /api/v1/monitor/alert-rules/:id
+func UpdateAlertRule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+
+		var rule model.AlertRuleRecord
+		if err := c.ShouldBindJSON(&rule); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			return
+		}
+		rule.ID = id
+
+		svc := service.NewAlertRuleService(db)
+		if err := svc.UpdateAlertRule(&rule); err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"data": rule})
+	}
+}
+
+// DeleteAlertRule deletes an alert rule.
+// DELETE /api/v1/monitor/alert-rules/:id
+func DeleteAlertRule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+
+		svc := service.NewAlertRuleService(db)
+		if err := svc.DeleteAlertRule(id); err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"message": "alert rule deleted"})
+	}
+}
+
+// GetAlertRule retrieves a single alert rule.
+// GET /api/v1/monitor/alert-rules/:id
+func GetAlertRule(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		id := c.Param("id")
+
+		svc := service.NewAlertRuleService(db)
+		rule, err := svc.GetAlertRule(id)
+		if err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"data": rule})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -51,6 +51,7 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 	sseGroup.Use(auth.AuthMiddleware(blacklist))
 	{
 		sseGroup.GET("/deploy/:app_id", DeploySSE(bridge))
+		sseGroup.GET("/alerts", AlertSSE(bridge))
 	}
 
 	// Public routes
@@ -239,6 +240,10 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			mon.GET("/container/:name", GetContainerMetrics(bridge))
 			mon.GET("/alerts", ListAlerts(bridge))
 			mon.GET("/alert-rules", ListAlertRules(bridge))
+			mon.POST("/alert-rules", CreateAlertRule(db))
+			mon.GET("/alert-rules/:id", GetAlertRule(db))
+			mon.PUT("/alert-rules/:id", UpdateAlertRule(db))
+			mon.DELETE("/alert-rules/:id", DeleteAlertRule(db))
 			mon.POST("/heal/:name", HealContainer(bridge))
 			mon.POST("/check/:name", CheckContainerHealth(bridge))
 		}

--- a/internal/api/sse_alert.go
+++ b/internal/api/sse_alert.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+// AlertSSE handles SSE connections for alert events.
+// GET /api/v1/sse/alerts
+func AlertSSE(bridge *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Set SSE headers
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+		c.Header("X-Accel-Buffering", "no")
+
+		ctx := c.Request.Context()
+
+		if bridge.TypedBus == nil {
+			c.SSEvent("error", gin.H{"message": "typed event bus not available"})
+			c.Writer.Flush()
+			return
+		}
+
+		ch := bridge.TypedBus.Subscribe(ctx, "alert:all")
+
+		// Send heartbeat every 15s
+		heartbeat := time.NewTicker(15 * time.Second)
+		defer heartbeat.Stop()
+
+		// Send initial connection event
+		c.SSEvent("connected", gin.H{"topic": "alert:all", "timestamp": time.Now().Format(time.RFC3339)})
+		c.Writer.Flush()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-ch:
+				c.SSEvent("alert", event)
+				c.Writer.Flush()
+			case <-heartbeat.C:
+				c.SSEvent("heartbeat", gin.H{"timestamp": time.Now().Format(time.RFC3339)})
+				c.Writer.Flush()
+			}
+		}
+	}
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -526,6 +526,30 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("api_keys")
 			},
 		},
+		// 202605020001: Create alert_rules table for persistent alert rule configuration
+		{
+			ID: "202605020001",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec(`CREATE TABLE IF NOT EXISTS alert_rules (
+					id TEXT PRIMARY KEY,
+					tenant_id TEXT,
+					name TEXT NOT NULL,
+					metric_type TEXT NOT NULL,
+					condition TEXT NOT NULL,
+					threshold REAL DEFAULT 0,
+					severity TEXT NOT NULL DEFAULT 'warning',
+					enabled INTEGER DEFAULT 1,
+					cooldown_seconds INTEGER DEFAULT 900,
+					notify_channels TEXT,
+					server_id TEXT,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				)`).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("alert_rules")
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -229,6 +229,25 @@ type AlertHistory struct {
 
 func (AlertHistory) TableName() string { return "alert_histories" }
 
+// AlertRuleRecord stores persistent alert rule configuration.
+type AlertRuleRecord struct {
+	ID              string    `gorm:"primaryKey" json:"id"`
+	TenantID        string    `gorm:"index" json:"tenant_id,omitempty"`
+	Name            string    `gorm:"not null;size:100" json:"name"`
+	MetricType      string    `gorm:"not null;size:20" json:"metric_type"`
+	Condition       string    `gorm:"not null;size:10" json:"condition"`
+	Threshold       float64   `json:"threshold"`
+	Severity        string    `gorm:"not null;size:20;default:warning" json:"severity"`
+	Enabled         bool      `gorm:"default:true" json:"enabled"`
+	CooldownSeconds int       `gorm:"default:900" json:"cooldown_seconds"`
+	NotifyChannels  string    `gorm:"type:text" json:"notify_channels"` // JSON array string: ["webhook","email"]
+	ServerID        string    `gorm:"index" json:"server_id,omitempty"`
+	CreatedAt       time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt       time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (AlertRuleRecord) TableName() string { return "alert_rules" }
+
 // ScheduledTask represents a cron-based scheduled task.
 type ScheduledTask struct {
 	ID          string     `gorm:"primaryKey" json:"id"`

--- a/internal/monitor/alert.go
+++ b/internal/monitor/alert.go
@@ -6,6 +6,15 @@ import (
 	"time"
 )
 
+// AlertHandler is the interface for handling fired alerts.
+// Implemented by the service layer (Bridge) to avoid circular imports.
+type AlertHandler interface {
+	// OnAlert is called when a new alert fires.
+	OnAlert(alert *Alert)
+	// OnAlertResolved is called when a previously firing alert is resolved.
+	OnAlertResolved(alert *Alert)
+}
+
 // AlertSeverity defines alert severity levels.
 type AlertSeverity string
 
@@ -17,14 +26,16 @@ const (
 
 // AlertRule defines a monitoring alert rule.
 type AlertRule struct {
-	ID         string        `json:"id"`
-	Name       string        `json:"name"`
-	MetricType MetricType    `json:"metric_type"`
-	Condition  string        `json:"condition"` // gt, lt, eq, neq
-	Threshold  float64       `json:"threshold"`
-	Severity   AlertSeverity `json:"severity"`
-	Enabled    bool          `json:"enabled"`
-	Cooldown   time.Duration `json:"cooldown"`
+	ID             string        `json:"id"`
+	Name           string        `json:"name"`
+	MetricType     MetricType    `json:"metric_type"`
+	Condition      string        `json:"condition"` // gt, lt, eq, neq
+	Threshold      float64       `json:"threshold"`
+	Severity       AlertSeverity `json:"severity"`
+	Enabled        bool          `json:"enabled"`
+	Cooldown       time.Duration `json:"cooldown"`
+	NotifyChannels []string      `json:"notify_channels,omitempty"` // notification channel types (webhook, email, dingtalk, feishu, telegram, wecom, bark)
+	ServerID       string        `json:"server_id,omitempty"`       // optional: scope rule to a specific server
 }
 
 // Alert represents a triggered alert.
@@ -182,6 +193,13 @@ func (am *AlertManager) GetRules() []AlertRule {
 	am.mu.RLock()
 	defer am.mu.RUnlock()
 	return am.rules
+}
+
+// ReplaceRules replaces all alert rules atomically.
+func (am *AlertManager) ReplaceRules(rules []AlertRule) {
+	am.mu.Lock()
+	defer am.mu.Unlock()
+	am.rules = rules
 }
 
 // ResolveAlert marks an alert as resolved.

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -27,6 +27,7 @@ type Monitor struct {
 	healer       *healer.Healer
 	executor     deployer.CommandExecutor
 	store        *MetricStore
+	alertHandler AlertHandler // optional: called when alerts fire/resolve
 	cancel       context.CancelFunc
 	mu           sync.Mutex
 	running      bool
@@ -45,6 +46,11 @@ func NewMonitor(executor deployer.CommandExecutor, h *healer.Healer) *Monitor {
 // SetStore sets the metric store for persistence.
 func (m *Monitor) SetStore(store *MetricStore) {
 	m.store = store
+}
+
+// SetAlertHandler sets the alert handler for processing fired/resolved alerts.
+func (m *Monitor) SetAlertHandler(handler AlertHandler) {
+	m.alertHandler = handler
 }
 
 // GetStore returns the current metric store (may be nil).
@@ -189,6 +195,10 @@ func (m *Monitor) collectAndEvaluate(ctx context.Context) {
 
 	newAlerts := m.alertManager.Evaluate(metrics)
 	for _, alert := range newAlerts {
-		slog.Warn("alert fired", "message", alert.Message, "severity", alert.Severity)
+		if m.alertHandler != nil {
+			m.alertHandler.OnAlert(alert)
+		} else {
+			slog.Warn("alert fired", "message", alert.Message, "severity", alert.Severity)
+		}
 	}
 }

--- a/internal/plugin/builtin.go
+++ b/internal/plugin/builtin.go
@@ -203,6 +203,23 @@ func RegisterBuiltinPlugins(r *Registry) error {
 				return notify.NewWeComNotifier(webhookURL), nil
 			},
 		},
+		{
+			Name:        "bark-notify",
+			DisplayName: "Bark",
+			Version:     "1.0.0",
+			Description: "Bark (iOS Push) notification provider",
+			Author:      "DeployPilot",
+			Provider:    "notify",
+			Type:        "bark",
+			Factory: func(cfg map[string]interface{}) (interface{}, error) {
+				serverURL, _ := cfg["server_url"].(string)
+				deviceKey, _ := cfg["device_key"].(string)
+				if deviceKey == "" {
+					return nil, fmt.Errorf("bark notify: device_key is required")
+				}
+				return notify.NewBarkNotifier(serverURL, deviceKey), nil
+			},
+		},
 	}
 
 	// Registry providers

--- a/internal/provider/notify/bark.go
+++ b/internal/provider/notify/bark.go
@@ -1,0 +1,129 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// BarkNotifier sends push notifications via Bark (iOS push notification service).
+// See: https://github.com/Finb/bark-server
+type BarkNotifier struct {
+	ServerURL string
+	DeviceKey string
+	Group     string
+	Icon      string
+	Sound     string
+	Level     string // active, timeSensitive, passive
+	Archive   string // "1" to archive
+	Client    *http.Client
+}
+
+// NewBarkNotifier creates a new BarkNotifier.
+func NewBarkNotifier(serverURL, deviceKey string) *BarkNotifier {
+	if serverURL == "" {
+		serverURL = "https://api.day.app"
+	}
+	return &BarkNotifier{
+		ServerURL: serverURL,
+		DeviceKey: deviceKey,
+		Group:     "DeployPilot",
+		Sound:     "default",
+		Level:     "active",
+		Client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Name returns the notifier name.
+func (b *BarkNotifier) Name() string { return "bark" }
+
+// barkRequest is the request body for Bark API.
+type barkRequest struct {
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	Group    string `json:"group,omitempty"`
+	Sound    string `json:"sound,omitempty"`
+	Icon     string `json:"icon,omitempty"`
+	Level    string `json:"level,omitempty"`
+	IsArchive string `json:"isArchive,omitempty"`
+	URL      string `json:"url,omitempty"`
+}
+
+// barkResponse is the response from Bark API.
+type barkResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Timestamp int64 `json:"timestamp"`
+}
+
+// Send sends a notification via Bark push.
+func (b *BarkNotifier) Send(ctx context.Context, notification Notification) (*NotifyResult, error) {
+	// Map severity to Bark level
+	level := b.mapLevel(notification.Status)
+
+	reqBody := barkRequest{
+		Title:    fmt.Sprintf("[%s] %s", notification.Type, notification.AppName),
+		Body:     notification.Message,
+		Group:    b.Group,
+		Sound:    b.Sound,
+		Icon:     b.Icon,
+		Level:    level,
+		IsArchive: b.Archive,
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return &NotifyResult{Provider: "bark", Success: false, Error: err.Error()}, nil
+	}
+
+	url := fmt.Sprintf("%s/%s", b.ServerURL, b.DeviceKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return &NotifyResult{Provider: "bark", Success: false, Error: err.Error()}, nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := b.Client.Do(req)
+	if err != nil {
+		return &NotifyResult{Provider: "bark", Success: false, Error: err.Error()}, nil
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	var barkResp barkResponse
+	if err := json.NewDecoder(resp.Body).Decode(&barkResp); err != nil {
+		return &NotifyResult{Provider: "bark", Success: false, Error: fmt.Sprintf("decode response failed: %v", err)}, nil
+	}
+
+	if barkResp.Code == 200 {
+		return &NotifyResult{
+			Provider: "bark",
+			Success:  true,
+			Message:  "bark push delivered",
+		}, nil
+	}
+
+	return &NotifyResult{
+		Provider: "bark",
+		Success:  false,
+		Error:    fmt.Sprintf("bark error (code %d): %s", barkResp.Code, barkResp.Message),
+	}, nil
+}
+
+// mapLevel maps notification status to Bark notification level.
+func (b *BarkNotifier) mapLevel(status string) string {
+	switch status {
+	case "failed", "critical":
+		return "timeSensitive"
+	case "warning":
+		return "active"
+	default:
+		return "passive"
+	}
+}

--- a/internal/service/alert_handler.go
+++ b/internal/service/alert_handler.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/monitor"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"gorm.io/gorm"
+)
+
+// bridgeAlertHandler implements monitor.AlertHandler to bridge alerts from the monitor
+// package to the typed event bus and notification system.
+type bridgeAlertHandler struct {
+	db        *gorm.DB
+	typedBus  TypedEventBus
+	bridge    *Bridge
+}
+
+// newBridgeAlertHandler creates a new bridgeAlertHandler.
+func newBridgeAlertHandler(db *gorm.DB, typedBus TypedEventBus, bridge *Bridge) *bridgeAlertHandler {
+	return &bridgeAlertHandler{
+		db:       db,
+		typedBus: typedBus,
+		bridge:   bridge,
+	}
+}
+
+// OnAlert is called when a new alert fires.
+// It publishes the alert to the typed event bus and sends notifications.
+func (h *bridgeAlertHandler) OnAlert(alert *monitor.Alert) {
+	slog.Warn("alert fired", "alert_id", alert.ID, "rule", alert.RuleName, "severity", alert.Severity, "message", alert.Message)
+
+	// Publish to typed event bus
+	if h.typedBus != nil {
+		event := BusEvent{
+			ID:        GenerateBusEventID(),
+			Type:      EventAlert,
+			Topic:     "alert:all",
+			Payload: AlertEventPayload{
+				AlertID:   alert.ID,
+				RuleID:    alert.RuleID,
+				RuleName:  alert.RuleName,
+				Severity:  string(alert.Severity),
+				Message:   alert.Message,
+				Value:     alert.Value,
+				Threshold: alert.Threshold,
+				Status:    alert.Status,
+			},
+			Timestamp: time.Now(),
+		}
+		h.typedBus.Publish(event)
+	}
+
+	// Persist alert history
+	if h.db != nil {
+		h.saveAlertHistory(alert)
+	}
+
+	// Send notification asynchronously
+	if h.bridge != nil {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			_, err := h.bridge.SendNotification(ctx, "alert", "", "", string(alert.Severity), alert.Message)
+			if err != nil {
+				slog.Error("failed to send alert notification", "alert_id", alert.ID, "error", err)
+			}
+		}()
+	}
+}
+
+// OnAlertResolved is called when a previously firing alert is resolved.
+func (h *bridgeAlertHandler) OnAlertResolved(alert *monitor.Alert) {
+	slog.Info("alert resolved", "alert_id", alert.ID, "rule", alert.RuleName)
+
+	// Publish to typed event bus
+	if h.typedBus != nil {
+		event := BusEvent{
+			ID:        GenerateBusEventID(),
+			Type:      EventAlert,
+			Topic:     "alert:all",
+			Payload: AlertEventPayload{
+				AlertID:   alert.ID,
+				RuleID:    alert.RuleID,
+				RuleName:  alert.RuleName,
+				Severity:  string(alert.Severity),
+				Message:   alert.Message,
+				Value:     alert.Value,
+				Threshold: alert.Threshold,
+				Status:    "resolved",
+			},
+			Timestamp: time.Now(),
+		}
+		h.typedBus.Publish(event)
+	}
+
+	// Update alert history
+	if h.db != nil {
+		h.db.Model(&model.AlertHistory{}).
+			Where("rule_id = ? AND status = ?", alert.RuleID, "firing").
+			Update("status", "resolved").
+			Update("resolved_at", time.Now())
+	}
+}
+
+// saveAlertHistory persists an alert to the alert_histories table.
+func (h *bridgeAlertHandler) saveAlertHistory(alert *monitor.Alert) {
+	history := model.AlertHistory{
+		ID:        alert.ID,
+		RuleID:    alert.RuleID,
+		RuleName:  alert.RuleName,
+		Severity:  string(alert.Severity),
+		Message:   alert.Message,
+		Value:     alert.Value,
+		Threshold: alert.Threshold,
+		Status:    alert.Status,
+		FiredAt:   alert.FiredAt,
+	}
+	if err := h.db.Create(&history).Error; err != nil {
+		slog.Error("failed to save alert history", "alert_id", alert.ID, "error", err)
+	}
+}

--- a/internal/service/alert_rule_service.go
+++ b/internal/service/alert_rule_service.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/monitor"
+	"gorm.io/gorm"
+)
+
+// AlertRuleService provides CRUD operations for alert rules.
+type AlertRuleService struct {
+	db *gorm.DB
+}
+
+// NewAlertRuleService creates a new AlertRuleService.
+func NewAlertRuleService(db *gorm.DB) *AlertRuleService {
+	return &AlertRuleService{db: db}
+}
+
+// CreateAlertRule creates a new alert rule in the database.
+func (s *AlertRuleService) CreateAlertRule(rule *model.AlertRuleRecord) error {
+	if rule.ID == "" {
+		rule.ID = fmt.Sprintf("rule-%d", time.Now().UnixNano())
+	}
+	return s.db.Create(rule).Error
+}
+
+// UpdateAlertRule updates an existing alert rule.
+func (s *AlertRuleService) UpdateAlertRule(rule *model.AlertRuleRecord) error {
+	return s.db.Save(rule).Error
+}
+
+// DeleteAlertRule deletes an alert rule by ID.
+func (s *AlertRuleService) DeleteAlertRule(id string) error {
+	return s.db.Delete(&model.AlertRuleRecord{}, "id = ?", id).Error
+}
+
+// GetAlertRule retrieves a single alert rule by ID.
+func (s *AlertRuleService) GetAlertRule(id string) (*model.AlertRuleRecord, error) {
+	var rule model.AlertRuleRecord
+	if err := s.db.Where("id = ?", id).First(&rule).Error; err != nil {
+		return nil, err
+	}
+	return &rule, nil
+}
+
+// ListAlertRules returns all alert rules, optionally filtered by server_id.
+func (s *AlertRuleService) ListAlertRules(serverID string) ([]model.AlertRuleRecord, error) {
+	var rules []model.AlertRuleRecord
+	query := s.db.Order("created_at DESC")
+	if serverID != "" {
+		query = query.Where("server_id = ?", serverID)
+	}
+	if err := query.Find(&rules).Error; err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+// LoadAlertRulesFromDB loads all enabled alert rules from the database and converts them
+// to monitor.AlertRule format for the AlertManager.
+func (s *AlertRuleService) LoadAlertRulesFromDB() []monitor.AlertRule {
+	var records []model.AlertRuleRecord
+	if err := s.db.Where("enabled = ?", true).Find(&records).Error; err != nil {
+		slog.Error("failed to load alert rules from database", "error", err)
+		return nil
+	}
+
+	var rules []monitor.AlertRule
+	for _, r := range records {
+		var channels []string
+		if r.NotifyChannels != "" {
+			_ = json.Unmarshal([]byte(r.NotifyChannels), &channels)
+		}
+
+		rule := monitor.AlertRule{
+			ID:             r.ID,
+			Name:           r.Name,
+			MetricType:     monitor.MetricType(r.MetricType),
+			Condition:      r.Condition,
+			Threshold:      r.Threshold,
+			Severity:       monitor.AlertSeverity(r.Severity),
+			Enabled:        r.Enabled,
+			Cooldown:       time.Duration(r.CooldownSeconds) * time.Second,
+			NotifyChannels: channels,
+			ServerID:       r.ServerID,
+		}
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+// SyncRulesToAlertManager loads rules from DB and replaces the AlertManager's rules.
+// It preserves the built-in default rules and appends DB rules.
+func (s *AlertRuleService) SyncRulesToAlertManager(am *monitor.AlertManager) {
+	dbRules := s.LoadAlertRulesFromDB()
+
+	// Start with default built-in rules
+	defaults := monitor.DefaultRules()
+	allRules := make([]monitor.AlertRule, len(defaults))
+	copy(allRules, defaults)
+
+	// Append DB rules (they may override defaults by ID)
+	for _, rule := range dbRules {
+		found := false
+		for i, existing := range allRules {
+			if existing.ID == rule.ID {
+				allRules[i] = rule
+				found = true
+				break
+			}
+		}
+		if !found {
+			allRules = append(allRules, rule)
+		}
+	}
+
+	// Replace all rules in the AlertManager
+	am.ReplaceRules(allRules)
+	slog.Info("alert rules synced from database", "total", len(allRules), "db_rules", len(dbRules))
+}

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -74,6 +74,7 @@ type Bridge struct {
 	Monitor       *monitor.Monitor         // monitoring system (lazy-initialized)
 	healer        *healer.Healer           // self-healing engine (lazy-initialized)
 	EventBus      EventBus                 // pub/sub for deploy progress events
+	TypedBus      TypedEventBus            // typed event bus for alerts, notifications, system events
 	TunnelManager TunnelManager            // agent reverse tunnel manager
 	PluginMgr     *plugin.Manager          // plugin lifecycle manager
 	UpgradeSvc    *UpgradeService          // system upgrade service
@@ -128,6 +129,11 @@ func NewBridge(db *gorm.DB, executor deployer.CommandExecutor, encryptionKey []b
 // SetCache sets the cache on the Bridge.
 func (b *Bridge) SetCache(cache Cache) {
 	b.Cache = cache
+}
+
+// SetTypedBus sets the typed event bus on the Bridge.
+func (b *Bridge) SetTypedBus(bus TypedEventBus) {
+	b.TypedBus = bus
 }
 
 // SetBruteForceConfig replaces the brute-force protector with one using the given config.

--- a/internal/service/eventbus.go
+++ b/internal/service/eventbus.go
@@ -3,7 +3,58 @@ package service
 import (
 	"context"
 	"sync"
+	"time"
 )
+
+// EventType defines the type of a bus event.
+type EventType string
+
+const (
+	EventDeploy EventType = "deploy"
+	EventAlert  EventType = "alert"
+	EventNotify EventType = "notify"
+	EventSystem EventType = "system"
+)
+
+// BusEvent is a generic event envelope for the typed event bus.
+// It wraps any event payload with metadata for topic-based routing.
+type BusEvent struct {
+	ID        string      `json:"id"`
+	Type      EventType   `json:"type"`
+	Topic     string      `json:"topic"`               // e.g. "alert:all", "deploy:app-123"
+	Source    string      `json:"source,omitempty"`     // instance ID to prevent loop
+	Payload   interface{} `json:"payload"`
+	Timestamp time.Time   `json:"timestamp"`
+}
+
+// AlertEventPayload is the payload for alert events published on the typed event bus.
+type AlertEventPayload struct {
+	AlertID   string  `json:"alert_id"`
+	RuleID    string  `json:"rule_id"`
+	RuleName  string  `json:"rule_name"`
+	Severity  string  `json:"severity"`
+	Message   string  `json:"message"`
+	Value     float64 `json:"value"`
+	Threshold float64 `json:"threshold"`
+	Status    string  `json:"status"` // firing, resolved
+	ServerID  string  `json:"server_id,omitempty"`
+}
+
+// TypedEventBus defines the interface for multi-type event broadcasting.
+// This runs in parallel with the existing EventBus (deploy-only) for backward compatibility.
+type TypedEventBus interface {
+	// Publish sends a typed event to all subscribers of the given topic.
+	Publish(event BusEvent)
+
+	// Subscribe returns a read-only channel receiving events for the given topic.
+	Subscribe(ctx context.Context, topic string) <-chan BusEvent
+
+	// SubscribeType returns a read-only channel receiving events of the given type.
+	SubscribeType(ctx context.Context, eventType EventType) <-chan BusEvent
+
+	// Close shuts down the typed event bus and releases all resources.
+	Close() error
+}
 
 // EventBus defines the interface for deploy event broadcasting.
 // Implementations can be in-memory (single instance) or Redis-backed (multi-instance).

--- a/internal/service/monitor_service.go
+++ b/internal/service/monitor_service.go
@@ -63,6 +63,16 @@ func (b *Bridge) getMonitor() *monitor.Monitor {
 		if b.DB != nil {
 			b.Monitor.SetStore(monitor.NewMetricStore(b.DB))
 		}
+		// Set up alert handler for event bus + notification integration
+		if b.TypedBus != nil || b.DB != nil {
+			handler := newBridgeAlertHandler(b.DB, b.TypedBus, b)
+			b.Monitor.SetAlertHandler(handler)
+			// Sync alert rules from database
+			if b.DB != nil {
+				ruleSvc := NewAlertRuleService(b.DB)
+				ruleSvc.SyncRulesToAlertManager(b.Monitor.GetAlertManager())
+			}
+		}
 	}
 	return b.Monitor
 }

--- a/internal/service/typed_eventbus.go
+++ b/internal/service/typed_eventbus.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// InMemoryTypedEventBus is an in-memory implementation of TypedEventBus for single-instance deployments.
+type InMemoryTypedEventBus struct {
+	topicSubs map[string][]chan BusEvent  // topic -> channels
+	typeSubs  map[EventType][]chan BusEvent // event type -> channels
+	mu        sync.RWMutex
+}
+
+// NewInMemoryTypedEventBus creates a new InMemoryTypedEventBus.
+func NewInMemoryTypedEventBus() *InMemoryTypedEventBus {
+	return &InMemoryTypedEventBus{
+		topicSubs: make(map[string][]chan BusEvent),
+		typeSubs:  make(map[EventType][]chan BusEvent),
+	}
+}
+
+// Publish sends a typed event to all topic and type subscribers.
+func (b *InMemoryTypedEventBus) Publish(event BusEvent) {
+	b.mu.RLock()
+
+	// Collect topic subscribers
+	var topicChannels []chan BusEvent
+	if chs, ok := b.topicSubs[event.Topic]; ok {
+		topicChannels = make([]chan BusEvent, len(chs))
+		copy(topicChannels, chs)
+	}
+
+	// Collect type subscribers
+	var typeChannels []chan BusEvent
+	if chs, ok := b.typeSubs[event.Type]; ok {
+		typeChannels = make([]chan BusEvent, len(chs))
+		copy(typeChannels, chs)
+	}
+
+	b.mu.RUnlock()
+
+	// Send to topic subscribers (non-blocking, drop on full)
+	for _, ch := range topicChannels {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+
+	// Send to type subscribers (non-blocking, drop on full)
+	for _, ch := range typeChannels {
+		select {
+		case ch <- event:
+		default:
+		}
+	}
+}
+
+// Subscribe returns a buffered channel for the given topic.
+// The channel is closed when ctx is cancelled.
+func (b *InMemoryTypedEventBus) Subscribe(ctx context.Context, topic string) <-chan BusEvent {
+	ch := make(chan BusEvent, 100)
+	b.mu.Lock()
+	b.topicSubs[topic] = append(b.topicSubs[topic], ch)
+	b.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		b.unsubscribeTopic(topic, ch)
+	}()
+
+	return ch
+}
+
+// SubscribeType returns a buffered channel for the given event type.
+// The channel is closed when ctx is cancelled.
+func (b *InMemoryTypedEventBus) SubscribeType(ctx context.Context, eventType EventType) <-chan BusEvent {
+	ch := make(chan BusEvent, 100)
+	b.mu.Lock()
+	b.typeSubs[eventType] = append(b.typeSubs[eventType], ch)
+	b.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		b.unsubscribeType(eventType, ch)
+	}()
+
+	return ch
+}
+
+// Close is a no-op for the in-memory implementation.
+func (b *InMemoryTypedEventBus) Close() error {
+	return nil
+}
+
+// unsubscribeTopic removes a channel for the given topic.
+func (b *InMemoryTypedEventBus) unsubscribeTopic(topic string, ch chan BusEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	channels := b.topicSubs[topic]
+	for i, c := range channels {
+		if c == ch {
+			b.topicSubs[topic] = append(channels[:i], channels[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	if len(b.topicSubs[topic]) == 0 {
+		delete(b.topicSubs, topic)
+	}
+}
+
+// unsubscribeType removes a channel for the given event type.
+func (b *InMemoryTypedEventBus) unsubscribeType(eventType EventType, ch chan BusEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	channels := b.typeSubs[eventType]
+	for i, c := range channels {
+		if c == ch {
+			b.typeSubs[eventType] = append(channels[:i], channels[i+1:]...)
+			close(ch)
+			break
+		}
+	}
+	if len(b.typeSubs[eventType]) == 0 {
+		delete(b.typeSubs, eventType)
+	}
+}
+
+// GenerateBusEventID creates a unique event ID.
+func GenerateBusEventID() string {
+	return fmt.Sprintf("evt-%d", time.Now().UnixNano())
+}

--- a/internal/service/typed_eventbus_redis.go
+++ b/internal/service/typed_eventbus_redis.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisTypedEventBus implements TypedEventBus using Redis Pub/Sub for multi-instance broadcasting.
+// It uses a Source field to prevent processing self-published messages (ai-guide #28).
+type RedisTypedEventBus struct {
+	client   *redis.Client
+	ctx      context.Context
+	cancel   context.CancelFunc
+	localBus *InMemoryTypedEventBus // for local subscribers
+	instanceID string               // unique instance identifier for loop prevention
+	channel  string                 // Redis Pub/Sub channel name
+	mu       sync.RWMutex
+}
+
+// NewRedisTypedEventBus creates a new RedisTypedEventBus.
+func NewRedisTypedEventBus(client *redis.Client, instanceID string) *RedisTypedEventBus {
+	if instanceID == "" {
+		instanceID = GenerateBusEventID()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &RedisTypedEventBus{
+		client:     client,
+		ctx:        ctx,
+		cancel:     cancel,
+		localBus:   NewInMemoryTypedEventBus(),
+		instanceID: instanceID,
+		channel:    "deploypilot:typed-events",
+	}
+}
+
+// Publish sends a typed event to Redis for other instances and locally for this instance's subscribers.
+func (r *RedisTypedEventBus) Publish(event BusEvent) {
+	// Set source to this instance for loop prevention
+	event.Source = r.instanceID
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		slog.Error("failed to marshal redis typed eventbus event", "error", err)
+		return
+	}
+
+	// Publish to Redis for other instances
+	if err := r.client.Publish(r.ctx, r.channel, data).Err(); err != nil {
+		slog.Error("failed to publish typed event to redis", "error", err)
+	}
+
+	// Also publish locally
+	r.localBus.Publish(event)
+}
+
+// Subscribe returns a read-only channel receiving events for the given topic.
+// It merges events from both the local bus and the Redis Pub/Sub channel.
+func (r *RedisTypedEventBus) Subscribe(ctx context.Context, topic string) <-chan BusEvent {
+	ch := make(chan BusEvent, 100)
+
+	sub := r.client.Subscribe(ctx, r.channel)
+	localCh := r.localBus.Subscribe(ctx, topic)
+
+	go func() {
+		defer func() { _ = sub.Close() }()
+		defer close(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-r.ctx.Done():
+				return
+			case msg, ok := <-sub.Channel():
+				if !ok {
+					return
+				}
+				var event BusEvent
+				if json.Unmarshal([]byte(msg.Payload), &event) == nil {
+					// Skip self-published events (loop prevention)
+					if event.Source == r.instanceID {
+						continue
+					}
+					if event.Topic == topic {
+						select {
+						case ch <- event:
+						default:
+						}
+					}
+				}
+			case event, ok := <-localCh:
+				if !ok {
+					return
+				}
+				select {
+				case ch <- event:
+				default:
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+// SubscribeType returns a read-only channel receiving events of the given type.
+// It merges events from both the local bus and the Redis Pub/Sub channel.
+func (r *RedisTypedEventBus) SubscribeType(ctx context.Context, eventType EventType) <-chan BusEvent {
+	ch := make(chan BusEvent, 100)
+
+	sub := r.client.Subscribe(ctx, r.channel)
+	localCh := r.localBus.SubscribeType(ctx, eventType)
+
+	go func() {
+		defer func() { _ = sub.Close() }()
+		defer close(ch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-r.ctx.Done():
+				return
+			case msg, ok := <-sub.Channel():
+				if !ok {
+					return
+				}
+				var event BusEvent
+				if json.Unmarshal([]byte(msg.Payload), &event) == nil {
+					// Skip self-published events (loop prevention)
+					if event.Source == r.instanceID {
+						continue
+					}
+					if event.Type == eventType {
+						select {
+						case ch <- event:
+						default:
+						}
+					}
+				}
+			case event, ok := <-localCh:
+				if !ok {
+					return
+				}
+				select {
+				case ch <- event:
+				default:
+				}
+			}
+		}
+	}()
+
+	return ch
+}
+
+// Close shuts down the Redis typed event bus.
+func (r *RedisTypedEventBus) Close() error {
+	r.cancel()
+	return r.localBus.Close()
+}

--- a/internal/service/typed_eventbus_redis.go
+++ b/internal/service/typed_eventbus_redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"sync"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -12,13 +11,12 @@ import (
 // RedisTypedEventBus implements TypedEventBus using Redis Pub/Sub for multi-instance broadcasting.
 // It uses a Source field to prevent processing self-published messages (ai-guide #28).
 type RedisTypedEventBus struct {
-	client   *redis.Client
-	ctx      context.Context
-	cancel   context.CancelFunc
-	localBus *InMemoryTypedEventBus // for local subscribers
-	instanceID string               // unique instance identifier for loop prevention
-	channel  string                 // Redis Pub/Sub channel name
-	mu       sync.RWMutex
+	client     *redis.Client
+	ctx        context.Context
+	cancel     context.CancelFunc
+	localBus   *InMemoryTypedEventBus // for local subscribers
+	instanceID string                // unique instance identifier for loop prevention
+	channel    string                // Redis Pub/Sub channel name
 }
 
 // NewRedisTypedEventBus creates a new RedisTypedEventBus.


### PR DESCRIPTION
## Summary

Implements **v1.3 Phase 3.11**: Event Bus + Alert-Notification Linkage + Bark channel.

## Changes

### Typed Event Bus (parallel to existing EventBus for backward compatibility)
- `TypedEventBus` interface with topic-based and type-based subscription
- `InMemoryTypedEventBus` for single-instance deployments
- `RedisTypedEventBus` with instance-ID-based loop prevention (ai-guide #28)

### Alert-Notification Linkage
- `AlertHandler` interface in `monitor` package (dependency inversion)
- `bridgeAlertHandler` publishes alerts to TypedEventBus + persists to DB + sends notifications
- `Monitor.collectAndEvaluate` now delegates to AlertHandler instead of `slog.Warn`
- `AlertRule` gains `NotifyChannels` and `ServerID` fields

### Bark iOS Push Notification
- `BarkNotifier` implementing `Notifier` interface
- Severity-to-level mapping (critical→timeSensitive, warning→active, info→passive)
- Registered as built-in plugin (`bark-notify`)

### Alert Rule Persistence
- `AlertRuleRecord` model with `alert_rules` table
- Database migration `202605020001`
- `AlertRuleService` with full CRUD + DB-to-AlertManager sync
- `AlertManager.ReplaceRules()` for atomic rule replacement

### API Layer
- `GET /api/v1/sse/alerts` — Alert SSE endpoint
- `POST/GET/PUT/DELETE /api/v1/monitor/alert-rules` — Alert rule CRUD

### Integration
- `Bridge.TypedBus` field + `SetTypedBus()` method
- Lazy initialization in `getMonitor()` with AlertHandler wiring
- Graceful shutdown includes TypedEventBus cleanup

## Files Changed
- **7 new files**: typed_eventbus.go, typed_eventbus_redis.go, alert_handler.go, alert_rule_service.go, bark.go, sse_alert.go, monitor_alert_rules.go
- **10 modified files**: eventbus.go, bridge.go, monitor.go, alert.go, model.go, database.go, builtin.go, router.go, monitor_service.go, main.go