### PR TITLE
feat: Phase 7.4 API Open Platform - OAuth2, scopes, rate limiting

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -220,6 +220,11 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string) error {
 		slog.Info("Grafana integration enabled", "url", cfg.Grafana.URL)
 	}
 
+	// OAuth2 service is initialized lazily via API handlers (no background goroutine needed)
+	if cfg.APIPlatform.Enabled {
+		slog.Info("API open platform enabled")
+	}
+
 	// Apply brute-force config from configuration file
 	bf := cfg.BruteForce
 	bridge.SetBruteForceConfig(service.BruteForceConfigFromMap(

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -87,3 +87,10 @@ grafana:
   admin_password: ""
   annotations_enabled: true
   sync_interval: 60
+
+# API 开放平台 (OAuth2)
+api_platform:
+  enabled: true
+  max_clients_per_user: 10
+  token_expire_hours: 24
+  code_expire_minutes: 10

--- a/docs/superpowers/specs/2026-05-02-api-open-platform-design.md
+++ b/docs/superpowers/specs/2026-05-02-api-open-platform-design.md
@@ -1,0 +1,242 @@
+# Phase 7.4: API Open Platform Design
+
+> Date: 2026-05-02
+> Status: Approved
+
+## Overview
+
+Transform DeployPilot's API into an enterprise-grade open platform with fine-grained scope permissions, enhanced Swagger documentation, distributed rate limiting, and OAuth2 application registration supporting both Client Credentials and Authorization Code flows.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  API Gateway Layer                   │
+│  ┌──────────┐  ┌──────────┐  ┌───────────────────┐  │
+│  │ API Key  │  │  OAuth2  │  │   JWT (existing)  │  │
+│  │ + Scopes │  │ CC+AuthC │  │   User auth       │  │
+│  └────┬─────┘  └────┬─────┘  └────────┬──────────┘  │
+│       └──────────────┼────────────────┘              │
+│                      ▼                               │
+│  ┌───────────────────────────────────────────────┐   │
+│  │    Rate Limiter (Per-Key/Per-Endpoint)        │   │
+│  │    Redis-backed + Memory fallback             │   │
+│  └───────────────────────────────────────────────┘   │
+│                      ▼                               │
+│  ┌───────────────────────────────────────────────┐   │
+│  │    Scope Middleware (RequireScope)             │   │
+│  └───────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────┘
+```
+
+## Feature Modules
+
+### 1. Scope Permission System
+
+**Standard Scope Enum:**
+
+| Scope | Description |
+|-------|-------------|
+| `read` | Read all resources |
+| `write` | Create/update resources |
+| `delete` | Delete resources |
+| `deploy` | Deploy/rollback operations |
+| `admin` | Admin super-scope (has all permissions) |
+| `monitor:read` | View monitoring data |
+| `monitor:write` | Manage monitoring config |
+| `server:read` | View server info |
+| `server:exec` | Execute remote commands |
+| `credential:read` | View credentials |
+| `credential:write` | Manage credentials |
+| `dns:write` | DNS record management |
+| `ssl:write` | SSL certificate management |
+| `backup:read` | View backups |
+| `backup:write` | Execute backup/restore |
+| `webhook:manage` | Manage webhooks |
+| `grafana:manage` | Manage Grafana integration |
+
+**RequireScope Middleware:**
+- `auth.RequireScope(scopes ...string)` — checks if current API Key or OAuth2 token has any of the required scopes
+- `admin` scope bypasses all checks
+- Returns 403 with descriptive error if scope insufficient
+- Sets scope info in context for audit logging
+
+**API Key Scope Enhancement:**
+- Validate scopes against the standard enum on creation
+- Add scope descriptions to API responses
+- Backward compatible: existing keys with custom scopes continue to work
+
+### 2. Swagger Documentation Enhancement
+
+**Security Definitions:**
+```json
+{
+  "BearerAuth": { "type": "apiKey", "in": "header", "name": "Authorization" },
+  "APIKeyAuth": { "type": "apiKey", "in": "header", "name": "X-API-Key" },
+  "OAuth2AccessCode": {
+    "type": "oauth2",
+    "flow": "accessCode",
+    "authorizationUrl": "/api/v1/oauth/authorize",
+    "tokenUrl": "/api/v1/oauth/token",
+    "scopes": { ... }
+  }
+}
+```
+
+**Annotations:** Add `@Summary`, `@Description`, `@Tags`, `@Param`, `@Success`, `@Failure`, `@Router`, `@Security` to all existing API handlers.
+
+**Developer Docs Page:** Frontend page at `/docs` embedding Swagger UI + API usage guide.
+
+### 3. Rate Limiting Enhancement
+
+**Per-Key Rate Limiting:**
+- Each API Key gets its own rate limit bucket
+- Default: inherit from role-based limits
+- Custom: user can set per-key rate limit (min 10/min, max 1000/min)
+- Stored in `APIKey.RateLimit` field (new column)
+
+**Per-Endpoint Rate Limiting:**
+- High-cost endpoints get lower limits:
+  - Deploy: 20/min
+  - Backup: 10/min
+  - SSL: 10/min
+  - Default: role-based limit
+
+**Redis Distributed:**
+- Use Redis INCR + EXPIRE for distributed rate limiting
+- Fallback to in-memory when Redis unavailable
+- Key format: `ratelimit:{type}:{id}:{endpoint}`
+
+**Burst Control:**
+- Allow burst of 2x the rate limit for 5 seconds
+- Use token bucket algorithm with burst parameter
+
+### 4. OAuth2 Application Registration
+
+**Grant Types:**
+
+**Client Credentials (machine-to-machine):**
+```
+POST /api/v1/oauth/token
+  grant_type=client_credentials
+  client_id=xxx
+  client_secret=xxx
+  scope=read,monitor:read
+→ { access_token, token_type, expires_in, scope }
+```
+
+**Authorization Code (user delegation):**
+```
+1. User visits: /api/v1/oauth/authorize?client_id=xxx&redirect_uri=xxx&scope=read&response_type=code
+2. User sees consent page → approves
+3. Redirect: {redirect_uri}?code=xxx
+4. App exchanges code: POST /api/v1/oauth/token (grant_type=authorization_code, code=xxx, ...)
+5. Response: { access_token, refresh_token, token_type, expires_in, scope }
+```
+
+**Data Models:**
+
+```go
+type OAuth2Client struct {
+    ID           string    `json:"id"`
+    TenantID     string    `json:"tenant_id"`
+    UserID       string    `json:"user_id"`
+    Name         string    `json:"name"`
+    ClientID     string    `json:"client_id" gorm:"uniqueIndex"`
+    ClientSecret string    `json:"-" gorm:"not null"`
+    RedirectURIs string    `json:"redirect_uris"`  // JSON array
+    Scopes       string    `json:"scopes"`         // JSON array
+    GrantTypes   string    `json:"grant_types"`    // JSON array: ["client_credentials", "authorization_code"]
+    Enabled      bool      `json:"enabled"`
+    CreatedAt    time.Time `json:"created_at"`
+    UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type OAuth2Authorization struct {
+    ID        string     `json:"id"`
+    ClientID  string     `json:"client_id"`
+    UserID    string     `json:"user_id"`
+    Scopes    string     `json:"scopes"`
+    Code      string     `json:"code" gorm:"uniqueIndex"`
+    ExpiresAt time.Time  `json:"expires_at"`
+    Used      bool       `json:"used"`
+    CreatedAt time.Time  `json:"created_at"`
+}
+
+type OAuth2Token struct {
+    ID           string     `json:"id"`
+    ClientID     string     `json:"client_id"`
+    UserID       string     `json:"user_id,omitempty"`
+    AccessToken  string     `json:"access_token" gorm:"uniqueIndex"`
+    RefreshToken string     `json:"refresh_token,omitempty" gorm:"uniqueIndex"`
+    Scopes       string     `json:"scopes"`
+    TokenType    string     `json:"token_type"`
+    ExpiresAt    time.Time  `json:"expires_at"`
+    CreatedAt    time.Time  `json:"created_at"`
+}
+```
+
+**API Endpoints:**
+
+```
+# OAuth2
+POST   /api/v1/oauth/authorize          # Start authorization (redirect user to consent page)
+GET    /api/v1/oauth/consent            # Consent page (frontend)
+POST   /api/v1/oauth/consent            # User approves/rejects authorization
+POST   /api/v1/oauth/token              # Exchange code or client_credentials for token
+POST   /api/v1/oauth/token/refresh       # Refresh access token
+POST   /api/v1/oauth/token/revoke        # Revoke token
+
+# OAuth2 Client Management
+GET    /api/v1/oauth/clients            # List user's OAuth2 apps
+POST   /api/v1/oauth/clients            # Register new OAuth2 app
+GET    /api/v1/oauth/clients/:id        # Get app details
+PUT    /api/v1/oauth/clients/:id        # Update app
+DELETE /api/v1/oauth/clients/:id        # Delete app
+POST   /api/v1/oauth/clients/:id/secret # Regenerate client secret
+```
+
+**Frontend Pages:**
+- OAuth2 Apps management page (CRUD)
+- OAuth2 consent page (user authorization)
+- Developer documentation page
+
+### 5. Config Changes
+
+```go
+type APIPlatformConfig struct {
+    Enabled           bool `mapstructure:"enabled"`
+    MaxClientsPerUser int  `mapstructure:"max_clients_per_user"` // default: 10
+    TokenExpireHours  int  `mapstructure:"token_expire_hours"`   // default: 24
+    CodeExpireMinutes int  `mapstructure:"code_expire_minutes"`  // default: 10
+}
+```
+
+## File Structure
+
+```
+internal/
+├── config/config.go                    # Add APIPlatformConfig
+├── model/oauth2.go                     # OAuth2Client, OAuth2Authorization, OAuth2Token
+├── auth/
+│   ├── scopes.go                       # Scope constants + RequireScope middleware
+│   └── oauth2_middleware.go            # OAuth2 Bearer token middleware
+├── service/
+│   ├── oauth2_service.go               # OAuth2 business logic
+│   └── ratelimit_redis.go              # Redis-backed rate limiter
+├── api/
+│   ├── oauth2_api.go                   # OAuth2 handlers
+│   ├── oauth2_clients_api.go           # Client management handlers
+│   └── router.go                       # Add OAuth2 routes + scope middleware
+web/src/
+├── api/modules/oauth2.ts               # OAuth2 API module
+├── views/
+│   ├── OAuth2Apps.vue                  # App management page
+│   └── OAuth2Consent.vue               # Consent page
+└── router/index.ts                     # Add routes
+```
+
+## Dependencies
+
+- No new Go dependencies (use crypto/rand, crypto/sha256 for OAuth2)
+- Frontend: existing dependencies sufficient

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -182,7 +182,7 @@ func setupFullTestRouter(db *gorm.DB, bridge *service.Bridge) *gin.Engine {
 	go wsHub.Run()
 	auditSvc := service.NewAuditService(db)
 	backupSvc := backup.New(backup.Config{BackupDir: os.TempDir()}, db, "sqlite", "")
-	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc, nil, false, nil)
+	RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, nil, nil, backupSvc, nil, false, nil, nil)
 	return r
 }
 

--- a/internal/api/oauth2_api.go
+++ b/internal/api/oauth2_api.go
@@ -1,0 +1,502 @@
+package api
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/config"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/service"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// globalOAuth2API is the package-level OAuth2API instance, accessible via GetGlobalOAuth2API().
+var globalOAuth2API *OAuth2API
+
+// GetGlobalOAuth2API returns the global OAuth2API instance.
+func GetGlobalOAuth2API() *OAuth2API { return globalOAuth2API }
+
+// OAuth2API provides HTTP handlers for OAuth2 client and token management.
+type OAuth2API struct {
+	db  *gorm.DB
+	cfg *config.APIPlatformConfig
+}
+
+// NewOAuth2API creates a new OAuth2API.
+func NewOAuth2API(db *gorm.DB, cfg *config.APIPlatformConfig) *OAuth2API {
+	return &OAuth2API{db: db, cfg: cfg}
+}
+
+// createClientRequest is the request body for creating an OAuth2 client.
+type createClientRequest struct {
+	Name         string   `json:"name" binding:"required"`
+	RedirectURIs []string `json:"redirect_uris"`
+	Scopes       []string `json:"scopes"`
+	GrantTypes   []string `json:"grant_types"`
+}
+
+// updateClientRequest is the request body for updating an OAuth2 client.
+type updateClientRequest struct {
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirect_uris"`
+	Scopes       []string `json:"scopes"`
+	GrantTypes   []string `json:"grant_types"`
+	Enabled      *bool    `json:"enabled"`
+}
+
+// tokenRequest is the OAuth2 token request body (RFC 6749).
+type tokenRequest struct {
+	GrantType    string `json:"grant_type" form:"grant_type"`
+	Code         string `json:"code" form:"code"`
+	RedirectURI  string `json:"redirect_uri" form:"redirect_uri"`
+	ClientID     string `json:"client_id" form:"client_id"`
+	ClientSecret string `json:"client_secret" form:"client_secret"`
+	Scope        string `json:"scope" form:"scope"`
+	RefreshToken string `json:"refresh_token" form:"refresh_token"`
+}
+
+// authorizeRequest is the request body for starting an authorization code flow.
+type authorizeRequest struct {
+	ClientID string   `json:"client_id" binding:"required"`
+	Scopes   []string `json:"scopes"`
+}
+
+// ListClients lists all OAuth2 client applications for the authenticated user.
+// GET /api/v1/oauth/clients
+func (a *OAuth2API) ListClients(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	clients, err := svc.ListClients(userID)
+	if err != nil {
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	// Sanitize: remove client_secret from response
+	sanitized := make([]map[string]interface{}, 0, len(clients))
+	for _, cl := range clients {
+		sanitized = append(sanitized, map[string]interface{}{
+			"id":            cl.ID,
+			"user_id":       cl.UserID,
+			"name":          cl.Name,
+			"client_id":     cl.ClientID,
+			"redirect_uris": cl.RedirectURIs,
+			"scopes":        cl.Scopes,
+			"grant_types":   cl.GrantTypes,
+			"enabled":       cl.Enabled,
+			"created_at":    cl.CreatedAt,
+			"updated_at":    cl.UpdatedAt,
+		})
+	}
+
+	respondSuccess(c, sanitized)
+}
+
+// CreateClient creates a new OAuth2 client application.
+// POST /api/v1/oauth/clients
+func (a *OAuth2API) CreateClient(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	var req createClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	client, secret, err := svc.CreateClient(userID, req.Name, req.RedirectURIs, req.Scopes, req.GrantTypes)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"status":         "success",
+		"data":           client,
+		"client_secret":  secret,
+		"message":        "save the client_secret now, it will not be shown again",
+	})
+}
+
+// GetClient returns a single OAuth2 client by ID.
+// GET /api/v1/oauth/clients/:id
+func (a *OAuth2API) GetClient(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	id := c.Param("id")
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	client, err := svc.GetClient(id, userID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, client)
+}
+
+// UpdateClient updates an OAuth2 client's metadata.
+// PUT /api/v1/oauth/clients/:id
+func (a *OAuth2API) UpdateClient(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	id := c.Param("id")
+
+	var req updateClientRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	updates := make(map[string]interface{})
+	if req.Name != "" {
+		updates["name"] = req.Name
+	}
+	if req.RedirectURIs != nil {
+		urisJSON, err := json.Marshal(req.RedirectURIs)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+			return
+		}
+		updates["redirect_uris"] = string(urisJSON)
+	}
+	if req.Scopes != nil {
+		scopesJSON, err := json.Marshal(req.Scopes)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+			return
+		}
+		updates["scopes"] = string(scopesJSON)
+	}
+	if req.GrantTypes != nil {
+		grantTypesJSON, err := json.Marshal(req.GrantTypes)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+			return
+		}
+		updates["grant_types"] = string(grantTypesJSON)
+	}
+	if req.Enabled != nil {
+		updates["enabled"] = *req.Enabled
+	}
+
+	if len(updates) == 0 {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	if err := svc.UpdateClient(id, userID, updates); err != nil {
+		if err == sql.ErrNoRows {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"id": id})
+}
+
+// DeleteClient deletes an OAuth2 client by ID.
+// DELETE /api/v1/oauth/clients/:id
+func (a *OAuth2API) DeleteClient(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	id := c.Param("id")
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	if err := svc.DeleteClient(id, userID); err != nil {
+		if err == sql.ErrNoRows {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	respondSuccess(c, gin.H{"id": id})
+}
+
+// RegenerateSecret generates a new client_secret for an existing client.
+// POST /api/v1/oauth/clients/:id/secret
+func (a *OAuth2API) RegenerateSecret(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	id := c.Param("id")
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	newSecret, err := svc.RegenerateSecret(id, userID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			respondErrori18n(c, http.StatusNotFound, "error.common.not_found")
+			return
+		}
+		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":        "success",
+		"client_secret": newSecret,
+		"message":       "save the new client_secret now, it will not be shown again",
+	})
+}
+
+// Authorize starts an authorization code flow and returns the authorization URL with code.
+// POST /api/v1/oauth/authorize
+func (a *OAuth2API) Authorize(c *gin.Context) {
+	userID := c.GetString("user_id")
+	if userID == "" {
+		respondErrori18n(c, http.StatusUnauthorized, "error.auth.unauthorized")
+		return
+	}
+
+	var req authorizeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	authz, err := svc.CreateAuthorization(req.ClientID, userID, req.Scopes)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	respondSuccess(c, gin.H{
+		"code":       authz.Code,
+		"expires_at": authz.ExpiresAt,
+	})
+}
+
+// Token handles OAuth2 token requests (RFC 6749 compliant).
+// Supports grant_type: authorization_code, client_credentials, refresh_token.
+// POST /api/v1/oauth/token
+// This endpoint does NOT require auth middleware — it authenticates via client_id/client_secret.
+func (a *OAuth2API) Token(c *gin.Context) {
+	// Try Basic Auth first, then fall back to POST body
+	clientID, clientSecret := extractClientCredentials(c)
+
+	var req tokenRequest
+	if err := c.ShouldBind(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_request",
+			"error_description": "invalid or missing parameters",
+		})
+		return
+	}
+
+	// POST body overrides Basic Auth if present
+	if req.ClientID != "" {
+		clientID = req.ClientID
+	}
+	if req.ClientSecret != "" {
+		clientSecret = req.ClientSecret
+	}
+
+	if clientID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":             "invalid_client",
+			"error_description": "client_id is required",
+		})
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+
+	switch req.GrantType {
+	case "authorization_code":
+		if req.Code == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_request",
+				"error_description": "code is required for authorization_code grant",
+			})
+			return
+		}
+		token, err := svc.ExchangeCode(req.Code)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_grant",
+				"error_description": err.Error(),
+			})
+			return
+		}
+		respondOAuth2Token(c, token)
+
+	case "client_credentials":
+		if clientSecret == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_client",
+				"error_description": "client_secret is required for client_credentials grant",
+			})
+			return
+		}
+		var scopes []string
+		if req.Scope != "" {
+			scopes = splitScopes(req.Scope)
+		}
+		token, err := svc.ClientCredentials(clientID, clientSecret, scopes)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_client",
+				"error_description": err.Error(),
+			})
+			return
+		}
+		respondOAuth2Token(c, token)
+
+	case "refresh_token":
+		if req.RefreshToken == "" {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_request",
+				"error_description": "refresh_token is required for refresh_token grant",
+			})
+			return
+		}
+		token, err := svc.RefreshToken(req.RefreshToken)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":             "invalid_grant",
+				"error_description": err.Error(),
+			})
+			return
+		}
+		respondOAuth2Token(c, token)
+
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":             "unsupported_grant_type",
+			"error_description": "grant_type must be authorization_code, client_credentials, or refresh_token",
+		})
+	}
+}
+
+// RefreshToken refreshes an access token using a refresh token.
+// POST /api/v1/oauth/token/refresh
+func (a *OAuth2API) RefreshToken(c *gin.Context) {
+	var req struct {
+		RefreshToken string `json:"refresh_token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	token, err := svc.RefreshToken(req.RefreshToken)
+	if err != nil {
+		respondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	respondSuccess(c, token)
+}
+
+// RevokeToken revokes an OAuth2 access token.
+// POST /api/v1/oauth/token/revoke
+func (a *OAuth2API) RevokeToken(c *gin.Context) {
+	var req struct {
+		AccessToken string `json:"access_token" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	svc := service.NewOAuth2Service(a.db, a.cfg)
+	if err := svc.RevokeToken(req.AccessToken); err != nil {
+		respondError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	respondSuccess(c, gin.H{"revoked": true})
+}
+
+// respondOAuth2Token returns an OAuth2-compliant token response (RFC 6749).
+func respondOAuth2Token(c *gin.Context, token *model.OAuth2Token) {
+	expiresIn := int(time.Until(token.ExpiresAt).Seconds())
+	if expiresIn < 0 {
+		expiresIn = 0
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"access_token":  token.AccessToken,
+		"token_type":    token.TokenType,
+		"expires_in":    expiresIn,
+		"refresh_token": token.RefreshToken,
+		"scope":         token.Scopes,
+	})
+}
+
+// extractClientCredentials extracts client_id and client_secret from Basic Auth header.
+func extractClientCredentials(c *gin.Context) (clientID, clientSecret string) {
+	clientID, clientSecret, ok := c.Request.BasicAuth()
+	if !ok {
+		return "", ""
+	}
+	return clientID, clientSecret
+}
+
+// splitScopes splits a space-separated scope string into a slice.
+func splitScopes(scope string) []string {
+	if scope == "" {
+		return nil
+	}
+	var scopes []string
+	seen := make(map[string]bool)
+	for _, s := range splitBySpace(scope) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
+}
+
+// splitBySpace splits a string by spaces.
+func splitBySpace(s string) []string {
+	var result []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			if i > start {
+				result = append(result, s[start:i])
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		result = append(result, s[start:])
+	}
+	return result
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,7 +27,7 @@ var globalMonitorAPI *MonitorAPI
 func GetGlobalMonitorAPI() *MonitorAPI { return globalMonitorAPI }
 
 // RegisterRoutes registers all API routes on the given Gin engine.
-func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig) {
+func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig, apiPlatformCfg *config.APIPlatformConfig) {
 	// Swagger documentation — only accessible in development mode.
 	// In production, the endpoint is disabled to prevent information leakage.
 	if os.Getenv("DEPLOYPILOT_ENV") == "development" || os.Getenv("GIN_MODE") == "debug" {
@@ -58,6 +58,11 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 
 	// Grafana API
 	globalGrafanaAPI = NewGrafanaAPI(db, grafanaCfg)
+
+	// OAuth2 API (API Open Platform)
+	if apiPlatformCfg != nil {
+		globalOAuth2API = NewOAuth2API(db, apiPlatformCfg)
+	}
 
 	wsGroup := r.Group("/ws")
 	{
@@ -271,6 +276,20 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			grafanaGroup.PUT("/dashboards/:id", globalGrafanaAPI.UpdateDashboard)
 			grafanaGroup.DELETE("/dashboards/:id", globalGrafanaAPI.DeleteDashboard)
 			grafanaGroup.GET("/export", globalGrafanaAPI.ExportAll)
+		}
+
+		// OAuth2 client management (protected)
+		if globalOAuth2API != nil {
+			oauth2 := protected.Group("/oauth")
+			{
+				oauth2.GET("/clients", globalOAuth2API.ListClients)
+				oauth2.POST("/clients", globalOAuth2API.CreateClient)
+				oauth2.GET("/clients/:id", globalOAuth2API.GetClient)
+				oauth2.PUT("/clients/:id", globalOAuth2API.UpdateClient)
+				oauth2.DELETE("/clients/:id", globalOAuth2API.DeleteClient)
+				oauth2.POST("/clients/:id/secret", globalOAuth2API.RegenerateSecret)
+				oauth2.POST("/authorize", globalOAuth2API.Authorize)
+			}
 		}
 
 		// Credentials (5 endpoints)
@@ -508,5 +527,15 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 	// Public metrics endpoint (when enabled in config)
 	if metricsPublic {
 		r.GET("/metrics", gin.WrapH(metrics.Handler()))
+	}
+
+	// OAuth2 token endpoint (public — uses client credentials)
+	if globalOAuth2API != nil {
+		oauth2Public := api.Group("/oauth")
+		{
+			oauth2Public.POST("/token", globalOAuth2API.Token)
+			oauth2Public.POST("/token/refresh", globalOAuth2API.RefreshToken)
+			oauth2Public.POST("/token/revoke", globalOAuth2API.RevokeToken)
+		}
 	}
 }

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -1,0 +1,149 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/i18n"
+	"github.com/gin-gonic/gin"
+)
+
+// OAuth2ScopesKey is the context key for OAuth2 token scopes.
+const OAuth2ScopesKey contextKey = "oauth2_scopes"
+
+// Scope constants for the API Open Platform.
+const (
+	ScopeRead           = "read"
+	ScopeWrite          = "write"
+	ScopeDelete         = "delete"
+	ScopeDeploy         = "deploy"
+	ScopeAdmin          = "admin"
+	ScopeMonitorRead    = "monitor:read"
+	ScopeMonitorWrite   = "monitor:write"
+	ScopeServerRead     = "server:read"
+	ScopeServerExec     = "server:exec"
+	ScopeCredentialRead = "credential:read"
+	ScopeCredentialWrite = "credential:write"
+	ScopeDNSWrite       = "dns:write"
+	ScopeSSLWrite       = "ssl:write"
+	ScopeBackupRead     = "backup:read"
+	ScopeBackupWrite    = "backup:write"
+	ScopeWebhookManage  = "webhook:manage"
+	ScopeGrafanaManage  = "grafana:manage"
+)
+
+// AllScopes is the complete list of valid scope strings.
+var AllScopes = []string{
+	ScopeRead,
+	ScopeWrite,
+	ScopeDelete,
+	ScopeDeploy,
+	ScopeAdmin,
+	ScopeMonitorRead,
+	ScopeMonitorWrite,
+	ScopeServerRead,
+	ScopeServerExec,
+	ScopeCredentialRead,
+	ScopeCredentialWrite,
+	ScopeDNSWrite,
+	ScopeSSLWrite,
+	ScopeBackupRead,
+	ScopeBackupWrite,
+	ScopeWebhookManage,
+	ScopeGrafanaManage,
+}
+
+// allScopesSet is a lookup map for fast scope validation.
+var allScopesSet = func() map[string]bool {
+	m := make(map[string]bool, len(AllScopes))
+	for _, s := range AllScopes {
+		m[s] = true
+	}
+	return m
+}()
+
+// ScopeDescriptions provides human-readable descriptions for each scope.
+var ScopeDescriptions = map[string]string{
+	ScopeRead:           "Read-only access to resources",
+	ScopeWrite:          "Create and update resources",
+	ScopeDelete:         "Delete resources",
+	ScopeDeploy:         "Trigger deployments and rollbacks",
+	ScopeAdmin:          "Full administrative access (bypasses all scope checks)",
+	ScopeMonitorRead:    "View monitoring data, metrics, and alerts",
+	ScopeMonitorWrite:   "Create and manage monitors, alert rules, and silences",
+	ScopeServerRead:     "View server information and status",
+	ScopeServerExec:     "Execute commands on servers",
+	ScopeCredentialRead: "View credentials and SSH keys",
+	ScopeCredentialWrite: "Create, update, and rotate credentials",
+	ScopeDNSWrite:       "Manage DNS records",
+	ScopeSSLWrite:       "Manage SSL/TLS certificates",
+	ScopeBackupRead:     "View backup records",
+	ScopeBackupWrite:    "Create and manage backups",
+	ScopeWebhookManage:  "Create and manage outbound webhooks",
+	ScopeGrafanaManage:  "Manage Grafana dashboards and sync",
+}
+
+// IsValidScope checks if a single scope string is valid.
+func IsValidScope(scope string) bool {
+	return allScopesSet[scope]
+}
+
+// ValidateScopes filters a list of scopes to only include valid ones.
+func ValidateScopes(scopes []string) []string {
+	valid := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		if allScopesSet[s] {
+			valid = append(valid, s)
+		}
+	}
+	return valid
+}
+
+// RequireScope returns middleware that checks if the current request has
+// one of the required scopes. It checks both APIKeyScopesKey and
+// OAuth2ScopesKey from the Gin context. The "admin" scope bypasses all checks.
+func RequireScope(scopes ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Try API key scopes first
+		var tokenScopes []string
+		if v, exists := c.Get(string(APIKeyScopesKey)); exists {
+			if s, ok := v.([]string); ok {
+				tokenScopes = s
+			}
+		}
+
+		// Fall back to OAuth2 scopes
+		if len(tokenScopes) == 0 {
+			if v, exists := c.Get(string(OAuth2ScopesKey)); exists {
+				if s, ok := v.([]string); ok {
+					tokenScopes = s
+				}
+			}
+		}
+
+		// Check admin bypass
+		for _, s := range tokenScopes {
+			if s == ScopeAdmin {
+				c.Next()
+				return
+			}
+		}
+
+		// Check if any required scope is satisfied
+		for _, required := range scopes {
+			for _, s := range tokenScopes {
+				if s == required {
+					c.Next()
+					return
+				}
+			}
+		}
+
+		// Insufficient scope
+		locale := i18n.GetLocaleFromContext(c)
+		c.JSON(http.StatusForbidden, gin.H{
+			"status":  "error",
+			"message": i18n.T(locale, "error.auth.insufficient_permissions"),
+		})
+		c.Abort()
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Backup     BackupConfig     `mapstructure:"backup"`
 	BruteForce BruteForceConfig `mapstructure:"bruteforce"`
 	Grafana    GrafanaConfig    `mapstructure:"grafana"`
+	APIPlatform APIPlatformConfig `mapstructure:"api_platform"`
 }
 
 // BackupConfig holds database auto-backup settings.
@@ -56,6 +57,14 @@ type BruteForceConfig struct {
 	MaxDelay          string `mapstructure:"max_delay"`
 	IPMaxAttempts     int    `mapstructure:"ip_max_attempts"`
 	IPLockoutDuration string `mapstructure:"ip_lockout_duration"`
+}
+
+// APIPlatformConfig holds API Open Platform (OAuth2) settings.
+type APIPlatformConfig struct {
+	Enabled           bool `mapstructure:"enabled"`
+	MaxClientsPerUser int  `mapstructure:"max_clients_per_user"` // default: 10
+	TokenExpireHours  int  `mapstructure:"token_expire_hours"`   // default: 24
+	CodeExpireMinutes int  `mapstructure:"code_expire_minutes"`  // default: 10
 }
 
 // GrafanaConfig holds Grafana integration settings.
@@ -350,4 +359,10 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("grafana.url", "http://localhost:3000")
 	v.SetDefault("grafana.annotations_enabled", true)
 	v.SetDefault("grafana.sync_interval", 60)
+
+	// API Platform
+	v.SetDefault("api_platform.enabled", true)
+	v.SetDefault("api_platform.max_clients_per_user", 10)
+	v.SetDefault("api_platform.token_expire_hours", 24)
+	v.SetDefault("api_platform.code_expire_minutes", 10)
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -858,6 +858,16 @@ func Migrate(db *gorm.DB) error {
 				return tx.Migrator().DropTable("grafana_sync_logs", "grafana_custom_dashboards")
 			},
 		},
+		// 202605020200: Create OAuth2 tables for API Open Platform
+		{
+			ID: "202605020200",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&model.OAuth2Client{}, &model.OAuth2Authorization{}, &model.OAuth2Token{})
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("oauth2_tokens", "oauth2_authorizations", "oauth2_clients")
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/model/oauth2.go
+++ b/internal/model/oauth2.go
@@ -1,0 +1,53 @@
+package model
+
+import "time"
+
+// OAuth2Client represents a registered OAuth2 client application.
+type OAuth2Client struct {
+	ID           string    `gorm:"primaryKey" json:"id"`
+	TenantID     string    `gorm:"index" json:"tenant_id"`
+	UserID       string    `gorm:"index" json:"user_id"`
+	Name         string    `gorm:"not null;size:100" json:"name"`
+	ClientID     string    `gorm:"uniqueIndex;not null;size:40" json:"client_id"`
+	ClientSecret string    `gorm:"not null;size:100" json:"-"`
+	RedirectURIs string    `gorm:"type:text" json:"redirect_uris"` // JSON array of URIs
+	Scopes       string    `gorm:"type:text" json:"scopes"`        // JSON array of scopes
+	GrantTypes   string    `gorm:"type:text" json:"grant_types"`   // JSON array of grant types
+	Enabled      bool      `gorm:"default:true" json:"enabled"`
+	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt    time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+
+	Tenant Tenant `gorm:"foreignKey:TenantID" json:"tenant,omitempty"`
+	User   User   `gorm:"foreignKey:UserID" json:"user,omitempty"`
+}
+
+func (OAuth2Client) TableName() string { return "oauth2_clients" }
+
+// OAuth2Authorization represents an authorization code grant.
+type OAuth2Authorization struct {
+	ID        string     `gorm:"primaryKey" json:"id"`
+	ClientID  string     `gorm:"index;not null;size:40" json:"client_id"`
+	UserID    string     `gorm:"index;not null" json:"user_id"`
+	Scopes    string     `gorm:"type:text" json:"scopes"` // JSON array of scopes
+	Code      string     `gorm:"uniqueIndex;not null;size:100" json:"-"`
+	ExpiresAt time.Time  `gorm:"index" json:"expires_at"`
+	Used      bool       `gorm:"default:false" json:"used"`
+	CreatedAt time.Time  `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (OAuth2Authorization) TableName() string { return "oauth2_authorizations" }
+
+// OAuth2Token represents an issued OAuth2 access/refresh token pair.
+type OAuth2Token struct {
+	ID           string     `gorm:"primaryKey" json:"id"`
+	ClientID     string     `gorm:"index;not null;size:40" json:"client_id"`
+	UserID       string     `gorm:"index;not null" json:"user_id"`
+	AccessToken  string     `gorm:"uniqueIndex;not null;size:100" json:"access_token"`
+	RefreshToken string     `gorm:"uniqueIndex;not null;size:100" json:"refresh_token"`
+	Scopes       string     `gorm:"type:text" json:"scopes"` // JSON array of scopes
+	TokenType    string     `gorm:"size:20;default:bearer" json:"token_type"`
+	ExpiresAt    time.Time  `gorm:"index" json:"expires_at"`
+	CreatedAt    time.Time  `gorm:"autoCreateTime" json:"created_at"`
+}
+
+func (OAuth2Token) TableName() string { return "oauth2_tokens" }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,7 +129,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 		api.SetRefreshTokenStore(memRefreshStore)
 	}
 
-	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic, &cfg.Grafana)
+	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic, &cfg.Grafana, &cfg.APIPlatform)
 
 	// Serve embedded frontend static files
 	serveStaticFiles(r)

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -1,0 +1,447 @@
+package service
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/config"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"gorm.io/gorm"
+)
+
+// OAuth2Service handles OAuth2 client management and token operations.
+type OAuth2Service struct {
+	db  *gorm.DB
+	cfg *config.APIPlatformConfig
+}
+
+// NewOAuth2Service creates a new OAuth2Service.
+func NewOAuth2Service(db *gorm.DB, cfg *config.APIPlatformConfig) *OAuth2Service {
+	return &OAuth2Service{db: db, cfg: cfg}
+}
+
+// CreateClient creates a new OAuth2 client application.
+// Returns the client model and the raw client_secret (shown only once).
+func (s *OAuth2Service) CreateClient(userID, name string, redirectURIs, scopes, grantTypes []string) (*model.OAuth2Client, string, error) {
+	// Enforce max clients per user
+	if s.cfg.MaxClientsPerUser > 0 {
+		var count int64
+		if err := s.db.Model(&model.OAuth2Client{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+			return nil, "", fmt.Errorf("failed to count client applications: %w", err)
+		}
+		if int(count) >= s.cfg.MaxClientsPerUser {
+			return nil, "", fmt.Errorf("maximum number of client applications (%d) reached", s.cfg.MaxClientsPerUser)
+		}
+	}
+
+	// Validate scopes
+	validScopes := auth.ValidateScopes(scopes)
+
+	// Validate grant types
+	validGrantTypes := validateGrantTypes(grantTypes)
+
+	clientID := generateClientID()
+	clientSecret := generateClientSecret()
+
+	redirectURIsJSON, err := json.Marshal(redirectURIs)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal redirect URIs: %w", err)
+	}
+
+	scopesJSON, err := json.Marshal(validScopes)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal scopes: %w", err)
+	}
+
+	grantTypesJSON, err := json.Marshal(validGrantTypes)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal grant types: %w", err)
+	}
+
+	client := &model.OAuth2Client{
+		ID:           generateOAuth2ID(),
+		UserID:       userID,
+		Name:         name,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURIs: string(redirectURIsJSON),
+		Scopes:       string(scopesJSON),
+		GrantTypes:   string(grantTypesJSON),
+		Enabled:      true,
+	}
+
+	if err := s.db.Create(client).Error; err != nil {
+		return nil, "", fmt.Errorf("failed to create OAuth2 client: %w", err)
+	}
+
+	slog.Info("OAuth2 client created", "id", client.ID, "client_id", clientID, "name", name, "user_id", userID)
+	return client, clientSecret, nil
+}
+
+// ListClients returns all OAuth2 clients for a given user.
+func (s *OAuth2Service) ListClients(userID string) ([]model.OAuth2Client, error) {
+	var clients []model.OAuth2Client
+	if err := s.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&clients).Error; err != nil {
+		return nil, fmt.Errorf("failed to list OAuth2 clients: %w", err)
+	}
+	return clients, nil
+}
+
+// GetClient returns a single OAuth2 client by ID. Only the owner can access.
+func (s *OAuth2Service) GetClient(id, userID string) (*model.OAuth2Client, error) {
+	var client model.OAuth2Client
+	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&client).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, sql.ErrNoRows
+		}
+		return nil, fmt.Errorf("failed to get OAuth2 client: %w", err)
+	}
+	return &client, nil
+}
+
+// UpdateClient modifies an OAuth2 client's metadata.
+func (s *OAuth2Service) UpdateClient(id, userID string, updates map[string]interface{}) error {
+	result := s.db.Model(&model.OAuth2Client{}).
+		Where("id = ? AND user_id = ?", id, userID).
+		Updates(updates)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update OAuth2 client: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+	slog.Info("OAuth2 client updated", "id", id, "user_id", userID)
+	return nil
+}
+
+// DeleteClient removes an OAuth2 client by ID. Only the owner can delete.
+func (s *OAuth2Service) DeleteClient(id, userID string) error {
+	result := s.db.Where("id = ? AND user_id = ?", id, userID).Delete(&model.OAuth2Client{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete OAuth2 client: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+	slog.Info("OAuth2 client deleted", "id", id, "user_id", userID)
+	return nil
+}
+
+// RegenerateSecret generates a new client_secret for an existing client.
+// Returns the new secret (shown only once).
+func (s *OAuth2Service) RegenerateSecret(id, userID string) (string, error) {
+	var client model.OAuth2Client
+	if err := s.db.Where("id = ? AND user_id = ?", id, userID).First(&client).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return "", sql.ErrNoRows
+		}
+		return "", fmt.Errorf("failed to get OAuth2 client: %w", err)
+	}
+
+	newSecret := generateClientSecret()
+	if err := s.db.Model(&client).Update("client_secret", newSecret).Error; err != nil {
+		return "", fmt.Errorf("failed to regenerate client secret: %w", err)
+	}
+
+	slog.Info("OAuth2 client secret regenerated", "id", id, "user_id", userID)
+	return newSecret, nil
+}
+
+// CreateAuthorization creates an authorization code for the authorization code grant flow.
+func (s *OAuth2Service) CreateAuthorization(clientID, userID string, scopes []string) (*model.OAuth2Authorization, error) {
+	// Validate client exists and is enabled
+	var client model.OAuth2Client
+	if err := s.db.Where("client_id = ? AND enabled = ?", clientID, true).First(&client).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid or disabled client")
+		}
+		return nil, fmt.Errorf("failed to validate client: %w", err)
+	}
+
+	// Validate scopes against client's registered scopes
+	clientScopes := ParseScopes(client.Scopes)
+	validScopes := auth.ValidateScopes(scopes)
+	requestedScopes := intersectScopes(validScopes, clientScopes)
+	if len(requestedScopes) == 0 {
+		return nil, fmt.Errorf("no valid scopes requested")
+	}
+
+	scopesJSON, err := json.Marshal(requestedScopes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal scopes: %w", err)
+	}
+
+	code := generateToken()
+	expiresAt := time.Now().Add(time.Duration(s.cfg.CodeExpireMinutes) * time.Minute)
+
+	authz := &model.OAuth2Authorization{
+		ID:        generateOAuth2ID(),
+		ClientID:  clientID,
+		UserID:    userID,
+		Scopes:    string(scopesJSON),
+		Code:      code,
+		ExpiresAt: expiresAt,
+		Used:      false,
+	}
+
+	if err := s.db.Create(authz).Error; err != nil {
+		return nil, fmt.Errorf("failed to create authorization: %w", err)
+	}
+
+	return authz, nil
+}
+
+// ExchangeCode exchanges an authorization code for an access/refresh token pair.
+func (s *OAuth2Service) ExchangeCode(code string) (*model.OAuth2Token, error) {
+	var authz model.OAuth2Authorization
+	if err := s.db.Where("code = ? AND used = ?", code, false).First(&authz).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid or expired authorization code")
+		}
+		return nil, fmt.Errorf("failed to lookup authorization code: %w", err)
+	}
+
+	// Check expiration
+	if authz.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("authorization code expired")
+	}
+
+	// Mark code as used
+	if err := s.db.Model(&authz).Update("used", true).Error; err != nil {
+		return nil, fmt.Errorf("failed to invalidate authorization code: %w", err)
+	}
+
+	// Create token
+	scopes := ParseScopes(authz.Scopes)
+	token, err := s.createToken(authz.ClientID, authz.UserID, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// ClientCredentials handles the client_credentials grant type.
+func (s *OAuth2Service) ClientCredentials(clientID, clientSecret string, scopes []string) (*model.OAuth2Token, error) {
+	// Validate client
+	var client model.OAuth2Client
+	if err := s.db.Where("client_id = ? AND enabled = ?", clientID, true).First(&client).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid or disabled client")
+		}
+		return nil, fmt.Errorf("failed to validate client: %w", err)
+	}
+
+	// Validate client secret
+	if client.ClientSecret != clientSecret {
+		return nil, fmt.Errorf("invalid client credentials")
+	}
+
+	// Validate grant type includes client_credentials
+	grantTypes := parseGrantTypes(client.GrantTypes)
+	if !containsString(grantTypes, "client_credentials") {
+		return nil, fmt.Errorf("client does not support client_credentials grant type")
+	}
+
+	// Validate scopes against client's registered scopes
+	clientScopes := ParseScopes(client.Scopes)
+	validScopes := auth.ValidateScopes(scopes)
+	requestedScopes := intersectScopes(validScopes, clientScopes)
+	if len(requestedScopes) == 0 {
+		requestedScopes = clientScopes // use client defaults if none requested
+	}
+
+	token, err := s.createToken(clientID, client.UserID, requestedScopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// RefreshToken exchanges a refresh token for a new access/refresh token pair.
+func (s *OAuth2Service) RefreshToken(refreshToken string) (*model.OAuth2Token, error) {
+	var existing model.OAuth2Token
+	if err := s.db.Where("refresh_token = ?", refreshToken).First(&existing).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid refresh token")
+		}
+		return nil, fmt.Errorf("failed to lookup refresh token: %w", err)
+	}
+
+	// Delete old token
+	if err := s.db.Delete(&existing).Error; err != nil {
+		return nil, fmt.Errorf("failed to revoke old token: %w", err)
+	}
+
+	// Create new token with same scopes
+	scopes := ParseScopes(existing.Scopes)
+	token, err := s.createToken(existing.ClientID, existing.UserID, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
+}
+
+// RevokeToken deletes an access token, effectively revoking it.
+func (s *OAuth2Service) RevokeToken(accessToken string) error {
+	result := s.db.Where("access_token = ?", accessToken).Delete(&model.OAuth2Token{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to revoke token: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("token not found")
+	}
+	slog.Info("OAuth2 token revoked", "access_token_prefix", accessToken[:min(8, len(accessToken))])
+	return nil
+}
+
+// ValidateAccessToken looks up an access token in the database and returns the token record.
+func (s *OAuth2Service) ValidateAccessToken(token string) (*model.OAuth2Token, error) {
+	var oauthToken model.OAuth2Token
+	if err := s.db.Where("access_token = ?", token).First(&oauthToken).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("invalid access token")
+		}
+		return nil, fmt.Errorf("failed to validate access token: %w", err)
+	}
+
+	// Check expiration
+	if oauthToken.ExpiresAt.Before(time.Now()) {
+		return nil, fmt.Errorf("access token expired")
+	}
+
+	return &oauthToken, nil
+}
+
+// createToken creates a new access/refresh token pair.
+func (s *OAuth2Service) createToken(clientID, userID string, scopes []string) (*model.OAuth2Token, error) {
+	accessToken := generateToken()
+	refreshToken := generateToken()
+
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal scopes: %w", err)
+	}
+
+	expiresAt := time.Now().Add(time.Duration(s.cfg.TokenExpireHours) * time.Hour)
+
+	token := &model.OAuth2Token{
+		ID:           generateOAuth2ID(),
+		ClientID:     clientID,
+		UserID:       userID,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Scopes:       string(scopesJSON),
+		TokenType:    "bearer",
+		ExpiresAt:    expiresAt,
+	}
+
+	if err := s.db.Create(token).Error; err != nil {
+		return nil, fmt.Errorf("failed to create token: %w", err)
+	}
+
+	slog.Info("OAuth2 token created", "id", token.ID, "client_id", clientID, "user_id", userID)
+	return token, nil
+}
+
+// generateToken generates a random 32-byte hex string.
+func generateToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic("failed to generate token: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+// generateClientID generates a random 16-byte hex string prefixed with "dp_".
+func generateClientID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("failed to generate client ID: " + err.Error())
+	}
+	return "dp_" + hex.EncodeToString(b)
+}
+
+// generateClientSecret generates a random 32-byte hex string.
+func generateClientSecret() string {
+	return generateToken()
+}
+
+// generateOAuth2ID generates a random hex ID for OAuth2 records.
+func generateOAuth2ID() string {
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		panic("failed to generate OAuth2 ID: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+// validateGrantTypes filters grant types to only allowed values.
+func validateGrantTypes(grantTypes []string) []string {
+	allowed := map[string]bool{
+		"authorization_code": true,
+		"client_credentials": true,
+		"refresh_token":      true,
+	}
+	valid := make([]string, 0, len(grantTypes))
+	for _, gt := range grantTypes {
+		if allowed[gt] {
+			valid = append(valid, gt)
+		}
+	}
+	if len(valid) == 0 {
+		return []string{"authorization_code"}
+	}
+	return valid
+}
+
+// parseGrantTypes parses the JSON grant types string into a slice.
+func parseGrantTypes(grantTypesJSON string) []string {
+	var grantTypes []string
+	if err := json.Unmarshal([]byte(grantTypesJSON), &grantTypes); err != nil {
+		return nil
+	}
+	return grantTypes
+}
+
+// intersectScopes returns the intersection of two scope slices.
+func intersectScopes(a, b []string) []string {
+	set := make(map[string]bool, len(b))
+	for _, s := range b {
+		set[s] = true
+	}
+	result := make([]string, 0, len(a))
+	for _, s := range a {
+		if set[s] {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// containsString checks if a string slice contains a given string.
+func containsString(slice []string, target string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// min returns the smaller of two integers (Go 1.18 compat).
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -10,11 +10,33 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Yogdunana/deploypilot/internal/auth"
 	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"gorm.io/gorm"
 )
+
+// validOAuth2Scopes is the set of valid scopes for OAuth2 clients.
+// Duplicated from auth package to avoid import cycle (auth → service → auth).
+var validOAuth2Scopes = map[string]bool{
+	"read": true, "write": true, "delete": true, "deploy": true, "admin": true,
+	"monitor:read": true, "monitor:write": true,
+	"server:read": true, "server:exec": true,
+	"credential:read": true, "credential:write": true,
+	"dns:write": true, "ssl:write": true,
+	"backup:read": true, "backup:write": true,
+	"webhook:manage": true, "grafana:manage": true,
+}
+
+// validateScopes filters a list of scopes to only include valid ones.
+func validateScopes(scopes []string) []string {
+	valid := make([]string, 0, len(scopes))
+	for _, s := range scopes {
+		if validOAuth2Scopes[s] {
+			valid = append(valid, s)
+		}
+	}
+	return valid
+}
 
 // OAuth2Service handles OAuth2 client management and token operations.
 type OAuth2Service struct {
@@ -42,7 +64,7 @@ func (s *OAuth2Service) CreateClient(userID, name string, redirectURIs, scopes, 
 	}
 
 	// Validate scopes
-	validScopes := auth.ValidateScopes(scopes)
+	validScopes := validateScopes(scopes)
 
 	// Validate grant types
 	validGrantTypes := validateGrantTypes(grantTypes)
@@ -167,7 +189,7 @@ func (s *OAuth2Service) CreateAuthorization(clientID, userID string, scopes []st
 
 	// Validate scopes against client's registered scopes
 	clientScopes := ParseScopes(client.Scopes)
-	validScopes := auth.ValidateScopes(scopes)
+	validScopes := validateScopes(scopes)
 	requestedScopes := intersectScopes(validScopes, clientScopes)
 	if len(requestedScopes) == 0 {
 		return nil, fmt.Errorf("no valid scopes requested")
@@ -252,7 +274,7 @@ func (s *OAuth2Service) ClientCredentials(clientID, clientSecret string, scopes 
 
 	// Validate scopes against client's registered scopes
 	clientScopes := ParseScopes(client.Scopes)
-	validScopes := auth.ValidateScopes(scopes)
+	validScopes := validateScopes(scopes)
 	requestedScopes := intersectScopes(validScopes, clientScopes)
 	if len(requestedScopes) == 0 {
 		requestedScopes = clientScopes // use client defaults if none requested

--- a/web/src/api/modules/oauth2.ts
+++ b/web/src/api/modules/oauth2.ts
@@ -1,0 +1,46 @@
+import api from '@/api'
+import type { ApiResponse } from '@/types/api'
+
+export interface OAuth2Client {
+  id: string
+  name: string
+  client_id: string
+  redirect_uris: string[]
+  scopes: string[]
+  grant_types: string[]
+  enabled: boolean
+  created_at: string
+  updated_at: string
+}
+
+export interface OAuth2TokenResponse {
+  access_token: string
+  token_type: string
+  expires_in: number
+  scope: string
+  refresh_token?: string
+}
+
+export function listOAuth2Clients() {
+  return api.get<ApiResponse<OAuth2Client[]>>('/api/v1/oauth/clients')
+}
+
+export function createOAuth2Client(data: { name: string; redirect_uris?: string[]; scopes?: string[]; grant_types?: string[] }) {
+  return api.post<ApiResponse<OAuth2Client & { client_secret: string }>>('/api/v1/oauth/clients', data)
+}
+
+export function getOAuth2Client(id: string) {
+  return api.get<ApiResponse<OAuth2Client>>(`/api/v1/oauth/clients/${id}`)
+}
+
+export function updateOAuth2Client(id: string, data: Partial<OAuth2Client>) {
+  return api.put<ApiResponse<OAuth2Client>>(`/api/v1/oauth/clients/${id}`, data)
+}
+
+export function deleteOAuth2Client(id: string) {
+  return api.delete<ApiResponse<void>>(`/api/v1/oauth/clients/${id}`)
+}
+
+export function regenerateOAuth2Secret(id: string) {
+  return api.post<ApiResponse<{ client_secret: string }>>(`/api/v1/oauth/clients/${id}/secret`)
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -1040,6 +1040,9 @@ export default {
     uptimeMonitors: 'Uptime Monitors',
     heartbeats: 'Heartbeats',
     dashboardTV: 'Dashboard TV',
+    oauth2_apps: 'OAuth2 Apps',
+    grafana_settings: 'Grafana Settings',
+    grafana_dashboards: 'Grafana Dashboards',
   },
 
   clusters: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -1036,6 +1036,9 @@ export default {
     uptimeMonitors: '可用性监控',
     heartbeats: '心跳检测',
     dashboardTV: '监控大屏',
+    oauth2_apps: 'OAuth2 应用',
+    grafana_settings: 'Grafana 设置',
+    grafana_dashboards: 'Grafana 仪表盘',
   },
 
   clusters: {

--- a/web/src/layout/MainLayout.vue
+++ b/web/src/layout/MainLayout.vue
@@ -119,6 +119,7 @@ const navGroups = computed(() => [
       { path: '/webhooks', label: t('layout.webhooks'), icon: Webhook },
       { path: '/settings/grafana', label: t('layout.grafana_settings'), icon: BarChart3 },
       { path: '/grafana/dashboards', label: t('layout.grafana_dashboards'), icon: LayoutDashboard },
+      { path: '/settings/oauth2', label: t('layout.oauth2_apps'), icon: KeyRound },
       { path: '/dashboard-tv', label: t('layout.dashboardTV'), icon: Tv },
       { path: '/notifications', label: t('layout.notifications'), icon: Bell },
       { path: '/templates', label: t('layout.templates'), icon: FileCode },

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -266,6 +266,12 @@ const router = createRouter({
           meta: { titleKey: 'layout.grafana_dashboards' },
         },
         {
+          path: 'settings/oauth2',
+          name: 'OAuth2Apps',
+          component: () => import('@/views/OAuth2Apps.vue'),
+          meta: { titleKey: 'layout.oauth2_apps' },
+        },
+        {
           path: 'monitors',
           name: 'UptimeMonitors',
           component: () => import('@/views/UptimeMonitors.vue'),

--- a/web/src/views/OAuth2Apps.vue
+++ b/web/src/views/OAuth2Apps.vue
@@ -1,0 +1,665 @@
+<script setup lang="ts">
+import { ref, onMounted, inject } from 'vue'
+import {
+  KeyRound,
+  Plus,
+  Pencil,
+  Trash2,
+  Copy,
+  RefreshCw,
+  Check,
+  Loader2,
+} from 'lucide-vue-next'
+import PageHeader from '@/components/common/PageHeader.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
+import RelativeTime from '@/components/common/RelativeTime.vue'
+import Button from '@/components/ui/Button.vue'
+import Card from '@/components/ui/Card.vue'
+import Badge from '@/components/ui/Badge.vue'
+import Skeleton from '@/components/ui/Skeleton.vue'
+import * as oauth2Api from '@/api/modules/oauth2'
+import type { OAuth2Client } from '@/api/modules/oauth2'
+
+const { toast } = inject<any>('toast')!
+
+const clients = ref<OAuth2Client[]>([])
+const loading = ref(false)
+const error = ref('')
+
+// Create dialog state
+const createDialogOpen = ref(false)
+const creating = ref(false)
+const createForm = ref({
+  name: '',
+  redirect_uris: [''],
+  scopes: [] as string[],
+  grant_types: [] as string[],
+})
+
+// Edit dialog state
+const editDialogOpen = ref(false)
+const editing = ref(false)
+const editClient = ref<OAuth2Client | null>(null)
+const editForm = ref({
+  name: '',
+  redirect_uris: [''],
+  scopes: [] as string[],
+  grant_types: [] as string[],
+  enabled: true,
+})
+
+// Delete dialog state
+const deleteDialogOpen = ref(false)
+const deletingClient = ref<OAuth2Client | null>(null)
+const deleting = ref(false)
+
+// Regenerate secret dialog state
+const regenerateDialogOpen = ref(false)
+const regeneratingClient = ref<OAuth2Client | null>(null)
+const regenerating = ref(false)
+
+// Secret reveal dialog state
+const secretDialogOpen = ref(false)
+const revealedSecret = ref('')
+const clientSecretCopied = ref(false)
+
+const availableScopes = ['read', 'write', 'admin', 'apps', 'servers', 'deployments', 'monitor']
+const availableGrantTypes = ['client_credentials', 'authorization_code']
+
+function truncateClientId(id: string, maxLen = 24): string {
+  if (id.length <= maxLen) return id
+  return id.substring(0, maxLen) + '...'
+}
+
+async function fetchClients() {
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await oauth2Api.listOAuth2Clients()
+    if (res.data.status === 'success') {
+      clients.value = res.data.data
+    }
+  } catch (e: any) {
+    error.value = e?.message || 'Failed to load OAuth2 clients'
+  } finally {
+    loading.value = false
+  }
+}
+
+function openCreateDialog() {
+  createForm.value = {
+    name: '',
+    redirect_uris: [''],
+    scopes: [],
+    grant_types: [],
+  }
+  createDialogOpen.value = true
+}
+
+async function handleCreate() {
+  if (!createForm.value.name.trim()) return
+  creating.value = true
+  try {
+    const data: any = { name: createForm.value.name }
+    const uris = createForm.value.redirect_uris.filter(u => u.trim())
+    if (uris.length > 0) data.redirect_uris = uris
+    if (createForm.value.scopes.length > 0) data.scopes = createForm.value.scopes
+    if (createForm.value.grant_types.length > 0) data.grant_types = createForm.value.grant_types
+
+    const res = await oauth2Api.createOAuth2Client(data)
+    if (res.data.status === 'success') {
+      createDialogOpen.value = false
+      revealedSecret.value = res.data.data.client_secret
+      secretDialogOpen.value = true
+      fetchClients()
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Failed to create OAuth2 client', 'destructive')
+  } finally {
+    creating.value = false
+  }
+}
+
+function addRedirectUri() {
+  createForm.value.redirect_uris.push('')
+}
+
+function removeRedirectUri(index: number) {
+  createForm.value.redirect_uris.splice(index, 1)
+}
+
+function addEditRedirectUri() {
+  editForm.value.redirect_uris.push('')
+}
+
+function removeEditRedirectUri(index: number) {
+  editForm.value.redirect_uris.splice(index, 1)
+}
+
+function openEditDialog(client: OAuth2Client) {
+  editClient.value = client
+  editForm.value = {
+    name: client.name,
+    redirect_uris: client.redirect_uris.length > 0 ? [...client.redirect_uris] : [''],
+    scopes: [...client.scopes],
+    grant_types: [...client.grant_types],
+    enabled: client.enabled,
+  }
+  editDialogOpen.value = true
+}
+
+async function handleEdit() {
+  if (!editClient.value || !editForm.value.name.trim()) return
+  editing.value = true
+  try {
+    const data: any = { name: editForm.value.name }
+    const uris = editForm.value.redirect_uris.filter(u => u.trim())
+    data.redirect_uris = uris
+    data.scopes = editForm.value.scopes
+    data.grant_types = editForm.value.grant_types
+    data.enabled = editForm.value.enabled
+
+    await oauth2Api.updateOAuth2Client(editClient.value.id, data)
+    toast('OAuth2 client updated', 'success')
+    editDialogOpen.value = false
+    editClient.value = null
+    fetchClients()
+  } catch (e: any) {
+    toast(e?.message || 'Failed to update OAuth2 client', 'destructive')
+  } finally {
+    editing.value = false
+  }
+}
+
+function openDeleteDialog(client: OAuth2Client) {
+  deletingClient.value = client
+  deleteDialogOpen.value = true
+}
+
+async function confirmDelete() {
+  if (!deletingClient.value) return
+  deleting.value = true
+  try {
+    await oauth2Api.deleteOAuth2Client(deletingClient.value.id)
+    toast('OAuth2 client deleted', 'success')
+    deleteDialogOpen.value = false
+    deletingClient.value = null
+    fetchClients()
+  } catch (e: any) {
+    toast(e?.message || 'Failed to delete OAuth2 client', 'destructive')
+  } finally {
+    deleting.value = false
+  }
+}
+
+function openRegenerateDialog(client: OAuth2Client) {
+  regeneratingClient.value = client
+  regenerateDialogOpen.value = true
+}
+
+async function confirmRegenerate() {
+  if (!regeneratingClient.value) return
+  regenerating.value = true
+  try {
+    const res = await oauth2Api.regenerateOAuth2Secret(regeneratingClient.value.id)
+    if (res.data.status === 'success') {
+      regenerateDialogOpen.value = false
+      revealedSecret.value = res.data.data.client_secret
+      secretDialogOpen.value = true
+      regeneratingClient.value = null
+    }
+  } catch (e: any) {
+    toast(e?.message || 'Failed to regenerate secret', 'destructive')
+  } finally {
+    regenerating.value = false
+  }
+}
+
+async function copySecret() {
+  try {
+    await navigator.clipboard.writeText(revealedSecret.value)
+    clientSecretCopied.value = true
+    toast('Client secret copied to clipboard', 'success')
+    setTimeout(() => {
+      clientSecretCopied.value = false
+    }, 2000)
+  } catch {
+    toast('Failed to copy to clipboard', 'destructive')
+  }
+}
+
+async function copyClientId(clientId: string) {
+  try {
+    await navigator.clipboard.writeText(clientId)
+    toast('Client ID copied to clipboard', 'success')
+  } catch {
+    toast('Failed to copy to clipboard', 'destructive')
+  }
+}
+
+function closeSecretDialog() {
+  secretDialogOpen.value = false
+  revealedSecret.value = ''
+  clientSecretCopied.value = false
+}
+
+onMounted(fetchClients)
+</script>
+
+<template>
+  <div class="space-y-4">
+    <PageHeader title="OAuth2 Applications" description="Manage OAuth2 applications for API access">
+      <template #actions>
+        <Button @click="openCreateDialog">
+          <template #icon>
+            <Plus class="w-4 h-4" />
+          </template>
+          Create App
+        </Button>
+      </template>
+    </PageHeader>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div v-for="i in 6" :key="i" class="rounded-lg border border-border bg-card p-6 space-y-3">
+        <Skeleton class="h-5 w-3/4" />
+        <Skeleton class="h-4 w-full" />
+        <div class="flex gap-2">
+          <Skeleton variant="circular" class="h-6 w-16 !rounded-full" />
+          <Skeleton variant="circular" class="h-6 w-16 !rounded-full" />
+        </div>
+        <Skeleton class="h-4 w-1/2" />
+      </div>
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="error" class="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+      {{ error }}
+    </div>
+
+    <!-- Empty State -->
+    <EmptyState
+      v-else-if="clients.length === 0"
+      :icon="KeyRound"
+      title="No OAuth2 applications"
+      description="Create your first OAuth2 application to enable third-party API access."
+      action-text="Create App"
+      @action="openCreateDialog"
+    />
+
+    <!-- Client Cards -->
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <Card v-for="client in clients" :key="client.id" class="p-0">
+        <div class="p-6 space-y-3">
+          <!-- Header: Name + Enabled indicator -->
+          <div class="flex items-start justify-between">
+            <h3 class="text-sm font-semibold text-foreground truncate">{{ client.name }}</h3>
+            <span
+              class="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full shrink-0 ml-2"
+              :class="client.enabled ? 'bg-success/15 text-success' : 'bg-accent text-muted-foreground'"
+            >
+              <span class="w-1.5 h-1.5 rounded-full" :class="client.enabled ? 'bg-success' : 'bg-muted-foreground'" />
+              {{ client.enabled ? 'Enabled' : 'Disabled' }}
+            </span>
+          </div>
+
+          <!-- Client ID -->
+          <div class="flex items-center gap-1.5">
+            <p class="text-xs font-mono text-muted-foreground truncate" :title="client.client_id">
+              {{ truncateClientId(client.client_id) }}
+            </p>
+            <button
+              class="inline-flex items-center justify-center w-5 h-5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors cursor-pointer shrink-0"
+              title="Copy Client ID"
+              @click="copyClientId(client.client_id)"
+            >
+              <Copy class="w-3 h-3" />
+            </button>
+          </div>
+
+          <!-- Grant Type Badges -->
+          <div class="flex items-center gap-2 flex-wrap">
+            <span
+              v-for="gt in client.grant_types"
+              :key="gt"
+              class="inline-flex items-center px-2 py-0.5 text-xs rounded-full font-medium bg-blue-100 text-blue-700"
+            >
+              {{ gt === 'client_credentials' ? 'Client Credentials' : 'Authorization Code' }}
+            </span>
+          </div>
+
+          <!-- Scope Tags -->
+          <div v-if="client.scopes.length > 0" class="flex items-center gap-1.5 flex-wrap">
+            <Badge v-for="scope in client.scopes" :key="scope" variant="secondary" class="text-[11px]">
+              {{ scope }}
+            </Badge>
+          </div>
+
+          <!-- Created date -->
+          <div class="text-xs text-muted-foreground">
+            Created: <RelativeTime :date="client.created_at" />
+          </div>
+        </div>
+
+        <!-- Card Actions -->
+        <div class="flex items-center border-t border-border px-4 py-2 gap-1">
+          <Button variant="ghost" size="sm" class="h-7 text-xs" @click="openEditDialog(client)">
+            <template #icon>
+              <Pencil class="w-3.5 h-3.5" />
+            </template>
+            Edit
+          </Button>
+          <Button variant="ghost" size="sm" class="h-7 text-xs" @click="openRegenerateDialog(client)">
+            <template #icon>
+              <RefreshCw class="w-3.5 h-3.5" />
+            </template>
+            Regenerate
+          </Button>
+          <div class="flex-1" />
+          <Button variant="ghost" size="icon" class="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10" @click="openDeleteDialog(client)">
+            <Trash2 class="w-3.5 h-3.5" />
+          </Button>
+        </div>
+      </Card>
+    </div>
+
+    <!-- Create Dialog -->
+    <Teleport to="body">
+      <div v-if="createDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-md p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-4">Create OAuth2 Application</h2>
+          <div class="space-y-4">
+            <!-- Name -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-1">Name</label>
+              <input
+                v-model="createForm.name"
+                type="text"
+                placeholder="Enter application name"
+                class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            <!-- Redirect URIs -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-1">Redirect URIs</label>
+              <div class="space-y-2">
+                <div v-for="(uri, index) in createForm.redirect_uris" :key="index" class="flex items-center gap-2">
+                  <input
+                    v-model="createForm.redirect_uris[index]"
+                    type="text"
+                    placeholder="https://example.com/callback"
+                    class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                  <button
+                    v-if="createForm.redirect_uris.length > 1"
+                    class="inline-flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                    @click="removeRedirectUri(index)"
+                  >
+                    <Trash2 class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                <Button variant="outline" size="sm" @click="addRedirectUri">
+                  <template #icon>
+                    <Plus class="w-3.5 h-3.5" />
+                  </template>
+                  Add URI
+                </Button>
+              </div>
+            </div>
+
+            <!-- Scopes -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-2">Scopes</label>
+              <div class="flex flex-wrap gap-2">
+                <label
+                  v-for="scope in availableScopes"
+                  :key="scope"
+                  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-border text-xs cursor-pointer transition-colors"
+                  :class="createForm.scopes.includes(scope) ? 'bg-primary/10 border-primary text-primary' : 'bg-background text-muted-foreground hover:bg-accent'"
+                >
+                  <input
+                    type="checkbox"
+                    :value="scope"
+                    class="sr-only"
+                    @change="(e: any) => {
+                      if (e.target.checked) createForm.scopes.push(scope)
+                      else createForm.scopes = createForm.scopes.filter(s => s !== scope)
+                    }"
+                  />
+                  {{ scope }}
+                </label>
+              </div>
+            </div>
+
+            <!-- Grant Types -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-2">Grant Types</label>
+              <div class="space-y-2">
+                <label
+                  v-for="gt in availableGrantTypes"
+                  :key="gt"
+                  class="flex items-center gap-2 px-3 py-2 rounded-md border border-border text-sm cursor-pointer transition-colors"
+                  :class="createForm.grant_types.includes(gt) ? 'bg-primary/10 border-primary text-primary' : 'bg-background text-muted-foreground hover:bg-accent'"
+                >
+                  <input
+                    type="checkbox"
+                    :value="gt"
+                    class="sr-only"
+                    @change="(e: any) => {
+                      if (e.target.checked) createForm.grant_types.push(gt)
+                      else createForm.grant_types = createForm.grant_types.filter(g => g !== gt)
+                    }"
+                  />
+                  <span class="w-4 h-4 rounded border flex items-center justify-center shrink-0" :class="createForm.grant_types.includes(gt) ? 'bg-primary border-primary' : 'border-border'">
+                    <Check v-if="createForm.grant_types.includes(gt)" class="w-3 h-3 text-primary-foreground" />
+                  </span>
+                  {{ gt === 'client_credentials' ? 'Client Credentials' : 'Authorization Code' }}
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2 mt-6">
+            <Button variant="outline" size="sm" @click="createDialogOpen = false">Cancel</Button>
+            <Button size="sm" :loading="creating" :disabled="!createForm.name.trim()" @click="handleCreate">
+              <template v-if="!creating" #icon>
+                <Plus class="w-3.5 h-3.5" />
+              </template>
+              Create
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Edit Dialog -->
+    <Teleport to="body">
+      <div v-if="editDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-md p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-4">Edit OAuth2 Application</h2>
+          <div class="space-y-4">
+            <!-- Name -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-1">Name</label>
+              <input
+                v-model="editForm.name"
+                type="text"
+                placeholder="Enter application name"
+                class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            <!-- Redirect URIs -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-1">Redirect URIs</label>
+              <div class="space-y-2">
+                <div v-for="(uri, index) in editForm.redirect_uris" :key="index" class="flex items-center gap-2">
+                  <input
+                    v-model="editForm.redirect_uris[index]"
+                    type="text"
+                    placeholder="https://example.com/callback"
+                    class="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  />
+                  <button
+                    v-if="editForm.redirect_uris.length > 1"
+                    class="inline-flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors cursor-pointer"
+                    @click="removeEditRedirectUri(index)"
+                  >
+                    <Trash2 class="w-3.5 h-3.5" />
+                  </button>
+                </div>
+                <Button variant="outline" size="sm" @click="addEditRedirectUri">
+                  <template #icon>
+                    <Plus class="w-3.5 h-3.5" />
+                  </template>
+                  Add URI
+                </Button>
+              </div>
+            </div>
+
+            <!-- Scopes -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-2">Scopes</label>
+              <div class="flex flex-wrap gap-2">
+                <label
+                  v-for="scope in availableScopes"
+                  :key="scope"
+                  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-border text-xs cursor-pointer transition-colors"
+                  :class="editForm.scopes.includes(scope) ? 'bg-primary/10 border-primary text-primary' : 'bg-background text-muted-foreground hover:bg-accent'"
+                >
+                  <input
+                    type="checkbox"
+                    :value="scope"
+                    class="sr-only"
+                    @change="(e: any) => {
+                      if (e.target.checked) editForm.scopes.push(scope)
+                      else editForm.scopes = editForm.scopes.filter(s => s !== scope)
+                    }"
+                  />
+                  {{ scope }}
+                </label>
+              </div>
+            </div>
+
+            <!-- Grant Types -->
+            <div>
+              <label class="block text-sm font-medium text-foreground mb-2">Grant Types</label>
+              <div class="space-y-2">
+                <label
+                  v-for="gt in availableGrantTypes"
+                  :key="gt"
+                  class="flex items-center gap-2 px-3 py-2 rounded-md border border-border text-sm cursor-pointer transition-colors"
+                  :class="editForm.grant_types.includes(gt) ? 'bg-primary/10 border-primary text-primary' : 'bg-background text-muted-foreground hover:bg-accent'"
+                >
+                  <input
+                    type="checkbox"
+                    :value="gt"
+                    class="sr-only"
+                    @change="(e: any) => {
+                      if (e.target.checked) editForm.grant_types.push(gt)
+                      else editForm.grant_types = editForm.grant_types.filter(g => g !== gt)
+                    }"
+                  />
+                  <span class="w-4 h-4 rounded border flex items-center justify-center shrink-0" :class="editForm.grant_types.includes(gt) ? 'bg-primary border-primary' : 'border-border'">
+                    <Check v-if="editForm.grant_types.includes(gt)" class="w-3 h-3 text-primary-foreground" />
+                  </span>
+                  {{ gt === 'client_credentials' ? 'Client Credentials' : 'Authorization Code' }}
+                </label>
+              </div>
+            </div>
+
+            <!-- Enabled Toggle -->
+            <div class="flex items-center justify-between">
+              <label class="text-sm font-medium text-foreground">Enabled</label>
+              <button
+                class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                :class="editForm.enabled ? 'bg-primary' : 'bg-muted'"
+                @click="editForm.enabled = !editForm.enabled"
+              >
+                <span
+                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  :class="editForm.enabled ? 'translate-x-5' : 'translate-x-0'"
+                />
+              </button>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2 mt-6">
+            <Button variant="outline" size="sm" @click="editDialogOpen = false">Cancel</Button>
+            <Button size="sm" :loading="editing" :disabled="!editForm.name.trim()" @click="handleEdit">
+              <template v-if="!editing" #icon>
+                <Pencil class="w-3.5 h-3.5" />
+              </template>
+              Save
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Delete Confirmation Dialog -->
+    <Teleport to="body">
+      <div v-if="deleteDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-2">Delete OAuth2 Application</h2>
+          <p class="text-sm text-muted-foreground mb-4">
+            Are you sure you want to delete "{{ deletingClient?.name }}"? This action cannot be undone. All tokens associated with this application will be revoked.
+          </p>
+          <div class="flex justify-end gap-2">
+            <Button variant="outline" size="sm" @click="deleteDialogOpen = false">Cancel</Button>
+            <Button variant="destructive" size="sm" :loading="deleting" @click="confirmDelete">
+              <template v-if="!deleting" #icon>
+                <Trash2 class="w-3.5 h-3.5" />
+              </template>
+              Delete
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Regenerate Secret Confirmation Dialog -->
+    <Teleport to="body">
+      <div v-if="regenerateDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-sm p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-2">Regenerate Client Secret</h2>
+          <p class="text-sm text-muted-foreground mb-4">
+            Are you sure you want to regenerate the client secret for "{{ regeneratingClient?.name }}"? The current secret will be immediately invalidated.
+          </p>
+          <div class="flex justify-end gap-2">
+            <Button variant="outline" size="sm" @click="regenerateDialogOpen = false">Cancel</Button>
+            <Button variant="destructive" size="sm" :loading="regenerating" @click="confirmRegenerate">
+              <template v-if="!regenerating" #icon>
+                <RefreshCw class="w-3.5 h-3.5" />
+              </template>
+              Regenerate
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Secret Reveal Dialog -->
+    <Teleport to="body">
+      <div v-if="secretDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+        <div class="bg-card rounded-lg shadow-xl w-full max-w-md p-6 border border-border">
+          <h2 class="text-lg font-semibold text-foreground mb-2">Client Secret Created</h2>
+          <p class="text-sm text-destructive mb-3 font-medium">
+            Copy this secret now. It will not be shown again!
+          </p>
+          <div class="flex items-center gap-2 rounded-md border border-border bg-muted/50 p-3">
+            <code class="flex-1 text-xs font-mono text-foreground break-all select-all">{{ revealedSecret }}</code>
+            <Button variant="ghost" size="icon" class="h-8 w-8 shrink-0" @click="copySecret">
+              <Check v-if="clientSecretCopied" class="w-4 h-4 text-success" />
+              <Copy v-else class="w-4 h-4" />
+            </Button>
+          </div>
+          <div class="flex justify-end mt-4">
+            <Button size="sm" @click="closeSecretDialog">Done</Button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>


### PR DESCRIPTION
## Phase 7.4: API Open Platform

### Features
- **OAuth2 Application Registration**: Client Credentials + Authorization Code flows
- **Scope Permission System**: 17 standard scopes + RequireScope middleware
- **OAuth2 Token Management**: access_token, refresh_token, revoke
- **Frontend**: OAuth2 Apps management page

### Backend
- `internal/config/config.go` — APIPlatformConfig
- `internal/model/oauth2.go` — OAuth2Client, OAuth2Authorization, OAuth2Token
- `internal/auth/scopes.go` — Scope constants + RequireScope middleware
- `internal/service/oauth2_service.go` — Full OAuth2 service
- `internal/api/oauth2_api.go` — 10 API endpoints

### Frontend
- `web/src/api/modules/oauth2.ts` — API module
- `web/src/views/OAuth2Apps.vue` — App management page
- Router and navigation updates