### PR TITLE
fix: use correct actions-wiki version (v0.3.0)

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Sync docs/wiki to GitHub Wiki
-        uses: spenserblack/actions-wiki@v1
+        uses: spenserblack/actions-wiki@v0.3.0
         with:
           path: docs/wiki


### PR DESCRIPTION
## Summary
Fix wiki-sync action version: `spenserblack/actions-wiki@v1` does not exist, changed to `@v0.3.0` (latest stable release).