### PR TITLE
feat: add process daemon management (Phase 5.7)

### DIFF
--- a/internal/api/process_api.go
+++ b/internal/api/process_api.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// ProcessAPI provides HTTP handlers for remote process management.
+type ProcessAPI struct {
+	procSvc *service.ProcessService
+}
+
+// NewProcessAPI creates a new ProcessAPI.
+func NewProcessAPI(db *gorm.DB) *ProcessAPI {
+	return &ProcessAPI{
+		procSvc: service.NewProcessService(db),
+	}
+}
+
+// ListProcesses lists processes on a remote server.
+// GET /api/v1/servers/:server_id/processes?filter=nginx
+func (p *ProcessAPI) ListProcesses(c *gin.Context) {
+	serverID := c.Param("server_id")
+	filter := c.Query("filter")
+
+	stats, err := p.procSvc.ListProcesses(c.Request.Context(), serverID, filter)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, stats)
+}
+
+// GetProcess gets details of a specific process by PID.
+// GET /api/v1/servers/:server_id/processes/:pid
+func (p *ProcessAPI) GetProcess(c *gin.Context) {
+	serverID := c.Param("server_id")
+	pid, err := strconv.Atoi(c.Param("pid"))
+	if err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	info, err := p.procSvc.GetProcess(c.Request.Context(), serverID, pid)
+	if err != nil {
+		respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+		return
+	}
+
+	respondSuccess(c, info)
+}
+
+// KillProcess sends a signal to a process.
+// POST /api/v1/servers/:server_id/processes/:pid/kill
+func (p *ProcessAPI) KillProcess(c *gin.Context) {
+	serverID := c.Param("server_id")
+	pid, err := strconv.Atoi(c.Param("pid"))
+	if err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	var req struct {
+		Signal string `json:"signal"`
+	}
+	_ = c.ShouldBindJSON(&req) // signal is optional
+
+	if err := p.procSvc.KillProcess(c.Request.Context(), serverID, pid, req.Signal); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"pid": pid, "signal": req.Signal, "status": "sent"})
+}
+
+// SearchProcesses searches for processes matching a pattern.
+// GET /api/v1/servers/:server_id/processes/search?pattern=nginx
+func (p *ProcessAPI) SearchProcesses(c *gin.Context) {
+	serverID := c.Param("server_id")
+	pattern := c.Query("pattern")
+	if pattern == "" {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	processes, err := p.procSvc.SearchProcesses(c.Request.Context(), serverID, pattern)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, processes)
+}
+
+// GetProcessTree returns the process tree.
+// GET /api/v1/servers/:server_id/processes/tree
+func (p *ProcessAPI) GetProcessTree(c *gin.Context) {
+	serverID := c.Param("server_id")
+
+	processes, err := p.procSvc.GetProcessTree(c.Request.Context(), serverID)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, processes)
+}
+
+// GetSystemResources returns system resource usage.
+// GET /api/v1/servers/:server_id/resources
+func (p *ProcessAPI) GetSystemResources(c *gin.Context) {
+	serverID := c.Param("server_id")
+
+	resources, err := p.procSvc.SystemResources(c.Request.Context(), serverID)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, resources)
+}
+
+// ========== Process Rules (CRUD) ==========
+
+// CreateRule creates a new process monitoring rule.
+// POST /api/v1/processes/rules
+func (p *ProcessAPI) CreateRule(c *gin.Context) {
+	var rule service.ProcessRule
+	if err := c.ShouldBindJSON(&rule); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	if err := p.procSvc.CreateRule(c.Request.Context(), &rule); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, rule)
+}
+
+// ListRules lists all process monitoring rules.
+// GET /api/v1/processes/rules?server_id=xxx
+func (p *ProcessAPI) ListRules(c *gin.Context) {
+	tenantID := c.GetString("tenant_id")
+	serverID := c.Query("server_id")
+
+	rules, err := p.procSvc.ListRules(c.Request.Context(), tenantID, serverID)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, rules)
+}
+
+// GetRule gets a process monitoring rule by ID.
+// GET /api/v1/processes/rules/:id
+func (p *ProcessAPI) GetRule(c *gin.Context) {
+	id := c.Param("id")
+
+	rule, err := p.procSvc.GetRule(c.Request.Context(), id)
+	if err != nil {
+		respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+		return
+	}
+
+	respondSuccess(c, rule)
+}
+
+// UpdateRule updates a process monitoring rule.
+// PUT /api/v1/processes/rules/:id
+func (p *ProcessAPI) UpdateRule(c *gin.Context) {
+	id := c.Param("id")
+
+	var rule service.ProcessRule
+	if err := c.ShouldBindJSON(&rule); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	rule.ID = id
+	if err := p.procSvc.UpdateRule(c.Request.Context(), &rule); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, rule)
+}
+
+// DeleteRule deletes a process monitoring rule.
+// DELETE /api/v1/processes/rules/:id
+func (p *ProcessAPI) DeleteRule(c *gin.Context) {
+	id := c.Param("id")
+
+	if err := p.procSvc.DeleteRule(c.Request.Context(), id); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"id": id, "status": "deleted"})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -153,6 +153,24 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			sshGroup.POST("/revoke", sshAPI.RevokeKey)
 		}
 
+		// Process daemon management
+		procAPI := NewProcessAPI(db)
+		servers.GET("/:id/processes", procAPI.ListProcesses)
+		servers.GET("/:id/processes/tree", procAPI.GetProcessTree)
+		servers.GET("/:id/processes/search", procAPI.SearchProcesses)
+		servers.GET("/:id/processes/:pid", procAPI.GetProcess)
+		servers.POST("/:id/processes/:pid/kill", procAPI.KillProcess)
+		servers.GET("/:id/resources", procAPI.GetSystemResources)
+
+		procGroup := protected.Group("/processes")
+		{
+			procGroup.GET("/rules", procAPI.ListRules)
+			procGroup.GET("/rules/:id", procAPI.GetRule)
+			procGroup.POST("/rules", procAPI.CreateRule)
+			procGroup.PUT("/rules/:id", procAPI.UpdateRule)
+			procGroup.DELETE("/rules/:id", procAPI.DeleteRule)
+		}
+
 		// Credentials (5 endpoints)
 		creds := protected.Group("/credentials")
 		{

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -727,6 +727,29 @@ func Migrate(db *gorm.DB) error {
 				return tx.Exec("DROP TABLE IF EXISTS ssh_key_pairs").Error
 			},
 		},
+		// 202605010800: Create process_rules table
+		{
+			ID: "202605010800",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec(`CREATE TABLE IF NOT EXISTS process_rules (
+					id TEXT PRIMARY KEY,
+					tenant_id TEXT,
+					server_id TEXT,
+					name TEXT NOT NULL,
+					process_pattern TEXT NOT NULL,
+					restart_command TEXT,
+					auto_restart INTEGER DEFAULT 0,
+					max_restarts INTEGER DEFAULT 5,
+					restart_count INTEGER DEFAULT 0,
+					enabled INTEGER DEFAULT 1,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				)`).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("DROP TABLE IF EXISTS process_rules").Error
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/service/process_service.go
+++ b/internal/service/process_service.go
@@ -321,7 +321,6 @@ func parsePsAuxLine(line string) *ProcessInfo {
 	}
 
 	cpu, _ := strconv.ParseFloat(matches[3], 64)
-	mem, _ := strconv.ParseFloat(matches[4], 64)
 	vsz, _ := strconv.ParseFloat(matches[5], 64)
 	rss, _ := strconv.ParseFloat(matches[6], 64)
 	pid, _ := strconv.Atoi(matches[2])

--- a/internal/service/process_service.go
+++ b/internal/service/process_service.go
@@ -1,0 +1,340 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ProcessInfo represents a running process on a remote server.
+type ProcessInfo struct {
+	PID         int     `json:"pid"`
+	User        string  `json:"user"`
+	CPU         float64 `json:"cpu"`
+	Memory      float64 `json:"memory"` // MB
+	VirtualMem  float64 `json:"virtual_memory"` // MB
+	State       string  `json:"state"`  // R, S, D, Z, T
+	Start       string  `json:"start"`
+	Time        string  `json:"time"`
+	Command     string  `json:"command"`
+}
+
+// ProcessStats represents aggregate process statistics.
+type ProcessStats struct {
+	Total      int     `json:"total"`
+	Running    int     `json:"running"`
+	Sleeping   int     `json:"sleeping"`
+	Stopped    int     `json:"stopped"`
+	Zombie     int     `json:"zombie"`
+	TotalCPU   float64 `json:"total_cpu"`
+	TotalMem   float64 `json:"total_mem"` // MB
+	Processes  []ProcessInfo `json:"processes,omitempty"`
+}
+
+// ProcessRule represents a monitoring rule for auto-restart.
+type ProcessRule struct {
+	ID             string `gorm:"primaryKey" json:"id"`
+	TenantID       string `gorm:"index" json:"tenant_id"`
+	ServerID       string `gorm:"index" json:"server_id"`
+	Name           string `gorm:"not null;size:100" json:"name"`
+	ProcessPattern string `gorm:"not null;size:500" json:"process_pattern"` // grep pattern
+	RestartCommand string `gorm:"size:1000" json:"restart_command"`
+	AutoRestart    bool   `gorm:"default:false" json:"auto_restart"`
+	MaxRestarts    int    `gorm:"default:5" json:"max_restarts"`
+	RestartCount   int    `gorm:"default:0" json:"restart_count"`
+	Enabled        bool   `gorm:"default:true" json:"enabled"`
+	CreatedAt      string `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt      string `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (ProcessRule) TableName() string { return "process_rules" }
+
+// ProcessService manages remote server processes via SSH.
+type ProcessService struct {
+	db     *gorm.DB
+	logger *slog.Logger
+}
+
+// NewProcessService creates a new ProcessService.
+func NewProcessService(db *gorm.DB) *ProcessService {
+	return &ProcessService{
+		db:     db,
+		logger: slog.Default(),
+	}
+}
+
+// ListProcesses lists processes on a remote server.
+func (p *ProcessService) ListProcesses(ctx context.Context, serverID string, filter string) (*ProcessStats, error) {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = exec.Close() }()
+
+	cmd := "ps aux --no-headers 2>/dev/null || ps aux 2>/dev/null"
+	if filter != "" {
+		cmd = fmt.Sprintf("ps aux --no-headers 2>/dev/null | grep -E %s | grep -v grep || ps aux 2>/dev/null | grep -E %s | grep -v grep",
+			shellQuote(filter), shellQuote(filter))
+	}
+
+	output, err := exec.RunCommand(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list processes: %w", err)
+	}
+
+	processes, stats := parsePsAux(output)
+	stats.Processes = processes
+
+	return &stats, nil
+}
+
+// GetProcess gets details of a specific process by PID.
+func (p *ProcessService) GetProcess(ctx context.Context, serverID string, pid int) (*ProcessInfo, error) {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = exec.Close() }()
+
+	cmd := fmt.Sprintf("ps -p %d -o pid=,user=,%%cpu=,%%mem=,vsz=,rss=,stat=,start=,time=,args= --no-headers 2>/dev/null", pid)
+	output, err := exec.RunCommand(ctx, cmd)
+	if err != nil || output == "" {
+		return nil, fmt.Errorf("process %d not found", pid)
+	}
+
+	processes, _ := parsePsAux(output)
+	if len(processes) == 0 {
+		return nil, fmt.Errorf("process %d not found", pid)
+	}
+	return &processes[0], nil
+}
+
+// KillProcess sends a signal to a process.
+func (p *ProcessService) KillProcess(ctx context.Context, serverID string, pid int, signal string) error {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = exec.Close() }()
+
+	if signal == "" {
+		signal = "TERM"
+	}
+
+	// Validate signal
+	validSignals := map[string]bool{
+		"TERM": true, "KILL": true, "HUP": true, "INT": true,
+		"USR1": true, "USR2": true, "STOP": true, "CONT": true,
+	}
+	if !validSignals[signal] {
+		return fmt.Errorf("invalid signal: %s", signal)
+	}
+
+	cmd := fmt.Sprintf("sudo kill -%s %d", signal, pid)
+	_, err = exec.RunCommand(ctx, cmd)
+	return err
+}
+
+// SearchProcesses searches for processes matching a pattern.
+func (p *ProcessService) SearchProcesses(ctx context.Context, serverID, pattern string) ([]ProcessInfo, error) {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = exec.Close() }()
+
+	cmd := fmt.Sprintf("ps aux --no-headers 2>/dev/null | grep -E %s | grep -v grep || echo ''", shellQuote(pattern))
+	output, err := exec.RunCommand(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search processes: %w", err)
+	}
+
+	if output == "" || strings.TrimSpace(output) == "" {
+		return []ProcessInfo{}, nil
+	}
+
+	processes, _ := parsePsAux(output)
+	return processes, nil
+}
+
+// GetProcessTree returns the process tree (parent-child relationships).
+func (p *ProcessService) GetProcessTree(ctx context.Context, serverID string) ([]ProcessInfo, error) {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = exec.Close() }()
+
+	cmd := "ps auxf --no-headers 2>/dev/null || ps auxf 2>/dev/null"
+	output, err := exec.RunCommand(ctx, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get process tree: %w", err)
+	}
+
+	processes, _ := parsePsAux(output)
+	return processes, nil
+}
+
+// SystemResources returns system resource usage (CPU, memory, disk, uptime).
+func (p *ProcessService) SystemResources(ctx context.Context, serverID string) (map[string]interface{}, error) {
+	exec, err := p.getExecutor(ctx, serverID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = exec.Close() }()
+
+	result := make(map[string]interface{})
+
+	// Uptime
+	if output, err := exec.RunCommand(ctx, "uptime -p 2>/dev/null || uptime 2>/dev/null"); err == nil {
+		result["uptime"] = strings.TrimSpace(output)
+	}
+
+	// CPU usage (1-second sample)
+	if output, err := exec.RunCommand(ctx, "top -bn1 | head -5 2>/dev/null"); err == nil {
+		result["top_summary"] = strings.TrimSpace(output)
+	}
+
+	// Memory info
+	if output, err := exec.RunCommand(ctx, "free -m 2>/dev/null"); err == nil {
+		result["memory"] = strings.TrimSpace(output)
+	}
+
+	// Disk usage
+	if output, err := exec.RunCommand(ctx, "df -h --total 2>/dev/null | tail -1"); err == nil {
+		result["disk"] = strings.TrimSpace(output)
+	}
+
+	// Load average
+	if output, err := exec.RunCommand(ctx, "cat /proc/loadavg 2>/dev/null"); err == nil {
+		result["load_average"] = strings.TrimSpace(output)
+	}
+
+	return result, nil
+}
+
+// ========== Process Rules (CRUD) ==========
+
+// CreateRule creates a new process monitoring rule.
+func (p *ProcessService) CreateRule(ctx context.Context, rule *ProcessRule) error {
+	if rule.ID == "" {
+		rule.ID = uuid.New().String()
+	}
+	return p.db.WithContext(ctx).Create(rule).Error
+}
+
+// ListRules lists all process monitoring rules.
+func (p *ProcessService) ListRules(ctx context.Context, tenantID, serverID string) ([]ProcessRule, error) {
+	var rules []ProcessRule
+	query := p.db.WithContext(ctx).Where("enabled = ?", true)
+	if tenantID != "" {
+		query = query.Where("tenant_id = ?", tenantID)
+	}
+	if serverID != "" {
+		query = query.Where("server_id = ?", serverID)
+	}
+	if err := query.Order("created_at DESC").Find(&rules).Error; err != nil {
+		return nil, err
+	}
+	return rules, nil
+}
+
+// GetRule gets a process monitoring rule by ID.
+func (p *ProcessService) GetRule(ctx context.Context, id string) (*ProcessRule, error) {
+	var rule ProcessRule
+	if err := p.db.WithContext(ctx).First(&rule, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &rule, nil
+}
+
+// UpdateRule updates a process monitoring rule.
+func (p *ProcessService) UpdateRule(ctx context.Context, rule *ProcessRule) error {
+	return p.db.WithContext(ctx).Save(rule).Error
+}
+
+// DeleteRule deletes a process monitoring rule.
+func (p *ProcessService) DeleteRule(ctx context.Context, id string) error {
+	return p.db.WithContext(ctx).Delete(&ProcessRule{}, "id = ?", id).Error
+}
+
+// ========== Helpers ==========
+
+func (p *ProcessService) getExecutor(ctx context.Context, serverID string) (*sshClientExecutor, error) {
+	b := &Bridge{DB: p.db}
+	return b.getRemoteExecutor(ctx, serverID)
+}
+
+// parsePsAux parses the output of `ps aux` into ProcessInfo structs.
+func parsePsAux(output string) ([]ProcessInfo, ProcessStats) {
+	var processes []ProcessInfo
+	stats := ProcessStats{}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		info := parsePsAuxLine(line)
+		if info == nil {
+			continue
+		}
+
+		processes = append(processes, *info)
+		stats.Total++
+		stats.TotalCPU += info.CPU
+		stats.TotalMem += info.Memory
+
+		switch info.State {
+		case "R":
+			stats.Running++
+		case "S":
+			stats.Sleeping++
+		case "D":
+			stats.Stopped++
+		case "Z":
+			stats.Zombie++
+		case "T":
+			stats.Stopped++
+		}
+	}
+
+	return processes, stats
+}
+
+// psAuxRegex matches a line from `ps aux` output.
+// Format: USER PID %CPU %MEM VSZ RSS STAT START TIME COMMAND
+var psAuxRegex = regexp.MustCompile(`^(\S+)\s+(\d+)\s+([\d.]+)\s+([\d.]+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$`)
+
+func parsePsAuxLine(line string) *ProcessInfo {
+	matches := psAuxRegex.FindStringSubmatch(line)
+	if len(matches) < 11 {
+		return nil
+	}
+
+	cpu, _ := strconv.ParseFloat(matches[3], 64)
+	mem, _ := strconv.ParseFloat(matches[4], 64)
+	vsz, _ := strconv.ParseFloat(matches[5], 64)
+	rss, _ := strconv.ParseFloat(matches[6], 64)
+	pid, _ := strconv.Atoi(matches[2])
+
+	return &ProcessInfo{
+		PID:        pid,
+		User:       matches[1],
+		CPU:        cpu,
+		Memory:     rss / 1024, // Convert KB to MB
+		VirtualMem: vsz / 1024, // Convert KB to MB
+		State:      matches[7],
+		Start:      matches[8],
+		Time:       matches[9],
+		Command:    matches[10],
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 5.7 — Process Daemon for remote server process management via SSH.

## API Endpoints (12 new)

### Server-scoped (under /servers/:id)
- `GET /processes` — List processes (optional filter param)
- `GET /processes/tree` — Process tree view
- `GET /processes/search?pattern=xxx` — Search processes by pattern
- `GET /processes/:pid` — Get process details
- `POST /processes/:pid/kill` — Send signal (TERM/KILL/HUP)
- `GET /resources` — System resources (uptime, CPU, memory, disk, load)

### Top-level (under /processes)
- `GET /rules` — List monitoring rules
- `GET /rules/:id` — Get rule
- `POST /rules` — Create rule
- `PUT /rules/:id` — Update rule
- `DELETE /rules/:id` — Delete rule

## Files Changed
- **2 new files**: `internal/service/process_service.go`, `internal/api/process_api.go`
- **2 modified files**: `internal/database/database.go`, `internal/api/router.go`

## Database Migration
- `202605010800`: Create `process_rules` table

Closes #201