### PR TITLE
docs: rewrite Issue lifecycle guide + add Phase Issue Form + standardize labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/phase.yml
+++ b/.github/ISSUE_TEMPLATE/phase.yml
@@ -1,0 +1,57 @@
+name: Phase Issue (Roadmap)
+description: Create a new Roadmap Phase issue with standardized format
+title: "[vX.X] "
+labels: ["enhancement", "in progress"]
+assignees: ["Yogdunana"]
+body:
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: Which version does this Phase belong to?
+      options:
+        - v1.5
+        - v1.6
+        - v1.7
+        - v1.8
+        - v1.9
+        - v1.10
+        - v1.11+
+    validations:
+      required: true
+
+  - type: input
+    id: phase
+    attributes:
+      label: Phase Number
+      description: e.g., 5.7
+      placeholder: "X.X"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Phase Description
+      description: What does this Phase implement?
+      placeholder: Brief description of the feature...
+    validations:
+      required: true
+
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: List of specific tasks (use - [ ] for checkboxes)
+      placeholder: |
+        - [ ] Task 1
+        - [ ] Task 2
+        - [ ] Task 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes / Constraints
+      description: Any technical notes, dependencies, or constraints.

--- a/docs/ai-guide.md
+++ b/docs/ai-guide.md
@@ -2,7 +2,7 @@
 
 > 本文件为唯一权威版本，位于 `docs/ai-guide.md`。
 > 此文件为 AI 助手操作本项目时的参考指南，避免重复踩坑。
-> **最后更新**: 2026-05-01 (Phase 5.6 完成, 新增全资源同步要求 + 踩坑 #37-#42)
+> **最后更新**: 2026-05-01 (Issue 标准规范重写 + Phase Issue Form + Labels 体系 + 踩坑 #43)
 
 ---
 
@@ -393,6 +393,10 @@ Markdown 表格的列头行必须与数据行列数一致。如果列头只有 2
 GitHub Wiki 是一个独立的 git 仓库（`<repo>.wiki.git`），修改 `docs/wiki/` 中的文件不会自动反映到 GitHub Wiki 页面。
 **解决方案**: 使用 GitHub Actions（如 `spencerblack/actions-wiki@v1`）在 push 到 main 时自动同步。
 
+### 43. Issue 元数据不完整导致进度追踪困难
+创建 Issue 时如果不设置 assignee、labels、milestone、project，会导致 Project Board 和 Milestone 进度不准确。
+**解决方案**: 使用 Issue Form 模板自动设置 assignee 和 labels；Guide 中定义了 Issue 标准规范，每个 Issue 必须包含完整元数据。
+
 ---
 
 ## 项目结构关键路径
@@ -576,146 +580,112 @@ Bridge God Object 已拆分为 18 个文件，87 个方法按领域分布：
 
 ## Issue & Milestone 生命周期管理
 
-> 这是 AI Agent 协作开发的核心流程。所有 Agent 必须遵循此流程来管理需求和进度追踪。
+> 这是 AI Agent 协作开发的核心流程。所有 Agent 必须遵循此流程。
 
-### 整体流程图
+### Issue 标准规范
 
-```
-需求提出 → 创建 Milestone → 创建子 Issues → 开发实现 → 关联 PR → 关闭 Issue → 关闭 Milestone → 发布版本
-```
+**每个 Issue 必须包含的元数据**：
 
-### 1. Milestone 管理
+| 字段 | 要求 | 示例 |
+|------|------|------|
+| **Title** | `[vX.X] Phase 名称` 或 `🐛 Bug: 描述` | `[v1.5] Event Bus System` |
+| **Assignees** | 必须指定 `@Yogdunana` | — |
+| **Labels** | 至少 2 个: type + priority | `enhancement`, `priority: medium` |
+| **Milestone** | 必须关联到对应版本 | `v1.5: Notification & Alerting` |
+| **Project** | 必须添加到 DeployPilot Roadmap | — |
+| **Body** | 必须包含 Tasks (checkbox) + Notes | — |
 
-**何时创建 Milestone**:
-- 每个 Roadmap 版本（v1.x）对应一个 GitHub Milestone
-- Milestone 在该版本开始开发**之前**创建
-- 标题格式: `v1.x: 简短描述`（如 `v1.5: Notification & Alerting`）
-- 描述中包含该版本的所有 Phase 列表
+**标准 Labels 体系**：
 
-**Milestone 状态**:
-- `OPEN`: 版本开发中
-- `CLOSED`: 版本已发布（所有 Phase 完成 + Release 创建后）
+| 类别 | Labels | 说明 |
+|------|--------|------|
+| **Type** | `bug`, `enhancement`, `documentation`, `refactor`, `testing` | 工作类型 |
+| **Priority** | `priority: critical`, `priority: high`, `priority: medium`, `priority: low` | 优先级 |
+| **Status** | `in progress`, `blocked` | 当前状态 |
+| **Area** | `area: backend`, `area: frontend`, `area: infra`, `area: docs` | 代码区域 |
+| **Special** | `security`, `architecture`, `ui/ux`, `developer-experience` | 特殊标记 |
 
-**不要做的事**:
-- ❌ 不要在 Milestone 中混入不属于该版本的 Issue
-- ❌ 不要在版本未完成时关闭 Milestone
-- ❌ 不要创建没有对应 Roadmap Phase 的 Milestone
-
-### 2. Issue 管理
-
-**何时创建 Issue**:
-- 每个 Roadmap Phase 对应一个 GitHub Issue
-- Issue 在该 Phase **开始开发之前**创建
-- 标题格式: `[v1.x] Phase 描述`（如 `[v1.5] Event Bus System`）
-- 必须关联到正确的 Milestone
-
-**Issue 类型**:
-| 类型 | 标题格式 | 示例 |
-|------|----------|------|
-| 功能 Phase | `[v1.x] Phase 名称` | `[v1.5] Event Bus System` |
-| Bug | `🐛 Bug: 描述` | `🐛 Bug: Memory leak in WebSocket` |
-| 增强 | `✨ Enhancement: 描述` | `✨ Enhancement: Add dark mode` |
-
-**Issue 生命周期**:
-```
-OPEN (创建) → IN_PROGRESS (开发中) → CLOSED (PR 合并时自动关闭)
-```
-
-**Issue 与 PR 的关联**:
-- PR 描述中必须包含 `Closes #xx` 或 `Fixes #xx`
-- 这样 PR 合并时 GitHub 会自动关闭关联的 Issue
-- 如果一个 PR 覆盖多个 Phase，关闭对应的所有 Issue
-
-**Issue 内容模板**:
-```markdown
-## 目标
-简要描述该 Phase 要实现什么
-
-## 范围
-- 具体要做的事情列表
-- 不包含什么（明确边界）
-
-## 验收标准
-- [ ] 功能点 1
-- [ ] 功能点 2
-- [ ] 测试通过
-- [ ] 文档更新
-
-## 关联
-- Roadmap: Phase X.X
-- Milestone: v1.x
-```
-
-### 3. 开发过程中的 Issue 操作
-
-**每个 Phase 开发前**:
-1. 确认该 Phase 对应的 Issue 存在且关联了正确的 Milestone
-2. 如果 Issue 不存在，先创建 Issue
-3. 如果 Milestone 不存在，先创建 Milestone
-
-**每个 Phase 完成后**:
-1. PR 描述中写 `Closes #xx` 关联 Issue
-2. PR 合并后确认 Issue 自动关闭
-3. 如果 Issue 未自动关闭，手动关闭并添加评论说明
-
-**版本所有 Phase 完成后**:
-1. 确认 Milestone 中 0 个 open issue
-2. 如果有延后的 Phase，将对应 Issue 移到下一个版本的 Milestone
-3. 关闭 Milestone
-4. 执行版本发布流程（见下方）
-
-### 4. 新需求接入流程
-
-当用户提出新需求时，按以下顺序操作：
+### Issue 生命周期
 
 ```
-Step 1: 评估需求
-  ↓ 确定属于哪个版本（当前版本 or 未来版本）
-Step 2: 创建/更新 Milestone（如果版本 milestone 不存在）
-  ↓
-Step 3: 创建 Issue（关联到对应 Milestone）
-  ↓
-Step 4: 更新 Roadmap.md（添加 Phase 条目）
-  ↓
-Step 5: 开始开发
+创建 → 认领 → 开发 → PR 关联 → Review → 合并关闭
 ```
 
-**关键规则**:
-- **先 Milestone，后 Issue**: Milestone 是容器，Issue 是任务
-- **先 Issue，后开发**: 不要直接开发而不创建 Issue
-- **PR 必须关联 Issue**: 通过 `Closes #xx` 确保可追溯性
-- **Issue 必须关联 Milestone**: 确保进度可追踪
+#### 1. 创建 Issue
+- 使用 Issue Form 模板（Phase Issue / Bug Report / Feature Request）
+- 自动获得: assignee (@Yogdunana) + labels (enhancement, in progress) + title prefix
+- 手动关联: Milestone + Project Board
+- Body 必须包含: Tasks (checkbox list) + Notes
 
-### 5. 多 Agent 协作时的 Issue 管理
+#### 2. 认领 Issue（开始开发前）
+- 确认 assignee 已设置
+- 确认 milestone 已关联
+- 确认 labels 完整（type + priority + area）
+- 确认 Project Board 已添加
+- 创建开发分支: `feat/phase-X.X` 或 `fix/xxx`
 
-当多个 Agent 同时开发不同 Phase 时：
+#### 3. 开发过程中
+- 在 Issue 中评论进度（可选）
+- 遇到阻塞时: 添加 `blocked` label + 评论说明原因
+- PR 创建后: PR 描述中写 `Closes #xx` 或 `Fixes #xx`
+- Development 面板会自动关联 PR
 
-1. **每个 Agent 开始前检查**: 该 Phase 的 Issue 是否已被其他 Agent 认领
-   - 查看 Issue 是否有 `in-progress` label 或被 assign
-   - 如果已被认领，选择其他 Phase 或等待
+#### 4. Review 阶段
+- CI 通过后等待 review
+- Review 通过后合并
 
-2. **开发过程中更新 Issue**: 在 Issue 中评论进度
-   - `@agent 正在实现 Phase X.X，预计 PR #xxx`
-   - 遇到阻塞时及时评论
+#### 5. 合并关闭
+- PR 合并时通过 `Closes #xx` 自动关闭 Issue
+- 如果未自动关闭，手动关闭并评论说明
+- 从 Project Board 移到 Done 列
 
-3. **完成后更新 Issue**: PR 合并后确认 Issue 关闭
-   - 如果 Issue 未自动关闭，手动关闭
+### Development 关联说明
 
-### 6. Issue/Milestone 自动化检查清单
+> **何时关联**: PR 创建时自动关联，无需手动操作。
+>
+> **关联方式**: PR 描述中包含 `Closes #xx` / `Fixes #xx` / `Resolves #xx`。
+>
+> **效果**: GitHub 自动在 Issue 的 Development 面板显示关联的 PR 和分支。
+>
+> **注意**: 不要在开发前就关联分支，应在 PR 创建时通过 `Closes #xx` 一次性关联。
 
-完成一个 Phase 后，检查以下项：
-- [ ] Issue 已关闭（通过 PR 的 `Closes #xx` 或手动）
-- [ ] Issue 关联了正确的 Milestone
-- [ ] PR 描述中引用了 Issue 编号
-- [ ] Roadmap.md 中该 Phase 标记为 ✅
+### Milestone 管理
 
-完成一个版本后，检查以下项：
-- [ ] Milestone 中 0 个 open issue
-- [ ] Milestone 已关闭
-- [ ] CHANGELOG 已更新
-- [ ] Tag + Release 已创建
-- [ ] 无孤立的 open issue（所有 issue 都关联了 milestone）
-- [ ] **重复 Issue 清理**: 检查新版本 Milestone 中的 Issue 是否与已实现功能重复，关闭并评论 "已在 vX.X Phase X.X 中实现"
+**何时创建**: 版本开始开发前
+**标题格式**: `v1.x: 简短描述`
+**何时关闭**: 版本所有 Phase 完成 + Release 创建后
+
+### 新需求接入流程
+
+```
+评估需求 → 创建/确认 Milestone → 创建 Issue (用 Form) → 关联 Project → 开发 → PR (Closes #xx) → 合并 → 关闭 Issue
+```
+
+### 多 Agent 协作规则
+
+1. **开始前检查**: Issue 是否有 assignee / in-progress label
+2. **开发中更新**: 遇到阻塞及时评论
+3. **完成后确认**: Issue 自动/手动关闭
+
+### 自动化检查清单
+
+**Phase 完成后**:
+- [ ] Issue 已关闭 (Closes #xx)
+- [ ] Milestone 关联正确
+- [ ] Roadmap.md 标记 ✅
+- [ ] 踩坑记录更新（如有新坑）
+- [ ] 当前待办更新
+- [ ] **Issue 元数据**: 确认 assignee + labels + milestone + project 完整
+
+**版本完成后**:
+- [ ] Milestone 0 open issues → 关闭
+- [ ] CHANGELOG 更新
+- [ ] Tag + Release 创建
+- [ ] Project Board 更新
+- [ ] Discussions 发布公告
+- [ ] 重复 Issue 清理: 检查新版本 Milestone 中的 Issue 是否与已实现功能重复，关闭并评论 "已在 vX.X Phase X.X 中实现"
+
+```
 
 ## 版本发布流程
 


### PR DESCRIPTION
## Summary

Standardizes the entire Issue lifecycle management workflow in ai-guide, adds a Phase Issue Form template, creates missing labels, and batch-updates all existing Issues with complete metadata.

## Changes

### Guide Rewrite (docs/ai-guide.md)
- **Issue 标准规范**: Every Issue must have assignee + 2+ labels + milestone + project
- **标准 Labels 体系**: type (5) + priority (4) + status (2) + area (4) + special (4) = 19 labels
- **Issue 生命周期**: 创建 → 认领 → 开发 → PR 关联 → Review → 合并关闭 (5 stages)
- **Development 关联**: PR 创建时通过 `Closes #xx` 自动关联，不在开发前手动关联
- **新需求接入流程**: 评估 → Milestone → Issue(Form) → Project → 开发 → PR → 合并
- **多 Agent 协作规则**: 开始前检查 / 开发中更新 / 完成后确认
- **检查清单**: Phase 完成后 + 版本完成后
- **踩坑 #43**: Issue 元数据不完整

### New Phase Issue Form (.github/ISSUE_TEMPLATE/phase.yml)
- Auto-assignee: @Yogdunana
- Auto-labels: enhancement + in progress
- Fields: Version dropdown, Phase number, Description, Tasks, Notes

### GitHub Metadata Updates (via API)
- **9 new labels**: in progress, blocked, priority: critical/high/medium/low, area: backend/frontend/infra/docs
- **10 Issues**: assigned @Yogdunana (#201-#209, #177)
- **36 Issues**: added priority:medium + area labels
- **36 Issues**: added to DeployPilot Roadmap Project