### PR TITLE
feat(onboarding): add first-login detection, onboarding status, and demo data generation (Phase 4.8)

### DIFF
--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -89,7 +89,7 @@
 | 4.5 | CORS 安全加固（可配置 Origin/Method/Header/Credentials/Expose） | ✅ 已完成 (PR #184) |
 | 4.6 | 前端补全（集群、Registry、插件、批量操作、活动流） |
 | 4.7 | 日志审计增强（操作/访问/系统/登录 4 类日志 + 导出、归档、实时通知、append-only） | ✅ 已完成 (PR #185) |
-| 4.8 | Onboarding 引导（首次登录流程 + 空状态提示 + Demo 应用） |
+| 4.8 | Onboarding 引导（首次登录流程 + 空状态提示 + Demo 应用） | ✅ 已完成 (PR #186) |
 
 **相关 Issue**: #43
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -53,6 +53,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		username TEXT UNIQUE NOT NULL, email TEXT UNIQUE NOT NULL, password_hash TEXT NOT NULL,
 		auth_provider TEXT, auth_uid TEXT, avatar_url TEXT,
 		totp_secret TEXT, totp_enabled INTEGER DEFAULT 0, backup_codes TEXT,
+		onboarding_completed INTEGER DEFAULT 0, last_login_at DATETIME,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS credentials (

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -361,15 +361,25 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 			})
 		}
 
+		// Detect first login and update last_login_at
+		isFirstLogin := user.LastLoginAt == nil && !user.OnboardingCompleted
+		now := time.Now()
+		db.Model(&user).Updates(map[string]interface{}{
+			"last_login_at": now,
+		})
+
 		respondSuccess(c, gin.H{
 			"user": model.User{
-				ID:       user.ID,
-				TenantID: user.TenantID,
-				RoleID:   user.RoleID,
-				Username: user.Username,
-				Email:    user.Email,
+				ID:                 user.ID,
+				TenantID:           user.TenantID,
+				RoleID:             user.RoleID,
+				Username:           user.Username,
+				Email:              user.Email,
+				OnboardingCompleted: user.OnboardingCompleted,
+				LastLoginAt:        &now,
 			},
-			"token": token,
+			"token":          token,
+			"is_first_login": isFirstLogin,
 		})
 	}
 }

--- a/internal/api/onboarding.go
+++ b/internal/api/onboarding.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// CompleteOnboarding marks the current user's onboarding as completed.
+// PUT /api/v1/users/me/onboarding
+func CompleteOnboarding(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		result := db.Model(&model.User{}).
+			Where("id = ?", uid).
+			Update("onboarding_completed", true)
+		if result.Error != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		respondSuccess(c, gin.H{"message": "onboarding completed"})
+	}
+}
+
+// GetOnboardingStatus returns the current user's onboarding status and empty state hints.
+// GET /api/v1/users/me/onboarding
+func GetOnboardingStatus(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var user model.User
+		if err := db.Select("id, tenant_id, onboarding_completed, last_login_at").
+			Where("id = ?", uid).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		// Check empty states for each resource type
+		var serverCount, appCount, credCount int64
+		db.Model(&model.Server{}).Where("tenant_id = ?", user.TenantID).Count(&serverCount)
+		db.Model(&model.App{}).Where("tenant_id = ?", user.TenantID).Count(&appCount)
+		db.Model(&model.Credential{}).Where("tenant_id = ?", user.TenantID).Count(&credCount)
+
+		isFirstLogin := user.LastLoginAt == nil && !user.OnboardingCompleted
+
+		respondSuccess(c, gin.H{
+			"onboarding_completed": user.OnboardingCompleted,
+			"is_first_login":       isFirstLogin,
+			"empty_state": gin.H{
+				"no_servers":      serverCount == 0,
+				"no_apps":          appCount == 0,
+				"no_credentials":   credCount == 0,
+				"server_count":     serverCount,
+				"app_count":        appCount,
+				"credential_count": credCount,
+			},
+		})
+	}
+}
+
+// GenerateDemoData creates sample demo resources (server, app, credential) for the current user.
+// POST /api/v1/users/me/demo
+func GenerateDemoData(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID, _ := c.Get(string(auth.UserIDKey))
+		uid, _ := userID.(string)
+		if uid == "" {
+			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
+			return
+		}
+
+		var user model.User
+		if err := db.Select("id, tenant_id").Where("id = ?", uid).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+
+		// Check if demo data already exists
+		var existingCount int64
+		db.Model(&model.Server{}).Where("tenant_id = ? AND name LIKE ?", user.TenantID, "Demo%").Count(&existingCount)
+		if existingCount > 0 {
+			c.JSON(http.StatusConflict, gin.H{
+				"status":  "error",
+				"message": "demo data already exists",
+			})
+			return
+		}
+
+		// Create demo credential
+		credID := uuid.New().String()
+		demoCred := model.Credential{
+			ID:             credID,
+			TenantID:       user.TenantID,
+			Name:           "Demo SSH Key",
+			Type:           "ssh",
+			EncryptedValue: "demo-encrypted-key-content",
+			RotationDays:   0,
+		}
+		if err := db.Create(&demoCred).Error; err != nil {
+			slog.Error("failed to create demo credential", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		// Create demo server
+		serverID := uuid.New().String()
+		demoServer := model.Server{
+			ID:           serverID,
+			TenantID:     user.TenantID,
+			CredentialID: credID,
+			Name:         "Demo Server",
+			Host:         "demo.example.com",
+			Port:         22,
+			Status:       "unknown",
+			Tags:         `["demo","example"]`,
+		}
+		if err := db.Create(&demoServer).Error; err != nil {
+			slog.Error("failed to create demo server", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		// Create demo app
+		appID := uuid.New().String()
+		demoApp := model.App{
+			ID:        appID,
+			TenantID:  user.TenantID,
+			ServerID:  serverID,
+			Name:      "Demo App",
+			RepoURL:   "https://github.com/example/demo-app",
+			Branch:    "main",
+			TechStack: "docker",
+			DeployMode: "api",
+			Status:    "pending",
+		}
+		if err := db.Create(&demoApp).Error; err != nil {
+			slog.Error("failed to create demo app", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		slog.Info("demo data generated", "user_id", uid, "tenant_id", user.TenantID)
+
+		respondSuccess(c, gin.H{
+			"message": "demo data generated",
+			"created": gin.H{
+				"credential": gin.H{"id": credID, "name": demoCred.Name},
+				"server":     gin.H{"id": serverID, "name": demoServer.Name},
+				"app":        gin.H{"id": appID, "name": demoApp.Name},
+			},
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -184,6 +184,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		users := protected.Group("/users")
 		{
 			users.GET("/me", GetCurrentUser)
+			users.GET("/me/onboarding", GetOnboardingStatus(db))
+			users.PUT("/me/onboarding", CompleteOnboarding(db))
+			users.POST("/me/demo", GenerateDemoData(db))
 			users.GET("", auth.RoleRequired("owner", "admin"), ListUsers(db))
 			users.DELETE("/:id", auth.RoleRequired("owner"), DeleteUser(db))
 			users.PUT("/:id/role", auth.RoleRequired("owner", "admin"), UpdateUserRole(db))

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -624,6 +624,28 @@ func Migrate(db *gorm.DB) error {
 				return nil
 			},
 		},
+		// 202605010400: Add onboarding_completed and last_login_at to users
+		{
+			ID: "202605010400",
+			Migrate: func(tx *gorm.DB) error {
+				if err := tx.Exec("ALTER TABLE users ADD COLUMN onboarding_completed BOOLEAN DEFAULT false").Error; err != nil {
+					if !strings.Contains(err.Error(), "duplicate column") {
+						return err
+					}
+				}
+				if err := tx.Exec("ALTER TABLE users ADD COLUMN last_login_at DATETIME").Error; err != nil {
+					if !strings.Contains(err.Error(), "duplicate column") {
+						return err
+					}
+				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				_ = tx.Migrator().DropColumn("users", "onboarding_completed")
+				_ = tx.Migrator().DropColumn("users", "last_login_at")
+				return nil
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -28,20 +28,22 @@ func (Role) TableName() string { return "roles" }
 
 // User represents a system user.
 type User struct {
-	ID           string    `gorm:"primaryKey" json:"id"`
-	TenantID     string    `gorm:"index" json:"tenant_id"`
-	RoleID       string    `gorm:"index" json:"role_id"`
-	Username     string    `gorm:"uniqueIndex;not null" json:"username"`
-	Email        string    `gorm:"uniqueIndex;not null" json:"email"`
-	PasswordHash string    `gorm:"" json:"-"`
-	AuthProvider string `gorm:"size:20;index" json:"auth_provider,omitempty"`
-	AuthUID      string `gorm:"size:100;index" json:"auth_uid,omitempty"`
-	AvatarURL    string `gorm:"size:500" json:"avatar_url,omitempty"`
-	TOTPSecret   string    `gorm:"size:256" json:"-"`
-	TOTPEnabled  bool      `gorm:"default:false" json:"totp_enabled"`
-	BackupCodes  string    `gorm:"type:text" json:"-"`
-	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt    time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	ID                 string     `gorm:"primaryKey" json:"id"`
+	TenantID           string     `gorm:"index" json:"tenant_id"`
+	RoleID             string     `gorm:"index" json:"role_id"`
+	Username           string     `gorm:"uniqueIndex;not null" json:"username"`
+	Email              string     `gorm:"uniqueIndex;not null" json:"email"`
+	PasswordHash       string     `gorm:"" json:"-"`
+	AuthProvider       string     `gorm:"size:20;index" json:"auth_provider,omitempty"`
+	AuthUID            string     `gorm:"size:100;index" json:"auth_uid,omitempty"`
+	AvatarURL          string     `gorm:"size:500" json:"avatar_url,omitempty"`
+	TOTPSecret         string     `gorm:"size:256" json:"-"`
+	TOTPEnabled        bool       `gorm:"default:false" json:"totp_enabled"`
+	BackupCodes        string     `gorm:"type:text" json:"-"`
+	OnboardingCompleted bool      `gorm:"default:false" json:"onboarding_completed"`
+	LastLoginAt        *time.Time `json:"last_login_at,omitempty"`
+	CreatedAt          time.Time  `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt          time.Time  `gorm:"autoUpdateTime" json:"updated_at"`
 
 	Tenant Tenant `gorm:"foreignKey:TenantID" json:"tenant,omitempty"`
 	Role   Role   `gorm:"foreignKey:RoleID" json:"role,omitempty"`


### PR DESCRIPTION
## Summary

Implements **v1.4 Phase 4.8**: Onboarding guidance with first-login detection, empty state hints, and demo data generation.

## Changes

### Model & Migration
- `User` model: added `onboarding_completed` (bool) and `last_login_at` (datetime) fields
- Migration `202605010400` (SQLite compatible)

### Login Enhancement
- Login response now includes `is_first_login` flag
- Login response includes `onboarding_completed` and `last_login_at` in user object
- `last_login_at` updated on every successful login
- First login detected when `last_login_at` is nil and onboarding not completed

### New API Endpoints
- `GET /api/v1/users/me/onboarding` — onboarding status + empty state hints
  - Returns: `onboarding_completed`, `is_first_login`, `empty_state` (no_servers, no_apps, no_credentials with counts)
- `PUT /api/v1/users/me/onboarding` — mark onboarding as completed
- `POST /api/v1/users/me/demo` — generate demo data (credential + server + app)
  - Idempotent: returns 409 if demo data already exists

## Files Changed
- **1 new file**: api/onboarding.go
- **5 modified files**: model/model.go, api/auth.go, api/router.go, database/database.go, Roadmap.md