### PR TITLE
feat(backup): add S3-compatible cloud storage, encryption, and retention

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/Yogdunana/deploypilot/docs/swagger"
 	"github.com/Yogdunana/deploypilot/internal/agent"
 	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/backup"
 	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/crypto"
 	"github.com/Yogdunana/deploypilot/internal/database"
@@ -216,7 +217,46 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		slog.Info("OAuth service initialized", "providers", len(cfg.Auth.OAuthProviders))
 	}
 
-	srv := server.New(listenAddr, db, bridge, cfg, tokenBlacklist, oauthSvc, rdb)
+	// Initialize backup service with optional cloud storage
+	backupInterval, _ := time.ParseDuration(cfg.Backup.Interval)
+	if backupInterval == 0 {
+		backupInterval = 6 * time.Hour
+	}
+	backupSvc := backup.New(backup.Config{
+		Enabled:        cfg.Backup.Enabled,
+		Interval:       backupInterval,
+		RetentionCount: cfg.Backup.RetentionCount,
+		RetentionDays:  cfg.Backup.RetentionDays,
+		BackupDir:      cfg.Backup.BackupDir,
+	}, db, cfg.Database.Type, cfg.Database.DSN)
+
+	// Configure cloud storage if enabled
+	if cfg.Backup.CloudEnabled {
+		cloudStorage, err := backup.NewS3Storage(backup.StorageConfig{
+			Enabled:   true,
+			Type:      cfg.Backup.CloudType,
+			Endpoint:  cfg.Backup.CloudEndpoint,
+			Region:    cfg.Backup.CloudRegion,
+			Bucket:    cfg.Backup.CloudBucket,
+			Prefix:    cfg.Backup.CloudPrefix,
+			AccessKey: cfg.Backup.CloudAccessKey,
+			SecretKey: cfg.Backup.CloudSecretKey,
+			UseSSL:    cfg.Backup.CloudUseSSL,
+			Encrypt:   cfg.Backup.CloudEncrypt,
+		})
+		if err != nil {
+			slog.Warn("failed to initialize cloud storage, local backup only", "error", err)
+		} else {
+			backupSvc.SetStorage(cloudStorage)
+			if cfg.Backup.CloudEncrypt && encKey != nil {
+				backupSvc.SetEncryptionKey(encKey)
+			}
+			slog.Info("cloud backup storage enabled", "type", cfg.Backup.CloudType, "bucket", cfg.Backup.CloudBucket)
+		}
+	}
+	backupSvc.Start()
+
+	srv := server.New(listenAddr, db, bridge, cfg, tokenBlacklist, oauthSvc, rdb, backupSvc)
 
 	// Initialize and start Prometheus metrics server
 	metrics.Init()
@@ -277,6 +317,9 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 	// 4. Stop monitor if running
 	if bridge.Monitor != nil {
 		bridge.Monitor.Stop()
+	}
+	if backupSvc != nil {
+		backupSvc.Stop()
 	}
 
 	// 5. Close event bus

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -100,7 +100,9 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	db.Exec(`CREATE TABLE IF NOT EXISTS backup_records (
 		id TEXT PRIMARY KEY, app_id TEXT, filename TEXT, file_path TEXT,
 		file_size INTEGER, db_type TEXT, status TEXT DEFAULT 'completed',
-		error TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		error TEXT, storage_type TEXT DEFAULT 'local', storage_path TEXT DEFAULT '',
+		storage_bucket TEXT DEFAULT '', file_checksum TEXT DEFAULT '', encrypted INTEGER DEFAULT 0,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS clusters (
 		id TEXT PRIMARY KEY, tenant_id TEXT, name TEXT NOT NULL,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -214,6 +214,8 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			system.POST("/backup/trigger", auth.RoleRequired("owner", "admin"), TriggerBackup(backupSvc))
 			system.GET("/backup/records", ListBackupRecords(backupSvc))
 			system.DELETE("/backup/records/:id", auth.RoleRequired("owner", "admin"), DeleteBackupRecord(backupSvc))
+			system.POST("/backup/cloud/download/:id", auth.RoleRequired("owner", "admin"), DownloadCloudBackup(backupSvc))
+			system.POST("/backup/cloud/retention", auth.RoleRequired("owner", "admin"), ApplyCloudRetention(backupSvc))
 		}
 
 	// Public health check endpoint (no auth required for Docker healthcheck)

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -317,7 +317,11 @@ func GetBackupStatus(backupSvc *backup.Service) gin.HandlerFunc {
 			c.JSON(http.StatusOK, gin.H{"status": "success", "data": gin.H{"enabled": false}})
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"status": "success", "data": backupSvc.GetStatus()})
+		status := backupSvc.GetStatus()
+		// Include cloud storage status
+		cloudStatus := backupSvc.GetCloudStatus()
+		status["cloud"] = cloudStatus
+		c.JSON(http.StatusOK, gin.H{"status": "success", "data": status})
 	}
 }
 
@@ -403,6 +407,50 @@ func DeleteBackupRecord(backupSvc *backup.Service) gin.HandlerFunc {
 // @Accept       json
 // @Produce      json
 // @Security     BearerAuth
+
+// DownloadCloudBackup downloads a backup from cloud storage to local.
+// @Summary      Download cloud backup
+// @Description  Download a backup from cloud storage to local filesystem
+// @Tags         System
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Backup record ID"
+// @Success      200 {object} map[string]interface{}
+// @Router       /system/backup/cloud/download/{id} [post]
+func DownloadCloudBackup(backupSvc *backup.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if backupSvc == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "backup service not available"})
+			return
+		}
+		id := c.Param("id")
+		localPath, err := backupSvc.DownloadFromCloud(c.Request.Context(), id)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "success", "message": "backup downloaded", "local_path": localPath})
+	}
+}
+
+// ApplyCloudRetention triggers cloud backup retention cleanup.
+// @Summary      Apply cloud retention
+// @Description  Manually trigger cloud backup retention policy cleanup
+// @Tags         System
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{}
+// @Router       /system/backup/cloud/retention [post]
+func ApplyCloudRetention(backupSvc *backup.Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if backupSvc == nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "backup service not available"})
+			return
+		}
+		backupSvc.ApplyCloudRetention(c.Request.Context())
+		c.JSON(http.StatusOK, gin.H{"status": "success", "message": "cloud retention applied"})
+	}
+}
 // @Param        id path string true "Confirmation ID"
 // @Success      200 {object} map[string]interface{}
 // @Router       /system/confirmations/{id}/reject [post]

--- a/internal/backup/encrypt.go
+++ b/internal/backup/encrypt.go
@@ -1,0 +1,95 @@
+package backup
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const (
+	// Encryption header: "DPENC01" (8 bytes) + nonce (12 bytes) + ciphertext
+	encryptionHeader = "DPENC01"
+	headerSize       = 8
+	nonceSize        = 12
+)
+
+// EncryptBackup encrypts data using AES-256-GCM.
+// The output format is: header (8 bytes) + nonce (12 bytes) + ciphertext + tag.
+// The key must be exactly 32 bytes (AES-256).
+func EncryptBackup(key, plaintext []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("encryption key must be 32 bytes, got %d", len(key))
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, nonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+
+	// Prepend header + nonce
+	result := make([]byte, 0, headerSize+nonceSize+len(ciphertext))
+	result = append(result, []byte(encryptionHeader)...)
+	result = append(result, nonce...)
+	result = append(result, ciphertext...)
+
+	return result, nil
+}
+
+// DecryptBackup decrypts data that was encrypted with EncryptBackup.
+func DecryptBackup(key, data []byte) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("encryption key must be 32 bytes, got %d", len(key))
+	}
+
+	if len(data) < headerSize+nonceSize {
+		return nil, fmt.Errorf("encrypted data too short: %d bytes", len(data))
+	}
+
+	// Verify header
+	header := string(data[:headerSize])
+	if header != encryptionHeader {
+		return nil, fmt.Errorf("invalid encryption header: expected %q, got %q", encryptionHeader, header)
+	}
+
+	nonce := data[headerSize : headerSize+nonceSize]
+	ciphertext := data[headerSize+nonceSize:]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// IsEncryptedBackup checks if data was encrypted by EncryptBackup.
+func IsEncryptedBackup(data []byte) bool {
+	if len(data) < headerSize {
+		return false
+	}
+	return string(data[:headerSize]) == encryptionHeader
+}

--- a/internal/backup/s3_storage.go
+++ b/internal/backup/s3_storage.go
@@ -26,7 +26,6 @@ type s3Storage struct {
 	prefix    string
 	accessKey string
 	secretKey string
-	useSSL    bool
 	client    *http.Client
 }
 
@@ -112,7 +111,7 @@ func (s *s3Storage) Upload(ctx context.Context, key string, reader io.Reader, si
 		host, contentSHA256, datetime)
 	signedHeaders := "content-type;host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("PUT\n%s\n\n%s\n%s%s",
+	canonicalRequest := fmt.Sprintf("PUT\n%s\n\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -140,7 +139,7 @@ func (s *s3Storage) Upload(ctx context.Context, key string, reader io.Reader, si
 	if err != nil {
 		return fmt.Errorf("s3 upload: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
@@ -166,7 +165,7 @@ func (s *s3Storage) Download(ctx context.Context, key string) (io.ReadCloser, in
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("GET\n%s\n\n%s\n%s%s",
+	canonicalRequest := fmt.Sprintf("GET\n%s\n\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -193,7 +192,7 @@ func (s *s3Storage) Download(ctx context.Context, key string) (io.ReadCloser, in
 	}
 
 	if resp.StatusCode >= 300 {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		return nil, 0, fmt.Errorf("s3 download failed (HTTP %d)", resp.StatusCode)
 	}
 
@@ -215,7 +214,7 @@ func (s *s3Storage) Delete(ctx context.Context, key string) error {
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("DELETE\n%s\n\n%s\n%s%s",
+	canonicalRequest := fmt.Sprintf("DELETE\n%s\n\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -240,7 +239,7 @@ func (s *s3Storage) Delete(ctx context.Context, key string) error {
 	if err != nil {
 		return fmt.Errorf("s3 delete: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 && resp.StatusCode != 404 {
 		body, _ := io.ReadAll(resp.Body)
@@ -300,7 +299,7 @@ func (s *s3Storage) List(ctx context.Context, prefix string) ([]StorageObject, e
 	if err != nil {
 		return nil, fmt.Errorf("s3 list: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
@@ -372,7 +371,7 @@ func (s *s3Storage) Exists(ctx context.Context, key string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("s3 exists: request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	return resp.StatusCode == 200, nil
 }

--- a/internal/backup/s3_storage.go
+++ b/internal/backup/s3_storage.go
@@ -111,7 +111,7 @@ func (s *s3Storage) Upload(ctx context.Context, key string, reader io.Reader, si
 		host, contentSHA256, datetime)
 	signedHeaders := "content-type;host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("PUT\n%s\n\n%s\n%s\n%s",
+	canonicalRequest := fmt.Sprintf("PUT\n%s\n%s\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -165,7 +165,7 @@ func (s *s3Storage) Download(ctx context.Context, key string) (io.ReadCloser, in
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("GET\n%s\n\n%s\n%s\n%s",
+	canonicalRequest := fmt.Sprintf("GET\n%s\n%s\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -214,7 +214,7 @@ func (s *s3Storage) Delete(ctx context.Context, key string) error {
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("DELETE\n%s\n\n%s\n%s\n%s",
+	canonicalRequest := fmt.Sprintf("DELETE\n%s\n%s\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -274,7 +274,7 @@ func (s *s3Storage) List(ctx context.Context, prefix string) ([]StorageObject, e
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("GET\n%s\n%s\n%s\n%s%s",
+	canonicalRequest := fmt.Sprintf("GET\n%s\n%s\n%s\n%s\n%s",
 		canonicalURI, escapedQuery, canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
@@ -346,7 +346,7 @@ func (s *s3Storage) Exists(ctx context.Context, key string) (bool, error) {
 		host, contentSHA256, datetime)
 	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
 
-	canonicalRequest := fmt.Sprintf("HEAD\n%s\n\n%s\n%s%s",
+	canonicalRequest := fmt.Sprintf("HEAD\n%s\n%s\n%s\n%s\n%s",
 		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
 
 	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)

--- a/internal/backup/s3_storage.go
+++ b/internal/backup/s3_storage.go
@@ -1,0 +1,428 @@
+package backup
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+// s3Storage implements StorageProvider using S3-compatible API.
+// Supports AWS S3, Aliyun OSS, Tencent COS, MinIO, and any S3-compatible storage.
+type s3Storage struct {
+	endpoint  string
+	region    string
+	bucket   string
+	prefix    string
+	accessKey string
+	secretKey string
+	useSSL    bool
+	client    *http.Client
+}
+
+// NewS3Storage creates a new S3-compatible storage provider.
+func NewS3Storage(cfg StorageConfig) (StorageProvider, error) {
+	if cfg.Endpoint == "" {
+		return nil, fmt.Errorf("s3 storage: endpoint is required")
+	}
+	if cfg.Bucket == "" {
+		return nil, fmt.Errorf("s3 storage: bucket is required")
+	}
+	if cfg.AccessKey == "" || cfg.SecretKey == "" {
+		return nil, fmt.Errorf("s3 storage: access_key and secret_key are required")
+	}
+
+	endpoint := cfg.Endpoint
+	if cfg.UseSSL && !strings.HasPrefix(endpoint, "https://") {
+		if strings.HasPrefix(endpoint, "http://") {
+			endpoint = "https://" + endpoint[7:]
+		} else {
+			endpoint = "https://" + endpoint
+		}
+	} else if !cfg.UseSSL && !strings.HasPrefix(endpoint, "http") {
+		endpoint = "http://" + endpoint
+	}
+
+	prefix := cfg.Prefix
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	region := cfg.Region
+	if region == "" {
+		region = "us-east-1"
+	}
+
+	return &s3Storage{
+		endpoint:  endpoint,
+		region:    region,
+		bucket:   cfg.Bucket,
+		prefix:    prefix,
+		accessKey: cfg.AccessKey,
+		secretKey: cfg.SecretKey,
+		client: &http.Client{
+			Timeout: 10 * time.Minute, // large file uploads
+		},
+	}, nil
+}
+
+func (s *s3Storage) Type() StorageType {
+	switch {
+	case strings.Contains(s.endpoint, "aliyuncs.com"):
+		return StorageOSS
+	case strings.Contains(s.endpoint, "myqcloud.com"):
+		return StorageCOS
+	case strings.Contains(s.endpoint, "minio"):
+		return StorageMinIO
+	default:
+		return StorageS3
+	}
+}
+
+// Upload uploads an object to S3 using PutObject.
+func (s *s3Storage) Upload(ctx context.Context, key string, reader io.Reader, size int64) error {
+	fullKey := s.prefix + key
+
+	// Read all content into memory for signing (simple approach for backup files)
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		return fmt.Errorf("s3 upload: failed to read content: %w", err)
+	}
+	content := buf.Bytes()
+
+	date := time.Now().UTC().Format("20060102")
+	datetime := time.Now().UTC().Format("20060102T150405Z")
+	host := s.bucket + "." + s.endpointURL().Host
+
+	// Build canonical request
+	canonicalURI := "/" + s.bucket + "/" + fullKey
+	contentSHA256 := sha256Hex(content)
+
+	canonicalHeaders := fmt.Sprintf("content-type:application/octet-stream\nhost:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+		host, contentSHA256, datetime)
+	signedHeaders := "content-type;host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := fmt.Sprintf("PUT\n%s\n\n%s\n%s%s",
+		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
+	stringToSign := aws4StringToSign(datetime, credentialScope, sha256Hex([]byte(canonicalRequest)))
+
+	signature := s.sign(datetime, stringToSign)
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s.accessKey, credentialScope, signedHeaders, signature)
+
+	reqURL := fmt.Sprintf("%s://%s/%s", s.endpointURL().Scheme, host, fullKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(content))
+	if err != nil {
+		return fmt.Errorf("s3 upload: failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Host", host)
+	req.Header.Set("x-amz-content-sha256", contentSHA256)
+	req.Header.Set("x-amz-date", datetime)
+	req.Header.Set("Authorization", authHeader)
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(content)))
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("s3 upload: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("s3 upload failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	slog.Info("uploaded backup to cloud storage", "key", fullKey, "size", len(content))
+	return nil
+}
+
+// Download downloads an object from S3.
+func (s *s3Storage) Download(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	fullKey := s.prefix + key
+
+	date := time.Now().UTC().Format("20060102")
+	datetime := time.Now().UTC().Format("20060102T150405Z")
+	host := s.bucket + "." + s.endpointURL().Host
+
+	canonicalURI := "/" + s.bucket + "/" + fullKey
+	contentSHA256 := sha256Hex([]byte{})
+
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+		host, contentSHA256, datetime)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := fmt.Sprintf("GET\n%s\n\n%s\n%s%s",
+		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
+	stringToSign := aws4StringToSign(datetime, credentialScope, sha256Hex([]byte(canonicalRequest)))
+	signature := s.sign(datetime, stringToSign)
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s.accessKey, credentialScope, signedHeaders, signature)
+
+	reqURL := fmt.Sprintf("%s://%s/%s", s.endpointURL().Scheme, host, fullKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("s3 download: failed to create request: %w", err)
+	}
+
+	req.Header.Set("Host", host)
+	req.Header.Set("x-amz-content-sha256", contentSHA256)
+	req.Header.Set("x-amz-date", datetime)
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("s3 download: request failed: %w", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		resp.Body.Close()
+		return nil, 0, fmt.Errorf("s3 download failed (HTTP %d)", resp.StatusCode)
+	}
+
+	return resp.Body, resp.ContentLength, nil
+}
+
+// Delete removes an object from S3.
+func (s *s3Storage) Delete(ctx context.Context, key string) error {
+	fullKey := s.prefix + key
+
+	date := time.Now().UTC().Format("20060102")
+	datetime := time.Now().UTC().Format("20060102T150405Z")
+	host := s.bucket + "." + s.endpointURL().Host
+
+	canonicalURI := "/" + s.bucket + "/" + fullKey
+	contentSHA256 := sha256Hex([]byte{})
+
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+		host, contentSHA256, datetime)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := fmt.Sprintf("DELETE\n%s\n\n%s\n%s%s",
+		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
+	stringToSign := aws4StringToSign(datetime, credentialScope, sha256Hex([]byte(canonicalRequest)))
+	signature := s.sign(datetime, stringToSign)
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s.accessKey, credentialScope, signedHeaders, signature)
+
+	reqURL := fmt.Sprintf("%s://%s/%s", s.endpointURL().Scheme, host, fullKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("s3 delete: failed to create request: %w", err)
+	}
+
+	req.Header.Set("Host", host)
+	req.Header.Set("x-amz-content-sha256", contentSHA256)
+	req.Header.Set("x-amz-date", datetime)
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("s3 delete: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 && resp.StatusCode != 404 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("s3 delete failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	slog.Info("deleted backup from cloud storage", "key", fullKey)
+	return nil
+}
+
+// List lists objects with the given prefix.
+func (s *s3Storage) List(ctx context.Context, prefix string) ([]StorageObject, error) {
+	listPrefix := s.prefix + prefix
+	if listPrefix != "" && !strings.HasSuffix(listPrefix, "/") {
+		listPrefix += "/"
+	}
+
+	date := time.Now().UTC().Format("20060102")
+	datetime := time.Now().UTC().Format("20060102T150405Z")
+	host := s.bucket + "." + s.endpointURL().Host
+
+	query := url.Values{}
+	query.Set("list-type", "2")
+	query.Set("prefix", listPrefix)
+	query.Set("max-keys", "1000")
+
+	canonicalURI := "/" + s.bucket + "/"
+	escapedQuery := query.Encode()
+	contentSHA256 := sha256Hex([]byte{})
+
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+		host, contentSHA256, datetime)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := fmt.Sprintf("GET\n%s\n%s\n%s\n%s%s",
+		canonicalURI, escapedQuery, canonicalHeaders, signedHeaders, contentSHA256)
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
+	stringToSign := aws4StringToSign(datetime, credentialScope, sha256Hex([]byte(canonicalRequest)))
+	signature := s.sign(datetime, stringToSign)
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s.accessKey, credentialScope, signedHeaders, signature)
+
+	reqURL := fmt.Sprintf("%s://%s/?%s", s.endpointURL().Scheme, host, escapedQuery)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("s3 list: failed to create request: %w", err)
+	}
+
+	req.Header.Set("Host", host)
+	req.Header.Set("x-amz-content-sha256", contentSHA256)
+	req.Header.Set("x-amz-date", datetime)
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("s3 list: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("s3 list failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var listResult s3ListResultV2
+	if err := xml.NewDecoder(resp.Body).Decode(&listResult); err != nil {
+		return nil, fmt.Errorf("s3 list: failed to decode response: %w", err)
+	}
+
+	var objects []StorageObject
+	for _, item := range listResult.Contents {
+		// Strip the configured prefix from the key
+		key := strings.TrimPrefix(item.Key, s.prefix)
+		objects = append(objects, StorageObject{
+			Key:          key,
+			Size:         item.Size,
+			LastModified: item.LastModified,
+			ETag:         strings.Trim(item.ETag, "\""),
+		})
+	}
+
+	// Sort by last modified (newest first)
+	sort.Slice(objects, func(i, j int) bool {
+		return objects[i].LastModified.After(objects[j].LastModified)
+	})
+
+	return objects, nil
+}
+
+// Exists checks if an object exists in S3 using HeadObject.
+func (s *s3Storage) Exists(ctx context.Context, key string) (bool, error) {
+	fullKey := s.prefix + key
+
+	date := time.Now().UTC().Format("20060102")
+	datetime := time.Now().UTC().Format("20060102T150405Z")
+	host := s.bucket + "." + s.endpointURL().Host
+
+	canonicalURI := "/" + s.bucket + "/" + fullKey
+	contentSHA256 := sha256Hex([]byte{})
+
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-content-sha256:%s\nx-amz-date:%s\n",
+		host, contentSHA256, datetime)
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+
+	canonicalRequest := fmt.Sprintf("HEAD\n%s\n\n%s\n%s%s",
+		canonicalURI, "", canonicalHeaders, signedHeaders, contentSHA256)
+
+	credentialScope := fmt.Sprintf("%s/%s/s3/aws4_request", date, s.region)
+	stringToSign := aws4StringToSign(datetime, credentialScope, sha256Hex([]byte(canonicalRequest)))
+	signature := s.sign(datetime, stringToSign)
+
+	authHeader := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s.accessKey, credentialScope, signedHeaders, signature)
+
+	reqURL := fmt.Sprintf("%s://%s/%s", s.endpointURL().Scheme, host, fullKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("s3 exists: failed to create request: %w", err)
+	}
+
+	req.Header.Set("Host", host)
+	req.Header.Set("x-amz-content-sha256", contentSHA256)
+	req.Header.Set("x-amz-date", datetime)
+	req.Header.Set("Authorization", authHeader)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("s3 exists: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == 200, nil
+}
+
+// endpointURL returns the parsed endpoint URL.
+func (s *s3Storage) endpointURL() *url.URL {
+	u, _ := url.Parse(s.endpoint)
+	if u == nil {
+		u = &url.URL{Host: s.endpoint}
+	}
+	return u
+}
+
+// sign generates an AWS4-HMAC-SHA256 signature.
+func (s *s3Storage) sign(datetime, stringToSign string) string {
+	date := datetime[:8]
+	hmacKey := hmacSHA256([]byte("AWS4"+s.secretKey), []byte(date))
+	hmacKey = hmacSHA256(hmacKey, []byte(s.region))
+	hmacKey = hmacSHA256(hmacKey, []byte("s3"))
+	hmacKey = hmacSHA256(hmacKey, []byte("aws4_request"))
+	return hex.EncodeToString(hmacSHA256(hmacKey, []byte(stringToSign)))
+}
+
+// hmacSHA256 computes HMAC-SHA256.
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// sha256Hex returns the hex-encoded SHA-256 hash.
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// aws4StringToSign builds the AWS4 string to sign.
+func aws4StringToSign(datetime, credentialScope, hashedCanonicalRequest string) string {
+	return fmt.Sprintf("AWS4-HMAC-SHA256\n%s\n%s\n%s", datetime, credentialScope, hashedCanonicalRequest)
+}
+
+// S3 ListObjectsV2 response types
+type s3ListResultV2 struct {
+	XMLName xml.Name `xml:"ListBucketResult"`
+	Contents []s3Object
+}
+
+type s3Object struct {
+	Key          string    `xml:"Key"`
+	Size         int64     `xml:"Size"`
+	LastModified time.Time `xml:"LastModified"`
+	ETag         string    `xml:"ETag"`
+}

--- a/internal/backup/service.go
+++ b/internal/backup/service.go
@@ -2,7 +2,10 @@ package backup
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -40,28 +43,35 @@ func DefaultConfig() Config {
 
 // Record represents a database backup record.
 type Record struct {
-	ID        string    `gorm:"primaryKey" json:"id"`
-	Type      string    `json:"type"`                // "database" or "container"
-	AppID     string    `gorm:"index" json:"app_id,omitempty"` // empty for system DB backups
-	Status    string    `json:"status"`              // "completed", "failed"
-	FilePath  string    `json:"file_path"`
-	FileSize  int64     `json:"file_size"`
-	Trigger   string    `json:"trigger"`             // "manual", "scheduled", "pre_deploy"
-	Error     string    `json:"error,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	ID            string    `gorm:"primaryKey" json:"id"`
+	Type          string    `json:"type"`                // "database" or "container"
+	AppID         string    `gorm:"index" json:"app_id,omitempty"` // empty for system DB backups
+	Status        string    `json:"status"`              // "completed", "failed"
+	FilePath      string    `json:"file_path"`
+	FileSize      int64     `json:"file_size"`
+	Trigger       string    `json:"trigger"`             // "manual", "scheduled", "pre_deploy"
+	Error         string    `json:"error,omitempty"`
+	StorageType   string    `gorm:"column:storage_type" json:"storage_type,omitempty"`   // "local", "s3", "oss", "cos", "minio"
+	StoragePath   string    `gorm:"column:storage_path" json:"storage_path,omitempty"`   // cloud storage key
+	StorageBucket string    `gorm:"column:storage_bucket" json:"storage_bucket,omitempty"` // cloud bucket name
+	FileChecksum  string    `gorm:"column:file_checksum" json:"file_checksum,omitempty"` // SHA-256 checksum
+	Encrypted     bool      `gorm:"column:encrypted" json:"encrypted,omitempty"`          // whether backup is encrypted
+	CreatedAt     time.Time `json:"created_at"`
 }
 
 func (Record) TableName() string { return "backup_records" }
 
 // Service manages database backups with scheduling and retention.
 type Service struct {
-	mu       sync.Mutex
-	config   Config
-	db       *gorm.DB
-	dsn      string
-	dbType   string
-	cancel   context.CancelFunc
-	running  bool
+	mu            sync.Mutex
+	config        Config
+	db            *gorm.DB
+	dsn           string
+	dbType        string
+	cancel        context.CancelFunc
+	running       bool
+	storage       StorageProvider // optional: cloud storage backend
+	encryptKey    []byte          // optional: 32-byte AES-256 key for backup encryption
 }
 
 // New creates a new backup service.
@@ -160,6 +170,19 @@ func (s *Service) GetConfig() Config {
 	return s.config
 }
 
+// SetStorage sets the cloud storage provider for uploading backups.
+func (s *Service) SetStorage(provider StorageProvider) {
+	s.storage = provider
+}
+
+// SetEncryptionKey sets the AES-256 encryption key for backup encryption.
+// The key must be exactly 32 bytes.
+func (s *Service) SetEncryptionKey(key []byte) {
+	if len(key) == 32 {
+		s.encryptKey = key
+	}
+}
+
 // CreateBackup performs a database backup.
 // For SQLite, it uses the .backup API for hot backup.
 // For other databases, it uses the appropriate dump mechanism.
@@ -213,6 +236,10 @@ func (s *Service) CreateBackup(ctx context.Context, trigger string) (*Record, er
 	// Clean up old backups after successful backup
 	if record.Status == "completed" {
 		s.ApplyRetention(ctx)
+		// Upload to cloud storage if configured
+		if s.storage != nil {
+			s.uploadToCloud(ctx, record)
+		}
 	}
 
 	return record, backupErr
@@ -511,4 +538,219 @@ func (s *Service) saveRecord(record *Record) {
 	if err := s.db.Create(record).Error; err != nil {
 		slog.Error("failed to save backup record", "error", err)
 	}
+}
+
+// uploadToCloud uploads a completed local backup to cloud storage.
+func (s *Service) uploadToCloud(ctx context.Context, record *Record) {
+	if s.storage == nil || record.FilePath == "" {
+		return
+	}
+
+	f, err := os.Open(record.FilePath)
+	if err != nil {
+		slog.Error("failed to open backup file for cloud upload", "path", record.FilePath, "error", err)
+		return
+	}
+	defer f.Close()
+
+	// Compute checksum before upload
+	checksum, err := s.computeFileChecksum(record.FilePath)
+	if err != nil {
+		slog.Warn("failed to compute checksum before upload", "error", err)
+	}
+
+	// Optionally encrypt before upload
+	var reader io.Reader = f
+	encrypted := false
+	if s.encryptKey != nil {
+		data, err := io.ReadAll(f)
+		if err != nil {
+			slog.Error("failed to read backup for encryption", "error", err)
+			return
+		}
+		encryptedData, err := EncryptBackup(s.encryptKey, data)
+		if err != nil {
+			slog.Error("failed to encrypt backup", "error", err)
+			return
+		}
+		reader = strings.NewReader(string(encryptedData))
+		encrypted = true
+	}
+
+	// Generate cloud storage key: prefix + type + timestamp + filename
+	filename := filepath.Base(record.FilePath)
+	cloudKey := fmt.Sprintf("database/%s", filename)
+
+	if err := s.storage.Upload(ctx, cloudKey, reader, record.FileSize); err != nil {
+		slog.Error("failed to upload backup to cloud storage", "key", cloudKey, "error", err)
+		return
+	}
+
+	// Update record with cloud metadata
+	updates := map[string]interface{}{
+		"storage_type":   string(s.storage.Type()),
+		"storage_path":   cloudKey,
+		"storage_bucket": "", // bucket info is in the storage provider config
+		"file_checksum":  checksum,
+		"encrypted":      encrypted,
+	}
+	if s.db != nil {
+		s.db.Model(&Record{}).Where("id = ?", record.ID).Updates(updates)
+	}
+
+	slog.Info("backup uploaded to cloud storage", "record_id", record.ID, "key", cloudKey, "encrypted", encrypted)
+}
+
+// DownloadFromCloud downloads a backup from cloud storage and saves it locally.
+func (s *Service) DownloadFromCloud(ctx context.Context, recordID string) (string, error) {
+	if s.storage == nil {
+		return "", fmt.Errorf("cloud storage not configured")
+	}
+	if s.db == nil {
+		return "", fmt.Errorf("database not available")
+	}
+
+	var record Record
+	if err := s.db.Where("id = ?", recordID).First(&record).Error; err != nil {
+		return "", fmt.Errorf("backup record not found: %w", err)
+	}
+	if record.StoragePath == "" {
+		return "", fmt.Errorf("backup record has no cloud storage path")
+	}
+
+	reader, size, err := s.storage.Download(ctx, record.StoragePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to download from cloud: %w", err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("failed to read cloud backup data: %w", err)
+	}
+
+	// Decrypt if needed
+	if record.Encrypted && s.encryptKey != nil {
+		data, err = DecryptBackup(s.encryptKey, data)
+		if err != nil {
+			return "", fmt.Errorf("failed to decrypt backup: %w", err)
+		}
+	}
+
+	// Save to local backup directory
+	if err := os.MkdirAll(s.config.BackupDir, 0750); err != nil {
+		return "", fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	localPath := filepath.Join(s.config.BackupDir, filepath.Base(record.StoragePath))
+	if err := os.WriteFile(localPath, data, 0640); err != nil {
+		return "", fmt.Errorf("failed to write local backup: %w", err)
+	}
+
+	slog.Info("backup downloaded from cloud storage", "record_id", recordID, "local_path", localPath, "size", size)
+	return localPath, nil
+}
+
+// DeleteFromCloud removes a backup from cloud storage.
+func (s *Service) DeleteFromCloud(ctx context.Context, recordID string) error {
+	if s.storage == nil {
+		return fmt.Errorf("cloud storage not configured")
+	}
+	if s.db == nil {
+		return fmt.Errorf("database not available")
+	}
+
+	var record Record
+	if err := s.db.Where("id = ?", recordID).First(&record).Error; err != nil {
+		return fmt.Errorf("backup record not found: %w", err)
+	}
+	if record.StoragePath == "" {
+		return fmt.Errorf("backup record has no cloud storage path")
+	}
+
+	if err := s.storage.Delete(ctx, record.StoragePath); err != nil {
+		return fmt.Errorf("failed to delete from cloud: %w", err)
+	}
+
+	// Clear cloud metadata from record
+	s.db.Model(&Record{}).Where("id = ?", recordID).Updates(map[string]interface{}{
+		"storage_type":   "",
+		"storage_path":   "",
+		"storage_bucket": "",
+	})
+
+	slog.Info("backup deleted from cloud storage", "record_id", recordID)
+	return nil
+}
+
+// ApplyCloudRetention applies retention policy to cloud-stored backups.
+func (s *Service) ApplyCloudRetention(ctx context.Context) {
+	if s.storage == nil {
+		return
+	}
+
+	objects, err := s.storage.List(ctx, "database/")
+	if err != nil {
+		slog.Warn("failed to list cloud backups for retention", "error", err)
+		return
+	}
+
+	if len(objects) <= s.config.RetentionCount {
+		return
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -s.config.RetentionDays)
+	removed := 0
+
+	for _, obj := range objects {
+		shouldRemove := false
+		if s.config.RetentionDays > 0 && obj.LastModified.Before(cutoff) {
+			shouldRemove = true
+		}
+		// Also remove oldest if exceeding count
+		if s.config.RetentionCount > 0 && (len(objects)-removed) > s.config.RetentionCount {
+			shouldRemove = true
+		}
+
+		if shouldRemove {
+			if err := s.storage.Delete(ctx, obj.Key); err != nil {
+				slog.Warn("failed to delete old cloud backup", "key", obj.Key, "error", err)
+			} else {
+				slog.Info("removed old cloud backup", "key", obj.Key, "age", time.Since(obj.LastModified).Round(time.Hour))
+				removed++
+			}
+		}
+	}
+
+	if removed > 0 {
+		slog.Info("cloud backup retention cleanup completed", "removed", removed)
+	}
+}
+
+// computeFileChecksum computes SHA-256 checksum of a file.
+func (s *Service) computeFileChecksum(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// GetCloudStatus returns the cloud storage configuration status.
+func (s *Service) GetCloudStatus() map[string]interface{} {
+	status := make(map[string]interface{})
+	if s.storage != nil {
+		status["enabled"] = true
+		status["type"] = string(s.storage.Type())
+		status["encryption"] = s.encryptKey != nil
+	} else {
+		status["enabled"] = false
+	}
+	return status
 }

--- a/internal/backup/service.go
+++ b/internal/backup/service.go
@@ -551,7 +551,7 @@ func (s *Service) uploadToCloud(ctx context.Context, record *Record) {
 		slog.Error("failed to open backup file for cloud upload", "path", record.FilePath, "error", err)
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Compute checksum before upload
 	checksum, err := s.computeFileChecksum(record.FilePath)
@@ -622,7 +622,7 @@ func (s *Service) DownloadFromCloud(ctx context.Context, recordID string) (strin
 	if err != nil {
 		return "", fmt.Errorf("failed to download from cloud: %w", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
@@ -733,7 +733,7 @@ func (s *Service) computeFileChecksum(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {

--- a/internal/backup/service_test.go
+++ b/internal/backup/service_test.go
@@ -33,6 +33,11 @@ func setupTestService(t *testing.T) (*Service, func()) {
 		file_size INTEGER DEFAULT 0,
 		trigger TEXT DEFAULT 'manual',
 		error TEXT,
+		storage_type TEXT DEFAULT 'local',
+		storage_path TEXT DEFAULT '',
+		storage_bucket TEXT DEFAULT '',
+		file_checksum TEXT DEFAULT '',
+		encrypted INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 
@@ -146,6 +151,11 @@ func TestCreateBackup_WithRealDB(t *testing.T) {
 		file_size INTEGER DEFAULT 0,
 		trigger TEXT DEFAULT 'manual',
 		error TEXT,
+		storage_type TEXT DEFAULT 'local',
+		storage_path TEXT DEFAULT '',
+		storage_bucket TEXT DEFAULT '',
+		file_checksum TEXT DEFAULT '',
+		encrypted INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 
@@ -278,6 +288,11 @@ func TestDeleteRecord(t *testing.T) {
 		file_size INTEGER DEFAULT 0,
 		trigger TEXT DEFAULT 'manual',
 		error TEXT,
+		storage_type TEXT DEFAULT 'local',
+		storage_path TEXT DEFAULT '',
+		storage_bucket TEXT DEFAULT '',
+		file_checksum TEXT DEFAULT '',
+		encrypted INTEGER DEFAULT 0,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 

--- a/internal/backup/storage.go
+++ b/internal/backup/storage.go
@@ -1,0 +1,62 @@
+package backup
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// StorageType defines the type of cloud storage backend.
+type StorageType string
+
+const (
+	StorageLocal StorageType = "local"
+	StorageS3    StorageType = "s3"
+	StorageOSS   StorageType = "oss"
+	StorageCOS   StorageType = "cos"
+	StorageMinIO StorageType = "minio"
+)
+
+// StorageConfig holds cloud storage connection configuration.
+type StorageConfig struct {
+	Enabled     bool   `mapstructure:"enabled"`
+	Type        string `mapstructure:"type"`          // s3, oss, cos, minio
+	Endpoint    string `mapstructure:"endpoint"`      // e.g. "https://s3.amazonaws.com"
+	Region      string `mapstructure:"region"`        // e.g. "us-east-1"
+	Bucket      string `mapstructure:"bucket"`        // bucket name
+	Prefix      string `mapstructure:"prefix"`        // key prefix, e.g. "deploypilot/backups/"
+	AccessKey   string `mapstructure:"access_key"`
+	SecretKey   string `mapstructure:"secret_key"`
+	UseSSL      bool   `mapstructure:"use_ssl"`       // default: true
+	Encrypt     bool   `mapstructure:"encrypt"`       // enable AES-256-GCM encryption before upload
+}
+
+// StorageProvider defines the interface for cloud storage backends.
+// Implementations support S3-compatible object storage (AWS S3, Aliyun OSS, Tencent COS, MinIO).
+type StorageProvider interface {
+	// Upload uploads a file to cloud storage.
+	Upload(ctx context.Context, key string, reader io.Reader, size int64) error
+
+	// Download downloads a file from cloud storage.
+	Download(ctx context.Context, key string) (io.ReadCloser, int64, error)
+
+	// Delete removes a file from cloud storage.
+	Delete(ctx context.Context, key string) error
+
+	// List lists objects with the given prefix.
+	List(ctx context.Context, prefix string) ([]StorageObject, error)
+
+	// Exists checks if an object exists.
+	Exists(ctx context.Context, key string) (bool, error)
+
+	// Type returns the storage type.
+	Type() StorageType
+}
+
+// StorageObject represents a cloud storage object.
+type StorageObject struct {
+	Key          string    `json:"key"`
+	Size         int64     `json:"size"`
+	LastModified time.Time `json:"last_modified"`
+	ETag         string    `json:"etag,omitempty"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,17 @@ type BackupConfig struct {
 	RetentionCount int    `mapstructure:"retention_count"`  // max backup files (default: 10)
 	RetentionDays  int    `mapstructure:"retention_days"`   // max days to keep (default: 30)
 	BackupDir      string `mapstructure:"backup_dir"`       // backup directory (default: ./data/backups)
+	// Cloud storage configuration (S3-compatible)
+	CloudEnabled   bool   `mapstructure:"cloud_enabled"`
+	CloudType      string `mapstructure:"cloud_type"`           // s3, oss, cos, minio
+	CloudEndpoint  string `mapstructure:"cloud_endpoint"`       // e.g. "https://s3.amazonaws.com"
+	CloudRegion    string `mapstructure:"cloud_region"`         // e.g. "us-east-1"
+	CloudBucket    string `mapstructure:"cloud_bucket"`         // bucket name
+	CloudPrefix    string `mapstructure:"cloud_prefix"`         // key prefix
+	CloudAccessKey string `mapstructure:"cloud_access_key"`
+	CloudSecretKey string `mapstructure:"cloud_secret_key"`
+	CloudUseSSL    bool   `mapstructure:"cloud_use_ssl"`
+	CloudEncrypt   bool   `mapstructure:"cloud_encrypt"`        // AES-256-GCM encryption
 }
 
 // BruteForceConfig holds brute-force protection settings.

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -550,6 +550,29 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("alert_rules")
 			},
 		},
+		// 202605020002: Add cloud storage columns to backup_records
+		{
+			ID: "202605020002",
+			Migrate: func(tx *gorm.DB) error {
+				if err := ignoreDuplicateColumnError(tx, tx.Exec("ALTER TABLE backup_records ADD COLUMN storage_type TEXT DEFAULT 'local'").Error); err != nil {
+					return err
+				}
+				if err := ignoreDuplicateColumnError(tx, tx.Exec("ALTER TABLE backup_records ADD COLUMN storage_path TEXT DEFAULT ''").Error); err != nil {
+					return err
+				}
+				if err := ignoreDuplicateColumnError(tx, tx.Exec("ALTER TABLE backup_records ADD COLUMN storage_bucket TEXT DEFAULT ''").Error); err != nil {
+					return err
+				}
+				if err := ignoreDuplicateColumnError(tx, tx.Exec("ALTER TABLE backup_records ADD COLUMN file_checksum TEXT DEFAULT ''").Error); err != nil {
+					return err
+				}
+				return ignoreDuplicateColumnError(tx, tx.Exec("ALTER TABLE backup_records ADD COLUMN encrypted INTEGER DEFAULT 0").Error)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				// SQLite doesn't support DROP COLUMN easily; table rebuild needed
+				return nil
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Yogdunana/deploypilot/internal/api"
 	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/backup"
 	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/i18n"
 	"github.com/Yogdunana/deploypilot/internal/middleware"
@@ -32,7 +33,7 @@ type Server struct {
 }
 
 // New creates a new API server with the given address, database, bridge, and config.
-func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, rdb *redis.Client) *Server {
+func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, rdb *redis.Client, backupSvc *backup.Service) *Server {
 	r := gin.Default()
 
 	// Request tracing — must be first middleware
@@ -81,7 +82,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	// Set encryption key for 2FA TOTP secret encryption
 	api.SetEncryptionKey(bridge.EncryptionKey)
 
-	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, nil, keySvc)
+	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, backupSvc, keySvc)
 
 	// Serve embedded frontend static files
 	serveStaticFiles(r)


### PR DESCRIPTION
## Summary

Implements **v1.3 Phase 3.12**: Multi-cloud backup (S3 protocol adapter + encryption + retention policy).

## Changes

### S3-Compatible Cloud Storage
- `StorageProvider` interface with Upload/Download/Delete/List/Exists methods
- `s3Storage` implementation using AWS4-HMAC-SHA256 signing (zero external dependencies)
- Auto-detects storage type (AWS S3, Aliyun OSS, Tencent COS, MinIO) from endpoint
- Supports any S3-compatible object storage

### Backup Encryption
- AES-256-GCM encryption with custom `DPENC01` header format
- `EncryptBackup` / `DecryptBackup` / `IsEncryptedBackup` utility functions
- Optional encryption before cloud upload (uses existing DEPLOYPILOT_ENCRYPTION_KEY)

### Configuration & Database
- `BackupConfig` extended with cloud storage fields (endpoint, bucket, region, access keys, SSL, encryption toggle)
- Database migration `202605020002`: adds storage_type, storage_path, storage_bucket, file_checksum, encrypted columns to backup_records
- `Record` struct extended with cloud metadata fields

### Service Integration
- `Service.SetStorage()` and `Service.SetEncryptionKey()` for dependency injection
- Auto-upload to cloud after successful local backup
- SHA-256 checksum computation before upload
- `DownloadFromCloud` with automatic decryption
- `DeleteFromCloud` with metadata cleanup
- `ApplyCloudRetention` for cloud-side retention policy

### API Layer
- `GET /system/backup/status` now includes cloud storage status
- `POST /system/backup/cloud/download/:id` — download cloud backup to local
- `POST /system/backup/cloud/retention` — trigger cloud retention cleanup

### Lifecycle
- `server.New()` now accepts `backupSvc` parameter
- `main.go` initializes backupSvc with cloud storage config
- Graceful shutdown stops backup scheduler

## Files Changed
- **3 new files**: storage.go, s3_storage.go, encrypt.go
- **7 modified files**: service.go, config.go, database.go, system.go, router.go, server.go, main.go