### PR TITLE
feat: Phase 7.2 Grafana Integration - dashboards, datasource, annotations

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -213,6 +213,13 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 	webhookSvc.Start()
 	go webhookSvc.StartCleanupLoop(context.Background())
 
+	// Initialize Grafana integration (Phase 7.2)
+	if cfg.Grafana.Enabled {
+		grafanaSvc := service.NewGrafanaService(db, &cfg.Grafana, typedBus)
+		grafanaSvc.StartAnnotationListener()
+		slog.Info("Grafana integration enabled", "url", cfg.Grafana.URL)
+	}
+
 	// Apply brute-force config from configuration file
 	bf := cfg.BruteForce
 	bridge.SetBruteForceConfig(service.BruteForceConfigFromMap(

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -77,3 +77,13 @@ bruteforce:
   max_delay: "30s"
   ip_max_attempts: 20
   ip_lockout_duration: "30m"
+
+# Grafana 集成
+grafana:
+  enabled: false
+  url: "http://localhost:3000"
+  api_key: ""
+  admin_user: ""
+  admin_password: ""
+  annotations_enabled: true
+  sync_interval: 60

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -182,7 +182,7 @@ func setupFullTestRouter(db *gorm.DB, bridge *service.Bridge) *gin.Engine {
 	go wsHub.Run()
 	auditSvc := service.NewAuditService(db)
 	backupSvc := backup.New(backup.Config{BackupDir: os.TempDir()}, db, "sqlite", "")
-	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc, nil, false)
+	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc, nil, false, nil)
 	return r
 }
 

--- a/internal/api/grafana_api.go
+++ b/internal/api/grafana_api.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/config"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// globalGrafanaAPI is the package-level GrafanaAPI instance, accessible via GetGlobalGrafanaAPI().
+var globalGrafanaAPI *GrafanaAPI
+
+// GetGlobalGrafanaAPI returns the global GrafanaAPI instance.
+func GetGlobalGrafanaAPI() *GrafanaAPI { return globalGrafanaAPI }
+
+// GrafanaAPI provides HTTP handlers for Grafana integration management.
+type GrafanaAPI struct {
+	db  *gorm.DB
+	cfg *config.GrafanaConfig
+}
+
+// NewGrafanaAPI creates a new GrafanaAPI.
+func NewGrafanaAPI(db *gorm.DB, cfg *config.GrafanaConfig) *GrafanaAPI {
+	return &GrafanaAPI{db: db, cfg: cfg}
+}
+
+// GetStatus returns the current Grafana integration status.
+// GET /api/v1/grafana/status
+func (a *GrafanaAPI) GetStatus(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	status := svc.GetStatus()
+	respondSuccess(c, status)
+}
+
+// TestConnection tests the connection to the Grafana server.
+// POST /api/v1/grafana/test
+func (a *GrafanaAPI) TestConnection(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	result, err := svc.TestConnection()
+	if err != nil {
+		respondErrori18n(c, http.StatusServiceUnavailable, "error.common.internal_error")
+		return
+	}
+	respondSuccess(c, result)
+}
+
+// SyncAll performs a full sync of datasources, folder, and dashboards.
+// POST /api/v1/grafana/sync
+func (a *GrafanaAPI) SyncAll(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	count, err := svc.SyncAll()
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+	respondSuccess(c, gin.H{"synced_dashboards": count})
+}
+
+// ListDashboards returns all Grafana dashboards.
+// GET /api/v1/grafana/dashboards
+func (a *GrafanaAPI) ListDashboards(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	dashboards, err := svc.ListDashboards()
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+	respondSuccess(c, dashboards)
+}
+
+// GetDashboard returns a single dashboard by ID.
+// GET /api/v1/grafana/dashboards/:id
+func (a *GrafanaAPI) GetDashboard(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	id := c.Param("id")
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	dashboard, err := svc.GetDashboard(id)
+	if err != nil {
+		respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+		return
+	}
+	respondSuccess(c, dashboard)
+}
+
+// CreateDashboard creates a new custom Grafana dashboard.
+// POST /api/v1/grafana/dashboards
+func (a *GrafanaAPI) CreateDashboard(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+
+	var req struct {
+		Name string `json:"name" binding:"required"`
+		JSON string `json:"json" binding:"required"`
+		Tags string `json:"tags"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	dashboard, err := svc.CreateCustomDashboard(req.Name, req.JSON, req.Tags)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"status": "success",
+		"data":   dashboard,
+	})
+}
+
+// UpdateDashboard updates an existing Grafana dashboard.
+// PUT /api/v1/grafana/dashboards/:id
+func (a *GrafanaAPI) UpdateDashboard(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	id := c.Param("id")
+
+	var req struct {
+		Name    string `json:"name"`
+		JSON    string `json:"json"`
+		Tags    string `json:"tags"`
+		Enabled *bool  `json:"enabled"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	if err := svc.UpdateCustomDashboard(id, req.Name, req.JSON, req.Tags, enabled); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"id": id, "status": "updated"})
+}
+
+// DeleteDashboard deletes a Grafana dashboard.
+// DELETE /api/v1/grafana/dashboards/:id
+func (a *GrafanaAPI) DeleteDashboard(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	id := c.Param("id")
+
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	if err := svc.DeleteCustomDashboard(id); err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"id": id, "status": "deleted"})
+}
+
+// ExportAll exports all dashboards and datasource configuration.
+// GET /api/v1/grafana/export
+func (a *GrafanaAPI) ExportAll(c *gin.Context) {
+	db := c.MustGet("db").(*gorm.DB)
+	svc := service.NewGrafanaService(db, a.cfg, nil)
+	result, err := svc.ExportAll()
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+	respondSuccess(c, result)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/auth"
 	"github.com/Yogdunana/deploypilot/internal/backup"
 	"github.com/Yogdunana/deploypilot/internal/bruteforce"
+	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/metrics"
 	"github.com/Yogdunana/deploypilot/internal/plugin"
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
@@ -25,8 +26,14 @@ var globalMonitorAPI *MonitorAPI
 // GetGlobalMonitorAPI returns the global MonitorAPI instance.
 func GetGlobalMonitorAPI() *MonitorAPI { return globalMonitorAPI }
 
+// globalGrafanaAPI is the package-level GrafanaAPI instance, accessible via GetGlobalGrafanaAPI().
+var globalGrafanaAPI *GrafanaAPI
+
+// GetGlobalGrafanaAPI returns the global GrafanaAPI instance.
+func GetGlobalGrafanaAPI() *GrafanaAPI { return globalGrafanaAPI }
+
 // RegisterRoutes registers all API routes on the given Gin engine.
-func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool) {
+func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig) {
 	// Swagger documentation — only accessible in development mode.
 	// In production, the endpoint is disabled to prevent information leakage.
 	if os.Getenv("DEPLOYPILOT_ENV") == "development" || os.Getenv("GIN_MODE") == "debug" {
@@ -54,6 +61,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 
 	// Outbound Webhook API
 	globalWebhookAPI = NewOutboundWebhookAPI(db)
+
+	// Grafana API
+	globalGrafanaAPI = NewGrafanaAPI(db, grafanaCfg)
 
 	wsGroup := r.Group("/ws")
 	{
@@ -253,6 +263,20 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			whGroup.POST("/:id/test", globalWebhookAPI.TestWebhook)
 			whGroup.GET("/:id/deliveries", globalWebhookAPI.ListDeliveries)
 			whGroup.GET("/:id/deliveries/:did", globalWebhookAPI.GetDelivery)
+		}
+
+		// Grafana Integration
+		grafanaGroup := protected.Group("/grafana")
+		{
+			grafanaGroup.GET("/status", globalGrafanaAPI.GetStatus)
+			grafanaGroup.POST("/test", globalGrafanaAPI.TestConnection)
+			grafanaGroup.POST("/sync", globalGrafanaAPI.SyncAll)
+			grafanaGroup.GET("/dashboards", globalGrafanaAPI.ListDashboards)
+			grafanaGroup.GET("/dashboards/:id", globalGrafanaAPI.GetDashboard)
+			grafanaGroup.POST("/dashboards", globalGrafanaAPI.CreateDashboard)
+			grafanaGroup.PUT("/dashboards/:id", globalGrafanaAPI.UpdateDashboard)
+			grafanaGroup.DELETE("/dashboards/:id", globalGrafanaAPI.DeleteDashboard)
+			grafanaGroup.GET("/export", globalGrafanaAPI.ExportAll)
 		}
 
 		// Credentials (5 endpoints)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -26,12 +26,6 @@ var globalMonitorAPI *MonitorAPI
 // GetGlobalMonitorAPI returns the global MonitorAPI instance.
 func GetGlobalMonitorAPI() *MonitorAPI { return globalMonitorAPI }
 
-// globalGrafanaAPI is the package-level GrafanaAPI instance, accessible via GetGlobalGrafanaAPI().
-var globalGrafanaAPI *GrafanaAPI
-
-// GetGlobalGrafanaAPI returns the global GrafanaAPI instance.
-func GetGlobalGrafanaAPI() *GrafanaAPI { return globalGrafanaAPI }
-
 // RegisterRoutes registers all API routes on the given Gin engine.
 func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig) {
 	// Swagger documentation — only accessible in development mode.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Audit      AuditConfig      `mapstructure:"audit"`
 	Backup     BackupConfig     `mapstructure:"backup"`
 	BruteForce BruteForceConfig `mapstructure:"bruteforce"`
+	Grafana    GrafanaConfig    `mapstructure:"grafana"`
 }
 
 // BackupConfig holds database auto-backup settings.
@@ -55,6 +56,17 @@ type BruteForceConfig struct {
 	MaxDelay          string `mapstructure:"max_delay"`
 	IPMaxAttempts     int    `mapstructure:"ip_max_attempts"`
 	IPLockoutDuration string `mapstructure:"ip_lockout_duration"`
+}
+
+// GrafanaConfig holds Grafana integration settings.
+type GrafanaConfig struct {
+	Enabled            bool   `mapstructure:"enabled"`
+	URL                string `mapstructure:"url"`
+	APIKey             string `mapstructure:"api_key"`
+	AdminUser          string `mapstructure:"admin_user"`
+	AdminPassword      string `mapstructure:"admin_password"`
+	AnnotationsEnabled bool   `mapstructure:"annotations_enabled"`
+	SyncInterval       int    `mapstructure:"sync_interval"`
 }
 
 // AuditConfig holds configuration for audit logging.
@@ -332,4 +344,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("bruteforce.max_delay", "30s")
 	v.SetDefault("bruteforce.ip_max_attempts", 20)
 	v.SetDefault("bruteforce.ip_lockout_duration", "30m")
+
+	// Grafana
+	v.SetDefault("grafana.enabled", false)
+	v.SetDefault("grafana.url", "http://localhost:3000")
+	v.SetDefault("grafana.annotations_enabled", true)
+	v.SetDefault("grafana.sync_interval", 60)
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -848,6 +848,16 @@ func Migrate(db *gorm.DB) error {
 				return tx.Exec("DROP TABLE IF EXISTS heartbeats").Error
 			},
 		},
+		// 202605020100: Create grafana_custom_dashboards and grafana_sync_logs tables
+		{
+			ID: "202605020100",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&model.GrafanaCustomDashboard{}, &model.GrafanaSyncLog{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("grafana_sync_logs", "grafana_custom_dashboards")
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/model/grafana.go
+++ b/internal/model/grafana.go
@@ -1,0 +1,32 @@
+package model
+
+import "time"
+
+// GrafanaCustomDashboard represents a custom Grafana dashboard stored in the database.
+type GrafanaCustomDashboard struct {
+	ID          string    `gorm:"primaryKey" json:"id"`
+	TenantID    string    `gorm:"index" json:"tenant_id"`
+	Name        string    `gorm:"not null" json:"name"`
+	UID         string    `gorm:"uniqueIndex;not null" json:"uid"`
+	Description string    `json:"description"`
+	JSON        string    `gorm:"type:text;not null" json:"json"` // full Grafana dashboard JSON
+	Tags        string    `gorm:"type:text" json:"tags"`          // JSON array string
+	IsBuiltIn   bool      `gorm:"default:false" json:"is_built_in"`
+	Enabled     bool      `gorm:"default:true" json:"enabled"`
+	CreatedAt   time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (GrafanaCustomDashboard) TableName() string { return "grafana_custom_dashboards" }
+
+// GrafanaSyncLog records Grafana sync operations for auditing.
+type GrafanaSyncLog struct {
+	ID        string    `gorm:"primaryKey" json:"id"`
+	TenantID  string    `gorm:"index" json:"tenant_id"`
+	Action    string    `gorm:"not null;size:50" json:"action"` // sync_dashboard, delete_dashboard, create_datasource, etc.
+	Status    string    `gorm:"not null;size:20" json:"status"` // success, failed
+	Message   string    `gorm:"type:text" json:"message"`
+	CreatedAt time.Time `gorm:"autoCreateTime;index" json:"created_at"`
+}
+
+func (GrafanaSyncLog) TableName() string { return "grafana_sync_logs" }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,7 +129,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 		api.SetRefreshTokenStore(memRefreshStore)
 	}
 
-	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic)
+	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic, &cfg.Grafana)
 
 	// Serve embedded frontend static files
 	serveStaticFiles(r)

--- a/internal/service/dashboards/alert_heartbeat.go
+++ b/internal/service/dashboards/alert_heartbeat.go
@@ -1,0 +1,123 @@
+package dashboards
+
+import "encoding/json"
+
+// AlertHeartbeatJSON returns the Grafana dashboard JSON for Alert & Heartbeat monitoring.
+func AlertHeartbeatJSON() map[string]interface{} {
+	jsonStr := `{
+  "uid": "deploypilot-alert-heartbeat",
+  "title": "DeployPilot - Alert & Heartbeat",
+  "tags": ["deploypilot", "auto-provisioned"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Heartbeat Status",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(deploypilot_heartbeat_up == 1)",
+          "legendFormat": "Up",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(deploypilot_heartbeat_up == 0) OR on() vector(0)",
+          "legendFormat": "Down",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Monitor Check Results",
+      "type": "table",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 6},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "deploypilot_monitor_up * on(name) group_left(type, target) deploypilot_monitor_latency_ms",
+          "legendFormat": "",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 0.5}
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "Value"},
+            "properties": [
+              {"id": "unit", "value": "ms"}
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {"show": false}
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true},
+            "indexByName": {"name": 0, "type": 1, "target": 2, "Value": 3},
+            "renameByName": {"name": "Monitor", "type": "Type", "target": "Target", "Value": "Latency (ms)"}
+          }
+        }
+      ]
+    }
+  ]
+}`
+	var result map[string]interface{}
+	_ = json.Unmarshal([]byte(jsonStr), &result)
+	return result
+}

--- a/internal/service/dashboards/deploy_stats.go
+++ b/internal/service/dashboards/deploy_stats.go
@@ -1,0 +1,139 @@
+package dashboards
+
+import "encoding/json"
+
+// DeployStatsJSON returns the Grafana dashboard JSON for Deploy Statistics.
+func DeployStatsJSON() map[string]interface{} {
+	jsonStr := `{
+  "uid": "deploypilot-deploy-stats",
+  "title": "DeployPilot - Deploy Statistics",
+  "tags": ["deploypilot", "auto-provisioned"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Deploy Count by Status",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (status) (increase(deploypilot_deploy_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 80,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {"displayMode": "table", "placement": "bottom"}
+      }
+    },
+    {
+      "id": 2,
+      "title": "Deploy Duration",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.50, sum(rate(deploypilot_deploy_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.95, sum(rate(deploypilot_deploy_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.99, sum(rate(deploypilot_deploy_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {"displayMode": "table", "placement": "bottom"}
+      }
+    },
+    {
+      "id": 3,
+      "title": "Deploy Success Rate",
+      "type": "stat",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(increase(deploypilot_deploy_total{status=\"success\"}[24h])) / sum(increase(deploypilot_deploy_total[24h])) * 100",
+          "legendFormat": "Success Rate",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 80},
+              {"color": "green", "value": 95}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    }
+  ]
+}`
+	var result map[string]interface{}
+	_ = json.Unmarshal([]byte(jsonStr), &result)
+	return result
+}

--- a/internal/service/dashboards/server_resources.go
+++ b/internal/service/dashboards/server_resources.go
@@ -1,0 +1,171 @@
+package dashboards
+
+import "encoding/json"
+
+// ServerResourcesJSON returns the Grafana dashboard JSON for Server Resources monitoring.
+func ServerResourcesJSON() map[string]interface{} {
+	jsonStr := `{
+  "uid": "deploypilot-server-resources",
+  "title": "DeployPilot - Server Resources",
+  "tags": ["deploypilot", "auto-provisioned"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active Containers",
+      "type": "gauge",
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "deploypilot_active_containers",
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 50},
+              {"color": "red", "value": 100}
+            ]
+          }
+        }
+      },
+      "options": {
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      }
+    },
+    {
+      "id": 2,
+      "title": "WebSocket Connections",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "deploypilot_ws_connections",
+          "legendFormat": "Connections",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 100},
+              {"color": "red", "value": 500}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "title": "API Request Duration (P50 / P95 / P99)",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 6},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.50, sum(rate(deploypilot_api_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.95, sum(rate(deploypilot_api_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.99, sum(rate(deploypilot_api_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {"displayMode": "table", "placement": "bottom"}
+      }
+    },
+    {
+      "id": 4,
+      "title": "Credential Expiry Countdown",
+      "type": "stat",
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 14},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "deploypilot_credential_expiry_days",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 7},
+              {"color": "green", "value": 30}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    }
+  ]
+}`
+	var result map[string]interface{}
+	_ = json.Unmarshal([]byte(jsonStr), &result)
+	return result
+}

--- a/internal/service/dashboards/uptime_overview.go
+++ b/internal/service/dashboards/uptime_overview.go
@@ -1,0 +1,151 @@
+package dashboards
+
+import "encoding/json"
+
+// UptimeOverviewJSON returns the Grafana dashboard JSON for the Uptime Monitor overview.
+func UptimeOverviewJSON() map[string]interface{} {
+	jsonStr := `{
+  "uid": "deploypilot-uptime-overview",
+  "title": "DeployPilot - Uptime Monitor",
+  "tags": ["deploypilot", "auto-provisioned"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Monitor Status",
+      "type": "stat",
+      "gridPos": {"h": 4, "w": 8, "x": 0, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(deploypilot_monitor_up == 1)",
+          "legendFormat": "Up",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count(deploypilot_monitor_up == 0) OR on() vector(0)",
+          "legendFormat": "Down",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "green", "value": 1}
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "title": "Response Latency",
+      "type": "timeseries",
+      "gridPos": {"h": 8, "w": 16, "x": 8, "y": 0},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "deploypilot_monitor_latency_ms",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "showPoints": "auto"
+          }
+        }
+      },
+      "options": {
+        "tooltip": {"mode": "multi", "sort": "desc"},
+        "legend": {"displayMode": "list", "placement": "bottom"}
+      }
+    },
+    {
+      "id": 3,
+      "title": "Uptime Percentage",
+      "type": "gauge",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 4},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "avg(deploypilot_monitor_uptime_pct)",
+          "legendFormat": "Avg Uptime",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 90},
+              {"color": "green", "value": 99}
+            ]
+          }
+        }
+      },
+      "options": {
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true
+      }
+    },
+    {
+      "id": 4,
+      "title": "Monitor Status by Type",
+      "type": "piechart",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 12},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "count by (type) (deploypilot_monitor_up)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "legend": {"displayMode": "table", "placement": "right"},
+        "pieType": "donut"
+      }
+    }
+  ]
+}`
+	var result map[string]interface{}
+	_ = json.Unmarshal([]byte(jsonStr), &result)
+	return result
+}

--- a/internal/service/grafana_client.go
+++ b/internal/service/grafana_client.go
@@ -1,0 +1,270 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GrafanaClient wraps the Grafana HTTP API.
+type GrafanaClient struct {
+	baseURL    string
+	apiKey     string
+	adminUser  string
+	adminPass  string
+	httpClient *http.Client
+}
+
+// NewGrafanaClient creates a new GrafanaClient with the given connection parameters.
+func NewGrafanaClient(rawURL, apiKey, adminUser, adminPass string) (*GrafanaClient, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Grafana URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme == "" {
+		parsed.Scheme = "http"
+	}
+	return &GrafanaClient{
+		baseURL:   strings.TrimRight(parsed.String(), "/"),
+		apiKey:    apiKey,
+		adminUser: adminUser,
+		adminPass: adminPass,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+// doRequest is the internal helper for all Grafana API calls.
+// It returns the response body, HTTP status code, and any error.
+func (c *GrafanaClient) doRequest(method, path string, body interface{}) ([]byte, int, error) {
+	var reqBody io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, 0, fmt.Errorf("marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	reqURL := c.baseURL + path
+	req, err := http.NewRequest(method, reqURL, reqBody)
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request %s %s: %w", method, reqURL, err)
+	}
+
+	// Prefer API key auth; fall back to basic auth.
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	} else if c.adminUser != "" {
+		req.SetBasicAuth(c.adminUser, c.adminPass)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request %s %s: %w", method, reqURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("read response body: %w", err)
+	}
+
+	return respBody, resp.StatusCode, nil
+}
+
+// TestConnection verifies connectivity by fetching the current organization.
+func (c *GrafanaClient) TestConnection() (map[string]interface{}, error) {
+	body, status, err := c.doRequest(http.MethodGet, "/api/org", nil)
+	if err != nil {
+		return nil, fmt.Errorf("test connection: %w", err)
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("test connection returned status %d: %s", status, string(body))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal org response: %w", err)
+	}
+	return result, nil
+}
+
+// EnsureDatasource creates or updates the "DeployPilot" Prometheus datasource.
+// It returns the datasource UID.
+func (c *GrafanaClient) EnsureDatasource(metricsURL string) (string, error) {
+	// First, try to find an existing datasource by name.
+	body, status, err := c.doRequest(http.MethodGet, "/api/datasources/name/DeployPilot", nil)
+	if err != nil {
+		return "", fmt.Errorf("lookup datasource: %w", err)
+	}
+
+	if status == http.StatusOK {
+		var existing map[string]interface{}
+		if err := json.Unmarshal(body, &existing); err != nil {
+			return "", fmt.Errorf("unmarshal existing datasource: %w", err)
+		}
+		uid, _ := existing["uid"].(string)
+		if uid != "" {
+			// Update the existing datasource URL.
+			idVal, _ := existing["id"].(float64)
+			updatePayload := map[string]interface{}{
+				"id":   int(idVal),
+				"name": "DeployPilot",
+				"type": "prometheus",
+				"url":  metricsURL,
+				"access": "proxy",
+				"isDefault": false,
+				"jsonData": map[string]interface{}{
+					"httpMethod": "POST",
+					"timeInterval": "15s",
+				},
+			}
+			_, updStatus, updErr := c.doRequest(http.MethodPut, "/api/datasources/"+strconv.FormatInt(int64(idVal), 10), updatePayload)
+			if updErr != nil {
+				return "", fmt.Errorf("update datasource: %w", updErr)
+			}
+			if updStatus != http.StatusOK {
+				return "", fmt.Errorf("update datasource returned status %d", updStatus)
+			}
+			return uid, nil
+		}
+	}
+
+	// Create a new datasource.
+	createPayload := map[string]interface{}{
+		"name":      "DeployPilot",
+		"type":      "prometheus",
+		"url":       metricsURL,
+		"access":    "proxy",
+		"isDefault": false,
+		"jsonData": map[string]interface{}{
+			"httpMethod":   "POST",
+			"timeInterval": "15s",
+		},
+	}
+	body, status, err = c.doRequest(http.MethodPost, "/api/datasources", createPayload)
+	if err != nil {
+		return "", fmt.Errorf("create datasource: %w", err)
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return "", fmt.Errorf("create datasource returned status %d: %s", status, string(body))
+	}
+
+	var created map[string]interface{}
+	if err := json.Unmarshal(body, &created); err != nil {
+		return "", fmt.Errorf("unmarshal created datasource: %w", err)
+	}
+	uid, _ := created["uid"].(string)
+	if uid == "" {
+		return "", fmt.Errorf("created datasource has no UID")
+	}
+	return uid, nil
+}
+
+// EnsureFolder creates the "DeployPilot" folder if it does not exist.
+// It returns the folder ID.
+func (c *GrafanaClient) EnsureFolder() (int, error) {
+	// Try to find existing folder.
+	body, status, err := c.doRequest(http.MethodGet, "/api/folders", nil)
+	if err != nil {
+		return 0, fmt.Errorf("list folders: %w", err)
+	}
+
+	if status == http.StatusOK {
+		var folders []map[string]interface{}
+		if err := json.Unmarshal(body, &folders); err != nil {
+			return 0, fmt.Errorf("unmarshal folders: %w", err)
+		}
+		for _, f := range folders {
+			if title, _ := f["title"].(string); title == "DeployPilot" {
+				if idVal, ok := f["id"].(float64); ok {
+					return int(idVal), nil
+				}
+			}
+		}
+	}
+
+	// Create the folder.
+	createPayload := map[string]interface{}{
+		"title": "DeployPilot",
+	}
+	body, status, err = c.doRequest(http.MethodPost, "/api/folders", createPayload)
+	if err != nil {
+		return 0, fmt.Errorf("create folder: %w", err)
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return 0, fmt.Errorf("create folder returned status %d: %s", status, string(body))
+	}
+
+	var created map[string]interface{}
+	if err := json.Unmarshal(body, &created); err != nil {
+		return 0, fmt.Errorf("unmarshal created folder: %w", err)
+	}
+	idVal, _ := created["id"].(float64)
+	return int(idVal), nil
+}
+
+// UpsertDashboard creates or updates a Grafana dashboard.
+// If overwrite is true, existing dashboards with the same UID will be replaced.
+func (c *GrafanaClient) UpsertDashboard(dashboardJSON map[string]interface{}, folderID int, overwrite bool) (map[string]interface{}, error) {
+	payload := map[string]interface{}{
+		"dashboard": dashboardJSON,
+		"folderId":  folderID,
+		"overwrite": overwrite,
+	}
+
+	body, status, err := c.doRequest(http.MethodPost, "/api/dashboards/db", payload)
+	if err != nil {
+		return nil, fmt.Errorf("upsert dashboard: %w", err)
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return nil, fmt.Errorf("upsert dashboard returned status %d: %s", status, string(body))
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("unmarshal dashboard response: %w", err)
+	}
+	return result, nil
+}
+
+// CreateAnnotation adds an annotation to Grafana with the given tags, text, and time range.
+func (c *GrafanaClient) CreateAnnotation(tags []string, text string, timestamp int64, timeEnd int64) error {
+	payload := map[string]interface{}{
+		"time":     timestamp,
+		"timeEnd":  timeEnd,
+		"tags":     tags,
+		"text":     text,
+	}
+
+	_, status, err := c.doRequest(http.MethodPost, "/api/annotations", payload)
+	if err != nil {
+		return fmt.Errorf("create annotation: %w", err)
+	}
+	if status != http.StatusOK && status != http.StatusCreated {
+		return fmt.Errorf("create annotation returned status %d", status)
+	}
+	return nil
+}
+
+// DeleteDashboard deletes a dashboard by its UID.
+func (c *GrafanaClient) DeleteDashboard(uid string) error {
+	_, status, err := c.doRequest(http.MethodDelete, "/api/dashboards/uid/"+uid, nil)
+	if err != nil {
+		return fmt.Errorf("delete dashboard %s: %w", uid, err)
+	}
+	if status != http.StatusOK && status != http.StatusNoContent {
+		return fmt.Errorf("delete dashboard %s returned status %d", uid, status)
+	}
+	return nil
+}

--- a/internal/service/grafana_client.go
+++ b/internal/service/grafana_client.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -54,7 +55,7 @@ func (c *GrafanaClient) doRequest(method, path string, body interface{}) ([]byte
 	}
 
 	reqURL := c.baseURL + path
-	req, err := http.NewRequest(method, reqURL, reqBody)
+	req, err := http.NewRequestWithContext(context.Background(), method, reqURL, reqBody)
 	if err != nil {
 		return nil, 0, fmt.Errorf("create request %s %s: %w", method, reqURL, err)
 	}

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -301,10 +301,6 @@ func (s *GrafanaService) PushAnnotation(event BusEvent) {
 		return
 	}
 
-	s.mu.RLock()
-	dsUID := s.dsUID
-	s.mu.RUnlock()
-
 	timestamp := event.Timestamp.UnixMilli()
 	var tags []string
 	var text string

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -74,7 +74,7 @@ func (s *GrafanaService) GetStatus() map[string]interface{} {
 // TestConnection verifies connectivity to the Grafana server.
 func (s *GrafanaService) TestConnection() (map[string]interface{}, error) {
 	if s.client == nil {
-		return nil, fmt.Errorf("Grafana client not initialized")
+		return nil, fmt.Errorf("grafana client not initialized")
 	}
 	return s.client.TestConnection()
 }
@@ -83,7 +83,7 @@ func (s *GrafanaService) TestConnection() (map[string]interface{}, error) {
 // It returns the count of synced dashboards.
 func (s *GrafanaService) SyncAll() (int, error) {
 	if s.client == nil {
-		return 0, fmt.Errorf("Grafana client not initialized")
+		return 0, fmt.Errorf("grafana client not initialized")
 	}
 
 	// 1. Ensure datasource

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -1,0 +1,482 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/config"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/service/dashboards"
+	"gorm.io/gorm"
+)
+
+// builtInDashboardList holds the definitions of all built-in dashboards.
+var builtInDashboardList = []struct {
+	name string
+	fn   func() map[string]interface{}
+}{
+	{"DeployPilot - Uptime Monitor", dashboards.UptimeOverviewJSON},
+	{"DeployPilot - Server Resources", dashboards.ServerResourcesJSON},
+	{"DeployPilot - Deploy Statistics", dashboards.DeployStatsJSON},
+	{"DeployPilot - Alert & Heartbeat", dashboards.AlertHeartbeatJSON},
+}
+
+// GrafanaService orchestrates Grafana integration: datasource provisioning,
+// dashboard sync, and event annotation forwarding.
+type GrafanaService struct {
+	db     *gorm.DB
+	cfg    *config.GrafanaConfig
+	bus    TypedEventBus
+	client *GrafanaClient
+	dsUID  string // cached datasource UID
+	mu     sync.RWMutex
+}
+
+// NewGrafanaService creates a GrafanaService from the given configuration.
+// If bus is nil, annotation listening is disabled.
+func NewGrafanaService(db *gorm.DB, cfg *config.GrafanaConfig, bus TypedEventBus) *GrafanaService {
+	client, err := NewGrafanaClient(cfg.URL, cfg.APIKey, cfg.AdminUser, cfg.AdminPassword)
+	if err != nil {
+		slog.Warn("failed to create Grafana client", "error", err)
+	}
+	return &GrafanaService{
+		db:     db,
+		cfg:    cfg,
+		bus:    bus,
+		client: client,
+	}
+}
+
+// GetStatus returns the current Grafana integration status.
+func (s *GrafanaService) GetStatus() map[string]interface{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	status := map[string]interface{}{
+		"enabled":  s.cfg.Enabled,
+		"url":      s.cfg.URL,
+		"connected": false,
+	}
+
+	if s.dsUID != "" {
+		status["connected"] = true
+		status["datasource_uid"] = s.dsUID
+	}
+
+	return status
+}
+
+// TestConnection verifies connectivity to the Grafana server.
+func (s *GrafanaService) TestConnection() (map[string]interface{}, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("Grafana client not initialized")
+	}
+	return s.client.TestConnection()
+}
+
+// SyncAll performs a full sync: datasource, folder, and all enabled dashboards.
+// It returns the count of synced dashboards.
+func (s *GrafanaService) SyncAll() (int, error) {
+	if s.client == nil {
+		return 0, fmt.Errorf("Grafana client not initialized")
+	}
+
+	// 1. Ensure datasource
+	metricsURL := "http://localhost:9090" // default Prometheus URL
+	dsUID, err := s.client.EnsureDatasource(metricsURL)
+	if err != nil {
+		return 0, fmt.Errorf("ensure datasource: %w", err)
+	}
+	s.mu.Lock()
+	s.dsUID = dsUID
+	s.mu.Unlock()
+
+	// 2. Ensure folder
+	folderID, err := s.client.EnsureFolder()
+	if err != nil {
+		return 0, fmt.Errorf("ensure folder: %w", err)
+	}
+
+	// 3. Seed built-in dashboards into DB if not present
+	s.seedBuiltInDashboards()
+
+	// 4. Sync all enabled dashboards from DB
+	var dashboards []model.GrafanaCustomDashboard
+	if err := s.db.Where("enabled = ?", true).Find(&dashboards).Error; err != nil {
+		return 0, fmt.Errorf("list dashboards: %w", err)
+	}
+
+	count := 0
+	for _, d := range dashboards {
+		var dashboardJSON map[string]interface{}
+		if err := json.Unmarshal([]byte(d.JSON), &dashboardJSON); err != nil {
+			slog.Warn("skip invalid dashboard JSON", "id", d.ID, "name", d.Name, "error", err)
+			continue
+		}
+
+		// Inject the actual datasource UID
+		s.injectDatasourceUID(dashboardJSON, dsUID)
+
+		_, err := s.client.UpsertDashboard(dashboardJSON, folderID, true)
+		if err != nil {
+			slog.Warn("failed to sync dashboard", "name", d.Name, "error", err)
+			continue
+		}
+
+		// Record sync log
+		s.recordSyncLog("sync_dashboard", "success", d.Name)
+		count++
+	}
+
+	return count, nil
+}
+
+// injectDatasourceUID recursively replaces "${datasource}" placeholder references
+// in the dashboard JSON with the actual datasource UID.
+func (s *GrafanaService) injectDatasourceUID(dashboardJSON map[string]interface{}, dsUID string) {
+	for key, val := range dashboardJSON {
+		switch v := val.(type) {
+		case string:
+			if v == "${datasource}" && (key == "datasource" || key == "uid" || key == "query") {
+				dashboardJSON[key] = dsUID
+			}
+		case map[string]interface{}:
+			// Check for datasource objects like {"type": "prometheus", "uid": "${datasource}"}
+			if uid, ok := v["uid"].(string); ok && uid == "${datasource}" {
+				v["uid"] = dsUID
+			}
+			// Recurse into nested maps
+			s.injectDatasourceUID(v, dsUID)
+		case []interface{}:
+			for _, item := range v {
+				if m, ok := item.(map[string]interface{}); ok {
+					s.injectDatasourceUID(m, dsUID)
+				}
+			}
+		}
+	}
+}
+
+// ListDashboards returns all dashboards from the database.
+// Built-in dashboards are seeded on first call if not present.
+func (s *GrafanaService) ListDashboards() ([]model.GrafanaCustomDashboard, error) {
+	s.seedBuiltInDashboards()
+
+	var dashboards []model.GrafanaCustomDashboard
+	if err := s.db.Order("created_at ASC").Find(&dashboards).Error; err != nil {
+		return nil, fmt.Errorf("list dashboards: %w", err)
+	}
+	return dashboards, nil
+}
+
+// GetDashboard returns a single dashboard by ID.
+func (s *GrafanaService) GetDashboard(id string) (*model.GrafanaCustomDashboard, error) {
+	var dashboard model.GrafanaCustomDashboard
+	if err := s.db.Where("id = ?", id).First(&dashboard).Error; err != nil {
+		return nil, fmt.Errorf("dashboard not found: %w", err)
+	}
+	return &dashboard, nil
+}
+
+// CreateCustomDashboard validates the JSON and creates a new dashboard in the database.
+func (s *GrafanaService) CreateCustomDashboard(name, jsonStr, tags string) (*model.GrafanaCustomDashboard, error) {
+	// Validate JSON
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid dashboard JSON: %w", err)
+	}
+
+	// Generate UID from title if present
+	uid := ""
+	if title, ok := parsed["uid"].(string); ok && title != "" {
+		uid = title
+	}
+	if uid == "" {
+		uid = fmt.Sprintf("custom-%d", time.Now().UnixNano())
+	}
+
+	dashboard := model.GrafanaCustomDashboard{
+		Name:      name,
+		UID:       uid,
+		JSON:      jsonStr,
+		Tags:      tags,
+		IsBuiltIn: false,
+		Enabled:   true,
+	}
+
+	if err := s.db.Create(&dashboard).Error; err != nil {
+		return nil, fmt.Errorf("create dashboard: %w", err)
+	}
+
+	return &dashboard, nil
+}
+
+// UpdateCustomDashboard updates an existing dashboard in the database.
+func (s *GrafanaService) UpdateCustomDashboard(id, name, jsonStr, tags string, enabled bool) error {
+	var dashboard model.GrafanaCustomDashboard
+	if err := s.db.Where("id = ?", id).First(&dashboard).Error; err != nil {
+		return fmt.Errorf("dashboard not found: %w", err)
+	}
+
+	// If JSON is provided, validate it
+	if jsonStr != "" {
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+			return fmt.Errorf("invalid dashboard JSON: %w", err)
+		}
+		dashboard.JSON = jsonStr
+	}
+
+	if name != "" {
+		dashboard.Name = name
+	}
+	if tags != "" {
+		dashboard.Tags = tags
+	}
+	dashboard.Enabled = enabled
+
+	if err := s.db.Save(&dashboard).Error; err != nil {
+		return fmt.Errorf("update dashboard: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteCustomDashboard deletes a dashboard from the database.
+func (s *GrafanaService) DeleteCustomDashboard(id string) error {
+	if err := s.db.Where("id = ?", id).Delete(&model.GrafanaCustomDashboard{}).Error; err != nil {
+		return fmt.Errorf("delete dashboard: %w", err)
+	}
+	return nil
+}
+
+// ExportAll returns all dashboards JSON along with datasource configuration.
+func (s *GrafanaService) ExportAll() (map[string]interface{}, error) {
+	s.seedBuiltInDashboards()
+
+	var dashboards []model.GrafanaCustomDashboard
+	if err := s.db.Find(&dashboards).Error; err != nil {
+		return nil, fmt.Errorf("list dashboards for export: %w", err)
+	}
+
+	exported := make([]map[string]interface{}, 0, len(dashboards))
+	for _, d := range dashboards {
+		var dashboardJSON map[string]interface{}
+		if err := json.Unmarshal([]byte(d.JSON), &dashboardJSON); err != nil {
+			slog.Warn("skip invalid dashboard JSON on export", "id", d.ID, "error", err)
+			continue
+		}
+		exported = append(exported, map[string]interface{}{
+			"name":       d.Name,
+			"uid":        d.UID,
+			"is_built_in": d.IsBuiltIn,
+			"enabled":    d.Enabled,
+			"tags":       d.Tags,
+			"dashboard":  dashboardJSON,
+		})
+	}
+
+	s.mu.RLock()
+	dsUID := s.dsUID
+	s.mu.RUnlock()
+
+	result := map[string]interface{}{
+		"datasource_uid": dsUID,
+		"grafana_url":    s.cfg.URL,
+		"dashboards":     exported,
+		"exported_at":    time.Now().UTC().Format(time.RFC3339),
+	}
+
+	return result, nil
+}
+
+// PushAnnotation converts a BusEvent to a Grafana annotation and pushes it.
+func (s *GrafanaService) PushAnnotation(event BusEvent) {
+	if s.client == nil || !s.cfg.AnnotationsEnabled {
+		return
+	}
+
+	s.mu.RLock()
+	dsUID := s.dsUID
+	s.mu.RUnlock()
+
+	timestamp := event.Timestamp.UnixMilli()
+	var tags []string
+	var text string
+
+	switch event.Type {
+	case EventDeploy:
+		p := s.parseDeployPayload(event.Payload)
+		tags = []string{"deploy", p.Status, p.AppName}
+		text = fmt.Sprintf("Deploy %s to %s: %s (%dms)", p.AppName, p.ServerName, p.Status, p.Duration)
+
+	case EventAlert:
+		p := s.parseAlertPayload(event.Payload)
+		tags = []string{"alert", p.Severity, p.RuleName}
+		text = fmt.Sprintf("Alert %s: %s - %s", p.RuleName, p.Severity, p.Message)
+
+	case EventServer:
+		p := s.parseServerPayload(event.Payload)
+		tags = []string{"server", p.Action}
+		text = fmt.Sprintf("Server %s: %s", p.ServerName, p.Action)
+
+	case EventSystem:
+		tags = []string{"system"}
+		text = fmt.Sprintf("System: %s", event.Topic)
+
+	default:
+		return
+	}
+
+	// Filter out empty tags
+	filteredTags := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != "" {
+			filteredTags = append(filteredTags, t)
+		}
+	}
+
+	if err := s.client.CreateAnnotation(filteredTags, text, timestamp, timestamp); err != nil {
+		slog.Warn("failed to push Grafana annotation", "type", event.Type, "error", err)
+	}
+}
+
+// StartAnnotationListener subscribes to deploy, alert, server, and system event
+// types and forwards them as Grafana annotations.
+func (s *GrafanaService) StartAnnotationListener() {
+	if s.bus == nil || !s.cfg.AnnotationsEnabled {
+		return
+	}
+
+	ctx := context.Background()
+	eventTypes := []EventType{EventDeploy, EventAlert, EventServer, EventSystem}
+	for _, et := range eventTypes {
+		go func(eventType EventType) {
+			ch := s.bus.SubscribeType(ctx, eventType)
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case event, ok := <-ch:
+					if !ok {
+						return
+					}
+					s.PushAnnotation(event)
+				}
+			}
+		}(et)
+	}
+	slog.Info("Grafana annotation listener started", "event_types", len(eventTypes))
+}
+
+// seedBuiltInDashboards checks if built-in dashboards exist in the database
+// and inserts them if not present.
+func (s *GrafanaService) seedBuiltInDashboards() {
+	for _, def := range builtInDashboardList {
+		var existing model.GrafanaCustomDashboard
+		err := s.db.Where("name = ? AND is_built_in = ?", def.name, true).First(&existing).Error
+		if err == nil {
+			continue // already exists
+		}
+		if err != gorm.ErrRecordNotFound {
+			slog.Warn("failed to check built-in dashboard", "name", def.name, "error", err)
+			continue
+		}
+
+		// Insert built-in dashboard
+		dashJSON := def.fn()
+		jsonBytes, err := json.Marshal(dashJSON)
+		if err != nil {
+			slog.Warn("failed to marshal built-in dashboard", "name", def.name, "error", err)
+			continue
+		}
+
+		uid := ""
+		if u, ok := dashJSON["uid"].(string); ok {
+			uid = u
+		}
+
+		dashboard := model.GrafanaCustomDashboard{
+			Name:      def.name,
+			UID:       uid,
+			JSON:      string(jsonBytes),
+			Tags:      `["deploypilot", "auto-provisioned"]`,
+			IsBuiltIn: true,
+			Enabled:   true,
+		}
+
+		if err := s.db.Create(&dashboard).Error; err != nil {
+			// Ignore duplicate key errors (race condition)
+			if !strings.Contains(err.Error(), "UNIQUE") && !strings.Contains(err.Error(), "duplicate") {
+				slog.Warn("failed to seed built-in dashboard", "name", def.name, "error", err)
+			}
+		}
+	}
+}
+
+// recordSyncLog creates a sync log entry in the database.
+func (s *GrafanaService) recordSyncLog(action, status, message string) {
+	log := model.GrafanaSyncLog{
+		Action:  action,
+		Status:  status,
+		Message: message,
+	}
+	if err := s.db.Create(&log).Error; err != nil {
+		slog.Warn("failed to record grafana sync log", "error", err)
+	}
+}
+
+// --- Payload parsers ---
+
+type deployAnnotationPayload struct {
+	AppName    string `json:"app_name"`
+	ServerName string `json:"server_name"`
+	Status     string `json:"status"`
+	Duration   int64  `json:"duration_ms"`
+}
+
+type alertAnnotationPayload struct {
+	RuleName string `json:"rule_name"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+type serverAnnotationPayload struct {
+	ServerName string `json:"server_name"`
+	Action     string `json:"action"`
+}
+
+func (s *GrafanaService) parseDeployPayload(payload interface{}) deployAnnotationPayload {
+	p := deployAnnotationPayload{}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return p
+	}
+	_ = json.Unmarshal(data, &p)
+	return p
+}
+
+func (s *GrafanaService) parseAlertPayload(payload interface{}) alertAnnotationPayload {
+	p := alertAnnotationPayload{}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return p
+	}
+	_ = json.Unmarshal(data, &p)
+	return p
+}
+
+func (s *GrafanaService) parseServerPayload(payload interface{}) serverAnnotationPayload {
+	p := serverAnnotationPayload{}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return p
+	}
+	_ = json.Unmarshal(data, &p)
+	return p
+}

--- a/web/src/api/modules/grafana.ts
+++ b/web/src/api/modules/grafana.ts
@@ -1,0 +1,64 @@
+import api from '@/api'
+import type { ApiResponse } from '@/types/api'
+
+export interface GrafanaStatus {
+  connected: boolean
+  url: string
+  version?: string
+  datasource_uid?: string
+  last_sync?: string
+  annotations_enabled: boolean
+}
+
+export interface GrafanaDashboard {
+  id: string
+  name: string
+  uid: string
+  description: string
+  tags: string
+  is_built_in: boolean
+  enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface GrafanaExport {
+  datasource: Record<string, unknown>
+  dashboards: { name: string; json: Record<string, unknown> }[]
+}
+
+export function getGrafanaStatus() {
+  return api.get<ApiResponse<GrafanaStatus>>('/api/v1/grafana/status')
+}
+
+export function testGrafanaConnection() {
+  return api.post<ApiResponse<{ success: boolean; version: string }>>('/api/v1/grafana/test')
+}
+
+export function syncGrafana() {
+  return api.post<ApiResponse<{ synced: number }>>('/api/v1/grafana/sync')
+}
+
+export function listGrafanaDashboards() {
+  return api.get<ApiResponse<GrafanaDashboard[]>>('/api/v1/grafana/dashboards')
+}
+
+export function getGrafanaDashboard(id: string) {
+  return api.get<ApiResponse<GrafanaDashboard>>(`/api/v1/grafana/dashboards/${id}`)
+}
+
+export function createGrafanaDashboard(data: { name: string; json: string; tags?: string }) {
+  return api.post<ApiResponse<GrafanaDashboard>>('/api/v1/grafana/dashboards', data)
+}
+
+export function updateGrafanaDashboard(id: string, data: { name?: string; json?: string; tags?: string; enabled?: boolean }) {
+  return api.put<ApiResponse<GrafanaDashboard>>(`/api/v1/grafana/dashboards/${id}`, data)
+}
+
+export function deleteGrafanaDashboard(id: string) {
+  return api.delete<ApiResponse<void>>(`/api/v1/grafana/dashboards/${id}`)
+}
+
+export function exportGrafana() {
+  return api.get<ApiResponse<GrafanaExport>>('/api/v1/grafana/export')
+}

--- a/web/src/layout/MainLayout.vue
+++ b/web/src/layout/MainLayout.vue
@@ -42,6 +42,7 @@ import {
   Tv,
   Download,
   Webhook,
+  BarChart3,
   Menu,
   X,
 } from 'lucide-vue-next'
@@ -116,6 +117,8 @@ const navGroups = computed(() => [
       { path: '/monitor/settings', label: t('layout.monitorSettings'), icon: Settings },
       { path: '/monitor/export', label: t('layout.monitorExport'), icon: Download },
       { path: '/webhooks', label: t('layout.webhooks'), icon: Webhook },
+      { path: '/settings/grafana', label: t('layout.grafana_settings'), icon: BarChart3 },
+      { path: '/grafana/dashboards', label: t('layout.grafana_dashboards'), icon: LayoutDashboard },
       { path: '/dashboard-tv', label: t('layout.dashboardTV'), icon: Tv },
       { path: '/notifications', label: t('layout.notifications'), icon: Bell },
       { path: '/templates', label: t('layout.templates'), icon: FileCode },

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -254,6 +254,18 @@ const router = createRouter({
           meta: { titleKey: 'routes.webhookDeliveries' },
         },
         {
+          path: 'settings/grafana',
+          name: 'GrafanaSettings',
+          component: () => import('@/views/GrafanaSettings.vue'),
+          meta: { titleKey: 'layout.grafana_settings' },
+        },
+        {
+          path: 'grafana/dashboards',
+          name: 'GrafanaDashboards',
+          component: () => import('@/views/GrafanaDashboards.vue'),
+          meta: { titleKey: 'layout.grafana_dashboards' },
+        },
+        {
           path: 'monitors',
           name: 'UptimeMonitors',
           component: () => import('@/views/UptimeMonitors.vue'),

--- a/web/src/views/GrafanaDashboards.vue
+++ b/web/src/views/GrafanaDashboards.vue
@@ -1,0 +1,442 @@
+<script setup lang="ts">
+import { ref, onMounted, inject } from 'vue'
+import {
+  LayoutDashboard,
+  Plus,
+  Pencil,
+  Trash2,
+  RefreshCw,
+  Loader2,
+  Tag,
+} from 'lucide-vue-next'
+import PageHeader from '@/components/common/PageHeader.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+import RelativeTime from '@/components/common/RelativeTime.vue'
+import Button from '@/components/ui/Button.vue'
+import Card from '@/components/ui/Card.vue'
+import Badge from '@/components/ui/Badge.vue'
+import Skeleton from '@/components/ui/Skeleton.vue'
+import {
+  listGrafanaDashboards,
+  createGrafanaDashboard,
+  updateGrafanaDashboard,
+  deleteGrafanaDashboard,
+  syncGrafana,
+} from '@/api/modules/grafana'
+import type { GrafanaDashboard } from '@/api/modules/grafana'
+
+const { toast } = inject<any>('toast')!
+
+const dashboards = ref<GrafanaDashboard[]>([])
+const loading = ref(false)
+const error = ref('')
+const syncing = ref(false)
+
+// Upload dialog state
+const uploadDialogOpen = ref(false)
+const uploading = ref(false)
+const uploadForm = ref({
+  name: '',
+  tags: '',
+  json: '',
+})
+
+// Edit dialog state
+const editDialogOpen = ref(false)
+const editing = ref(false)
+const editForm = ref({
+  id: '',
+  name: '',
+  tags: '',
+  json: '',
+  enabled: true,
+})
+
+// Delete dialog state
+const deleteDialogOpen = ref(false)
+const deletingDashboard = ref<GrafanaDashboard | null>(null)
+const deleting = ref(false)
+
+async function fetchDashboards() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await listGrafanaDashboards()
+    if (res.data.status === 'success') {
+      dashboards.value = res.data.data
+    }
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load dashboards'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openUploadDialog() {
+  uploadForm.value = { name: '', tags: '', json: '' }
+  uploadDialogOpen.value = true
+}
+
+async function handleUpload() {
+  if (!uploadForm.value.name.trim() || !uploadForm.value.json.trim()) {
+    toast('Name and JSON are required', 'destructive')
+    return
+  }
+  // Validate JSON
+  try {
+    JSON.parse(uploadForm.value.json)
+  } catch {
+    toast('Invalid JSON format', 'destructive')
+    return
+  }
+  uploading.value = true
+  try {
+    await createGrafanaDashboard({
+      name: uploadForm.value.name.trim(),
+      json: uploadForm.value.json.trim(),
+      tags: uploadForm.value.tags.trim() || undefined,
+    })
+    toast('Dashboard created successfully', 'success')
+    uploadDialogOpen.value = false
+    fetchDashboards()
+  } catch (e: any) {
+    toast(e?.message || 'Failed to create dashboard', 'destructive')
+  } finally {
+    uploading.value = false
+  }
+}
+
+function openEditDialog(dashboard: GrafanaDashboard) {
+  editForm.value = {
+    id: dashboard.id,
+    name: dashboard.name,
+    tags: dashboard.tags,
+    json: '',
+    enabled: dashboard.enabled,
+  }
+  editDialogOpen.value = true
+}
+
+async function handleEdit() {
+  if (!editForm.value.name.trim()) {
+    toast('Name is required', 'destructive')
+    return
+  }
+  const data: { name?: string; tags?: string; json?: string; enabled?: boolean } = {
+    name: editForm.value.name.trim(),
+    tags: editForm.value.tags.trim() || undefined,
+    enabled: editForm.value.enabled,
+  }
+  if (editForm.value.json.trim()) {
+    try {
+      JSON.parse(editForm.value.json)
+      data.json = editForm.value.json.trim()
+    } catch {
+      toast('Invalid JSON format', 'destructive')
+      return
+    }
+  }
+  editing.value = true
+  try {
+    await updateGrafanaDashboard(editForm.value.id, data)
+    toast('Dashboard updated successfully', 'success')
+    editDialogOpen.value = false
+    fetchDashboards()
+  } catch (e: any) {
+    toast(e?.message || 'Failed to update dashboard', 'destructive')
+  } finally {
+    editing.value = false
+  }
+}
+
+function openDeleteDialog(dashboard: GrafanaDashboard) {
+  deletingDashboard.value = dashboard
+  deleteDialogOpen.value = true
+}
+
+async function confirmDelete() {
+  if (!deletingDashboard.value) return
+  deleting.value = true
+  try {
+    await deleteGrafanaDashboard(deletingDashboard.value.id)
+    toast('Dashboard deleted', 'success')
+    deleteDialogOpen.value = false
+    deletingDashboard.value = null
+    fetchDashboards()
+  } catch (e: any) {
+    toast(e?.message || 'Failed to delete dashboard', 'destructive')
+  } finally {
+    deleting.value = false
+  }
+}
+
+async function handleSyncAll() {
+  syncing.value = true
+  try {
+    const res = await syncGrafana()
+    if (res.data.status === 'success') {
+      toast(`Synced ${res.data.data.synced} dashboards`, 'success')
+      fetchDashboards()
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Sync failed', 'destructive')
+  } finally {
+    syncing.value = false
+  }
+}
+
+function parseTags(tags: string): string[] {
+  if (!tags) return []
+  return tags.split(',').map(t => t.trim()).filter(Boolean)
+}
+
+onMounted(fetchDashboards)
+</script>
+
+<template>
+  <div class="space-y-4">
+    <PageHeader title="Grafana Dashboards" description="Manage built-in and custom Grafana dashboards">
+      <template #actions>
+        <Button variant="outline" :loading="syncing" @click="handleSyncAll">
+          <template #icon>
+            <RefreshCw class="w-4 h-4" />
+          </template>
+          Sync All
+        </Button>
+        <Button @click="openUploadDialog">
+          <template #icon>
+            <Plus class="w-4 h-4" />
+          </template>
+          Upload Dashboard
+        </Button>
+      </template>
+    </PageHeader>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-for="i in 6" :key="i" class="rounded-lg border border-border bg-card p-6 space-y-3">
+        <Skeleton class="h-5 w-3/4" />
+        <Skeleton class="h-4 w-full" />
+        <div class="flex gap-2">
+          <Skeleton variant="circular" class="h-6 w-16 !rounded-full" />
+          <Skeleton variant="circular" class="h-6 w-16 !rounded-full" />
+        </div>
+        <Skeleton class="h-4 w-1/2" />
+      </div>
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="error" class="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+      {{ error }}
+    </div>
+
+    <!-- Empty State -->
+    <EmptyState
+      v-else-if="dashboards.length === 0"
+      :icon="LayoutDashboard"
+      title="No dashboards found"
+      description="Sync dashboards from Grafana or upload a custom dashboard JSON."
+      action-text="Sync All"
+      @action="handleSyncAll"
+    />
+
+    <!-- Dashboard Cards -->
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <Card v-for="dashboard in dashboards" :key="dashboard.id" class="p-0">
+        <div class="p-6 space-y-3">
+          <!-- Header: Name + Type badge -->
+          <div class="flex items-start justify-between">
+            <h3 class="text-sm font-semibold text-foreground truncate">{{ dashboard.name }}</h3>
+            <span
+              class="inline-flex items-center px-2 py-0.5 text-xs rounded-full font-medium shrink-0 ml-2"
+              :class="dashboard.is_built_in ? 'bg-blue-100 text-blue-700' : 'bg-purple-100 text-purple-700'"
+            >
+              {{ dashboard.is_built_in ? 'Built-in' : 'Custom' }}
+            </span>
+          </div>
+
+          <!-- Description -->
+          <p v-if="dashboard.description" class="text-xs text-muted-foreground line-clamp-2">
+            {{ dashboard.description }}
+          </p>
+
+          <!-- Tags -->
+          <div v-if="dashboard.tags" class="flex items-center gap-1.5 flex-wrap">
+            <Tag class="w-3 h-3 text-muted-foreground shrink-0" />
+            <span
+              v-for="tag in parseTags(dashboard.tags)"
+              :key="tag"
+              class="inline-flex items-center px-1.5 py-0.5 text-xs rounded bg-gray-100 text-gray-600"
+            >
+              {{ tag }}
+            </span>
+          </div>
+
+          <!-- Enabled status -->
+          <div class="flex items-center gap-2">
+            <span
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full"
+              :class="dashboard.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'"
+            >
+              <span class="w-1.5 h-1.5 rounded-full" :class="dashboard.enabled ? 'bg-green-500' : 'bg-gray-400'" />
+              {{ dashboard.enabled ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+
+          <!-- Updated time -->
+          <div class="text-xs text-muted-foreground">
+            Updated: <RelativeTime :date="dashboard.updated_at" />
+          </div>
+        </div>
+
+        <!-- Card Actions -->
+        <div class="flex items-center border-t border-border px-4 py-2 gap-1">
+          <Button variant="ghost" size="sm" class="h-7 text-xs" @click="openEditDialog(dashboard)">
+            <template #icon>
+              <Pencil class="w-3.5 h-3.5" />
+            </template>
+            {{ dashboard.is_built_in ? 'View' : 'Edit' }}
+          </Button>
+          <template v-if="!dashboard.is_built_in">
+            <div class="flex-1" />
+            <Button variant="ghost" size="icon" class="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10" @click="openDeleteDialog(dashboard)">
+              <Trash2 class="w-3.5 h-3.5" />
+            </Button>
+          </template>
+        </div>
+      </Card>
+    </div>
+
+    <!-- Upload Dashboard Dialog -->
+    <Teleport to="body">
+      <div v-if="uploadDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-lg p-6 border border-border max-h-[90vh] overflow-auto">
+          <h2 class="text-lg font-semibold text-foreground mb-4">Upload Dashboard</h2>
+          <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium mb-1">Name</label>
+              <input
+                v-model="uploadForm.name"
+                type="text"
+                placeholder="My Dashboard"
+                class="w-full px-3 py-2 border rounded-md text-sm"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1">Tags</label>
+              <input
+                v-model="uploadForm.tags"
+                type="text"
+                placeholder="monitoring, app (comma-separated)"
+                class="w-full px-3 py-2 border rounded-md text-sm"
+              />
+              <p class="text-xs text-gray-500 mt-1">Comma-separated tags for categorization</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1">Dashboard JSON</label>
+              <textarea
+                v-model="uploadForm.json"
+                rows="10"
+                placeholder='Paste Grafana dashboard JSON here...'
+                class="w-full px-3 py-2 border rounded-md text-sm font-mono resize-y"
+              />
+              <p class="text-xs text-gray-500 mt-1">Paste the full Grafana dashboard JSON exported from Grafana</p>
+            </div>
+          </div>
+          <div class="flex justify-end gap-2 mt-6">
+            <Button variant="outline" size="sm" @click="uploadDialogOpen = false">Cancel</Button>
+            <Button size="sm" :loading="uploading" @click="handleUpload">
+              <template #icon>
+                <Plus class="w-3.5 h-3.5" />
+              </template>
+              Create
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Edit Dashboard Dialog -->
+    <Teleport to="body">
+      <div v-if="editDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-lg p-6 border border-border max-h-[90vh] overflow-auto">
+          <h2 class="text-lg font-semibold text-foreground mb-4">{{ editForm.enabled ? 'Edit' : 'View' }} Dashboard</h2>
+          <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium mb-1">Name</label>
+              <input
+                v-model="editForm.name"
+                type="text"
+                :disabled="editForm.enabled === false"
+                class="w-full px-3 py-2 border rounded-md text-sm"
+                :class="{ 'bg-gray-50 cursor-not-allowed': !editForm.enabled }"
+              />
+            </div>
+            <div>
+              <label class="block text-sm font-medium mb-1">Tags</label>
+              <input
+                v-model="editForm.tags"
+                type="text"
+                placeholder="monitoring, app (comma-separated)"
+                :disabled="editForm.enabled === false"
+                class="w-full px-3 py-2 border rounded-md text-sm"
+                :class="{ 'bg-gray-50 cursor-not-allowed': !editForm.enabled }"
+              />
+            </div>
+            <div v-if="!editForm.enabled">
+              <label class="block text-sm font-medium mb-1">Dashboard JSON</label>
+              <textarea
+                v-model="editForm.json"
+                rows="6"
+                placeholder="Leave empty to keep existing JSON, or paste new JSON to replace"
+                class="w-full px-3 py-2 border rounded-md text-sm font-mono resize-y bg-gray-50 cursor-not-allowed"
+                disabled
+              />
+              <p class="text-xs text-gray-500 mt-1">Built-in dashboards cannot be edited</p>
+            </div>
+            <div v-else>
+              <label class="block text-sm font-medium mb-1">Dashboard JSON</label>
+              <textarea
+                v-model="editForm.json"
+                rows="6"
+                placeholder="Leave empty to keep existing JSON, or paste new JSON to replace"
+                class="w-full px-3 py-2 border rounded-md text-sm font-mono resize-y"
+              />
+              <p class="text-xs text-gray-500 mt-1">Leave empty to keep existing JSON unchanged</p>
+            </div>
+          </div>
+          <div class="flex justify-end gap-2 mt-6">
+            <Button variant="outline" size="sm" @click="editDialogOpen = false">Cancel</Button>
+            <Button v-if="editForm.enabled" size="sm" :loading="editing" @click="handleEdit">
+              <template #icon>
+                <Pencil class="w-3.5 h-3.5" />
+              </template>
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Delete Confirmation Dialog -->
+    <Teleport to="body">
+      <div v-if="deleteDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-2">Delete Dashboard</h2>
+          <p class="text-sm text-muted-foreground mb-4">
+            Are you sure you want to delete "{{ deletingDashboard?.name }}"? This action cannot be undone.
+          </p>
+          <div class="flex justify-end gap-2">
+            <Button variant="outline" size="sm" @click="deleteDialogOpen = false">Cancel</Button>
+            <Button variant="destructive" size="sm" :loading="deleting" @click="confirmDelete">
+              <template v-if="!deleting" #icon>
+                <Trash2 class="w-3.5 h-3.5" />
+              </template>
+              Delete
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/web/src/views/GrafanaSettings.vue
+++ b/web/src/views/GrafanaSettings.vue
@@ -1,0 +1,271 @@
+<script setup lang="ts">
+import { ref, onMounted, inject } from 'vue'
+import PageHeader from '@/components/common/PageHeader.vue'
+import RelativeTime from '@/components/common/RelativeTime.vue'
+import Button from '@/components/ui/Button.vue'
+import Card from '@/components/ui/Card.vue'
+import Skeleton from '@/components/ui/Skeleton.vue'
+import {
+  RefreshCw,
+  Download,
+  Wifi,
+  WifiOff,
+  Loader2,
+  BarChart3,
+  Tag,
+  Clock,
+  Database,
+} from 'lucide-vue-next'
+import {
+  getGrafanaStatus,
+  testGrafanaConnection,
+  syncGrafana,
+  exportGrafana,
+} from '@/api/modules/grafana'
+import type { GrafanaStatus } from '@/api/modules/grafana'
+
+const { toast } = inject<any>('toast')!
+
+const status = ref<GrafanaStatus | null>(null)
+const loading = ref(false)
+const testing = ref(false)
+const syncing = ref(false)
+const exporting = ref(false)
+
+async function fetchStatus() {
+  loading.value = true
+  try {
+    const res = await getGrafanaStatus()
+    if (res.data.status === 'success') {
+      status.value = res.data.data
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Failed to load Grafana status', 'destructive')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleTestConnection() {
+  testing.value = true
+  try {
+    const res = await testGrafanaConnection()
+    if (res.data.status === 'success') {
+      toast(`Grafana connected successfully (v${res.data.data.version})`, 'success')
+      fetchStatus()
+    } else {
+      toast(res.data.message || 'Connection test failed', 'destructive')
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Connection test failed', 'destructive')
+  } finally {
+    testing.value = false
+  }
+}
+
+async function handleSyncAll() {
+  syncing.value = true
+  try {
+    const res = await syncGrafana()
+    if (res.data.status === 'success') {
+      toast(`Synced ${res.data.data.synced} dashboards`, 'success')
+      fetchStatus()
+    } else {
+      toast(res.data.message || 'Sync failed', 'destructive')
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Sync failed', 'destructive')
+  } finally {
+    syncing.value = false
+  }
+}
+
+async function handleExport() {
+  exporting.value = true
+  try {
+    const res = await exportGrafana()
+    if (res.data.status === 'success') {
+      const exportData = res.data.data
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = 'grafana-templates.json'
+      a.click()
+      URL.revokeObjectURL(url)
+      toast('Templates exported successfully', 'success')
+    } else {
+      toast(res.data.message || 'Export failed', 'destructive')
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Export failed', 'destructive')
+  } finally {
+    exporting.value = false
+  }
+}
+
+function formatTimestamp(ts?: string): string {
+  if (!ts) return 'Never'
+  return ts
+}
+
+onMounted(fetchStatus)
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageHeader title="Grafana Settings" description="Manage Grafana integration and dashboard synchronization">
+      <template #actions>
+        <Button variant="outline" :loading="testing" :disabled="loading" @click="handleTestConnection">
+          <template #icon>
+            <Wifi class="w-4 h-4" />
+          </template>
+          Test Connection
+        </Button>
+        <Button :loading="syncing" :disabled="loading" @click="handleSyncAll">
+          <template #icon>
+            <RefreshCw class="w-4 h-4" />
+          </template>
+          Sync All
+        </Button>
+        <Button variant="outline" :loading="exporting" :disabled="loading" @click="handleExport">
+          <template #icon>
+            <Download class="w-4 h-4" />
+          </template>
+          Export Templates
+        </Button>
+      </template>
+    </PageHeader>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="space-y-4">
+      <div class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm space-y-4">
+        <Skeleton class="h-6 w-1/3" />
+        <Skeleton class="h-4 w-2/3" />
+        <Skeleton class="h-4 w-1/2" />
+      </div>
+      <div class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm space-y-4">
+        <Skeleton class="h-6 w-1/3" />
+        <Skeleton class="h-4 w-2/3" />
+      </div>
+    </div>
+
+    <template v-else-if="status">
+      <!-- Connection Status Card -->
+      <div class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm">
+        <h3 class="text-base font-semibold mb-4">Connection Status</h3>
+        <div class="flex items-center gap-3 mb-4">
+          <span
+            class="inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-full font-medium"
+            :class="status.connected ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'"
+          >
+            <component :is="status.connected ? Wifi : WifiOff" class="w-4 h-4" />
+            {{ status.connected ? 'Connected' : 'Disconnected' }}
+          </span>
+          <span v-if="status.version" class="text-sm text-muted-foreground">
+            Grafana v{{ status.version }}
+          </span>
+        </div>
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div>
+            <label class="block text-sm font-medium mb-1">Grafana URL</label>
+            <p class="text-sm font-mono text-muted-foreground truncate" :title="status.url">
+              {{ status.url || 'Not configured' }}
+            </p>
+            <p class="text-xs text-gray-500 mt-1">Configure in server config.yaml</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium mb-1">Datasource UID</label>
+            <p class="text-sm font-mono text-muted-foreground truncate" :title="status.datasource_uid">
+              {{ status.datasource_uid || 'Not configured' }}
+            </p>
+            <p class="text-xs text-gray-500 mt-1">Auto-populated after first sync</p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium mb-1">Last Sync</label>
+            <p class="text-sm text-muted-foreground">
+              <template v-if="status.last_sync">
+                <RelativeTime :date="status.last_sync" />
+              </template>
+              <template v-else>
+                Never
+              </template>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Annotations Status Card -->
+      <div class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm">
+        <h3 class="text-base font-semibold mb-4">Annotations</h3>
+        <div class="flex items-center justify-between">
+          <div>
+            <p class="text-sm font-medium">Deployment Annotations</p>
+            <p class="text-xs text-gray-500 mt-0.5">Send deployment events as annotations to Grafana dashboards for correlation with metrics</p>
+          </div>
+          <span
+            class="inline-flex items-center gap-1.5 px-2.5 py-0.5 text-xs rounded-full font-medium"
+            :class="status.annotations_enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'"
+          >
+            <span class="w-1.5 h-1.5 rounded-full" :class="status.annotations_enabled ? 'bg-green-500' : 'bg-gray-400'" />
+            {{ status.annotations_enabled ? 'Enabled' : 'Disabled' }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Configuration Info Card -->
+      <div class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm">
+        <h3 class="text-base font-semibold mb-4">Configuration</h3>
+        <p class="text-sm text-muted-foreground mb-4">
+          Grafana connection settings are configured on the server side in <code class="px-1.5 py-0.5 bg-gray-100 rounded text-xs font-mono">config.yaml</code>. Use the "Test Connection" button above to verify the configuration.
+        </p>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div class="flex items-start gap-3 p-3 bg-gray-50 rounded-lg">
+            <BarChart3 class="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+            <div>
+              <p class="text-sm font-medium">Grafana URL</p>
+              <p class="text-xs text-gray-500 mt-0.5">Set <code class="font-mono">grafana.url</code> in config.yaml</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-3 p-3 bg-gray-50 rounded-lg">
+            <Tag class="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+            <div>
+              <p class="text-sm font-medium">API Key</p>
+              <p class="text-xs text-gray-500 mt-0.5">Set <code class="font-mono">grafana.api_key</code> in config.yaml</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-3 p-3 bg-gray-50 rounded-lg">
+            <Database class="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+            <div>
+              <p class="text-sm font-medium">Datasource</p>
+              <p class="text-xs text-gray-500 mt-0.5">Set <code class="font-mono">grafana.datasource_uid</code> in config.yaml</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-3 p-3 bg-gray-50 rounded-lg">
+            <Clock class="w-5 h-5 text-muted-foreground shrink-0 mt-0.5" />
+            <div>
+              <p class="text-sm font-medium">Admin Credentials</p>
+              <p class="text-xs text-gray-500 mt-0.5">Set <code class="font-mono">grafana.admin_user</code> and <code class="font-mono">grafana.admin_password</code> in config.yaml</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Error State - no status loaded -->
+    <div v-else class="p-6 bg-white border border-gray-200 rounded-xl shadow-sm">
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-base font-semibold">Unable to Load Grafana Status</h3>
+          <p class="text-sm text-muted-foreground mt-1">The Grafana integration may not be configured on the server.</p>
+        </div>
+        <Button variant="outline" @click="fetchStatus">
+          <template #icon>
+            <RefreshCw class="w-4 h-4" />
+          </template>
+          Retry
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Phase 7.2: Grafana Integration

### Features
- **Dual-mode integration**: Manual JSON export + automatic Grafana API provisioning
- **4 built-in dashboards**: Uptime Monitor, Server Resources, Deploy Statistics, Alert & Heartbeat
- **Custom dashboard upload**: Users can upload their own Grafana JSON templates
- **Datasource auto-config**: Automatically creates DeployPilot Prometheus datasource
- **Annotations push**: Deploy/alert/server/system events auto-pushed to Grafana
- **Frontend**: Settings page + Dashboard management page

### Backend
- `internal/config/config.go` — GrafanaConfig
- `internal/model/grafana.go` — GORM models
- `internal/service/grafana_client.go` — Grafana HTTP API client
- `internal/service/grafana_service.go` — Business logic
- `internal/service/dashboards/` — 4 built-in dashboard templates
- `internal/api/grafana_api.go` — 9 API endpoints

### Frontend
- `web/src/api/modules/grafana.ts` — API module
- `web/src/views/GrafanaSettings.vue` — Settings page
- `web/src/views/GrafanaDashboards.vue` — Dashboard management
- Router and navigation updates