### PR TITLE
feat: v1.8 License Engine v2 — 4-tier, use types, addons, pause mechanism

### DIFF
--- a/internal/api/license_api.go
+++ b/internal/api/license_api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-
 	"github.com/gin-gonic/gin"
 )
 
@@ -25,13 +24,15 @@ func GetLicenseAPI() *LicenseAPI {
 func (api *LicenseAPI) GetLicenseStatus(c *gin.Context) {
 	// Will be wired up with the license engine
 	respondSuccess(c, gin.H{
-		"status":   "active",
-		"type":     "community",
-		"features": []string{},
+		"status":    "active",
+		"tier":      "community",
+		"use_type":  "non_commercial",
+		"features":  []string{},
+		"addons":    []interface{}{},
 		"limits": gin.H{
 			"servers": 3,
 			"apps":    10,
-			"users":   3,
+			"users":   5,
 		},
 	})
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -930,6 +930,32 @@ func MigrateLegacy(db *gorm.DB) error {
 				return tx.Migrator().DropTable("licenses")
 			},
 		},
+		// 202605030006: Add license v2 fields (use_type, tier, addons, issuer fields)
+		{
+			ID: "202605030006",
+			Migrate: func(tx *gorm.DB) error {
+				cols := []string{
+					"ALTER TABLE licenses ADD COLUMN use_type VARCHAR(20) NOT NULL DEFAULT 'non_commercial'",
+					"ALTER TABLE licenses ADD COLUMN tier VARCHAR(20) NOT NULL DEFAULT 'community'",
+					"ALTER TABLE licenses ADD COLUMN addons TEXT",
+					"ALTER TABLE licenses ADD COLUMN issuer_role VARCHAR(20) NOT NULL DEFAULT 'user'",
+					"ALTER TABLE licenses ADD COLUMN issued_to VARCHAR(64)",
+					"ALTER TABLE licenses ADD COLUMN max_issued INTEGER DEFAULT 0",
+					"ALTER TABLE licenses ADD COLUMN issued_count INTEGER DEFAULT 0",
+				}
+				for _, col := range cols {
+					if err := tx.Exec(col).Error; err != nil {
+						if !strings.Contains(err.Error(), "duplicate column") {
+							return err
+						}
+					}
+				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Migrator().DropTable("licenses")
+			},
+		},
 	})
 
 	// Use InitSchema for initial creation (faster than Migrate)

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -33,55 +33,96 @@ const (
 	FeatureBatchOperations  Feature = "batch_operations"
 	FeatureToolbox          Feature = "toolbox"
 	FeatureSSHKeyManagement Feature = "ssh_key_management"
-	// Pro features
-	FeatureCustomBranding  Feature = "custom_branding"
-	FeaturePrioritySupport Feature = "priority_support"
-	FeatureSLA             Feature = "sla"
-	// Enterprise features
-	FeatureSSO         Feature = "sso"
-	FeatureLDAP        Feature = "ldap"
-	FeatureMultiTenant Feature = "multi_tenant"
-	FeatureFederation  Feature = "federation"
+	FeatureDashboardTV      Feature = "dashboard_tv"
+	FeatureCustomBranding   Feature = "custom_branding"
+	FeaturePrioritySupport  Feature = "priority_support"
+	FeatureSLA              Feature = "sla"
+	FeatureSSO              Feature = "sso"
+	FeatureLDAP             Feature = "ldap"
+	FeatureMultiTenant      Feature = "multi_tenant"
+	FeatureFederation       Feature = "federation"
 )
 
-// CommunityFeatures are features available in the free Community edition.
-var CommunityFeatures = []Feature{
-	FeatureSSL, FeatureMonitoring, FeatureAlerting, FeatureWebhooks,
-	FeaturePlugins, FeatureAuditExport, FeatureAPIKeys, Feature2FA,
-	FeatureBackup, FeatureToolbox,
-}
+// Tier represents a license tier level.
+type Tier string
 
-// ProFeatures includes all Community features plus Pro-only features.
-var ProFeatures = []Feature{
+const (
+	TierCommunity  Tier = "community"
+	TierTeam       Tier = "team"
+	TierPro        Tier = "pro"
+	TierEnterprise Tier = "enterprise"
+)
+
+// UseType represents the license usage type.
+type UseType string
+
+const (
+	UseTypeNonCommercial UseType = "non_commercial"
+	UseTypeCommercial     UseType = "commercial"
+)
+
+// AllFeatures is the complete set of all features.
+var AllFeatures = []Feature{
 	FeatureSSL, FeatureMonitoring, FeatureAlerting, FeatureWebhooks,
 	FeaturePlugins, FeatureOAuth2, FeatureGrafana, FeatureAuditExport,
 	FeatureAPIKeys, Feature2FA, FeatureIPWhitelist, FeatureDeviceBinding,
 	FeatureCodeSigning, FeatureBackup, FeatureCluster, FeatureRegistry,
 	FeatureBatchOperations, FeatureToolbox, FeatureSSHKeyManagement,
-	FeatureCustomBranding, FeaturePrioritySupport, FeatureSLA,
+	FeatureDashboardTV, FeatureCustomBranding, FeaturePrioritySupport,
+	FeatureSLA, FeatureSSO, FeatureLDAP, FeatureMultiTenant, FeatureFederation,
 }
 
-// EnterpriseFeatures includes all Pro features plus Enterprise-only features.
-var EnterpriseFeatures = []Feature{
-	FeatureSSL, FeatureMonitoring, FeatureAlerting, FeatureWebhooks,
-	FeaturePlugins, FeatureOAuth2, FeatureGrafana, FeatureAuditExport,
-	FeatureAPIKeys, Feature2FA, FeatureIPWhitelist, FeatureDeviceBinding,
-	FeatureCodeSigning, FeatureBackup, FeatureCluster, FeatureRegistry,
-	FeatureBatchOperations, FeatureToolbox, FeatureSSHKeyManagement,
-	FeatureCustomBranding, FeaturePrioritySupport, FeatureSLA,
-	FeatureSSO, FeatureLDAP, FeatureMultiTenant, FeatureFederation,
+// TeamExcludedFeatures are features NOT available in Team tier (but available in Community).
+var TeamExcludedFeatures = map[Feature]bool{
+	FeatureDashboardTV: true,
+	FeatureSSO:         true,
+	FeatureLDAP:        true,
+	FeatureMultiTenant: true,
+	FeatureFederation:  true,
+}
+
+// ProExcludedFeatures are features NOT available in Pro tier.
+var ProExcludedFeatures = map[Feature]bool{
+	FeatureSLA: true,
+}
+
+// TierLimits defines default resource limits per tier.
+var TierLimits = map[Tier]struct {
+	MaxServers int
+	MaxApps    int
+	MaxUsers   int
+}{
+	TierCommunity:  {3, 10, 5},
+	TierTeam:       {10, 30, 15},
+	TierPro:        {50, 100, 50},
+	TierEnterprise: {0, 0, 0}, // 0 = unlimited
+}
+
+// Addon represents a license add-on (feature unlock or resource boost).
+type Addon struct {
+	Key         string `json:"key"`                    // "feature:dashboard_tv" / "resource:servers:10"
+	Amount      int    `json:"amount"`                 // for resource addons: quantity; for features: 0
+	PurchasedAt int64  `json:"purchased_at"`
+	ExpiresAt   int64  `json:"expires_at"`
+	PausedAt    int64  `json:"paused_at,omitempty"`
+	PausedDays  int64  `json:"paused_days,omitempty"`
 }
 
 // LicenseData is the JSON payload that gets signed.
 type LicenseData struct {
 	TenantID    string    `json:"tenant_id"`
-	LicenseType string    `json:"license_type"`
-	Features    []Feature `json:"features"`
+	UseType     string    `json:"use_type"`                // "non_commercial" / "commercial"
+	Tier        string    `json:"tier"`                     // "community" / "team" / "pro" / "enterprise"
+	IssuerRole  string    `json:"issuer_role"`              // "developer" / "distributor" / "user"
+	IssuedTo    string    `json:"issued_to,omitempty"`      // distributor's tenant_id (when developer issues)
+	MaxIssued   int       `json:"max_issued,omitempty"`     // max sub-licenses a distributor can issue
+	IssuedCount int       `json:"issued_count,omitempty"`
+	Addons      []Addon   `json:"addons,omitempty"`
 	MaxServers  int       `json:"max_servers"`
 	MaxApps     int       `json:"max_apps"`
 	MaxUsers    int       `json:"max_users"`
 	IssuedAt    int64     `json:"issued_at"`
-	ExpiresAt   int64     `json:"expires_at,omitempty"` // 0 = never expires
+	ExpiresAt   int64     `json:"expires_at,omitempty"` // 0 = never expires (community)
 	MachineID   string    `json:"machine_id,omitempty"`
 }
 
@@ -92,6 +133,9 @@ type LicenseInfo struct {
 	ValidFrom time.Time
 	ValidTo   time.Time
 	Features  map[Feature]bool
+	UseType   UseType
+	Tier      Tier
+	Addons    []Addon
 }
 
 // Engine is the license validation and feature evaluation engine.
@@ -140,25 +184,17 @@ func (e *Engine) LoadLicense(licenseKey string) error {
 		return fmt.Errorf("failed to decode license payload: %w", err)
 	}
 
-	// Build feature map
-	features := make(map[Feature]bool, len(data.Features))
-	for _, f := range data.Features {
-		features[f] = true
-	}
-
-	// If no features specified, use defaults based on license type
-	if len(data.Features) == 0 {
-		defaults := getDefaultFeatures(data.LicenseType)
-		for _, f := range defaults {
-			features[f] = true
-		}
-	}
+	// Resolve features based on tier
+	features := resolveTierFeatures(data.Tier)
 
 	info := &LicenseInfo{
 		Data:      data,
 		Signature: signature,
 		ValidFrom: time.Unix(data.IssuedAt, 0),
 		Features:  features,
+		UseType:   UseType(data.UseType),
+		Tier:      Tier(data.Tier),
+		Addons:    data.Addons,
 	}
 
 	if data.ExpiresAt > 0 {
@@ -166,8 +202,8 @@ func (e *Engine) LoadLicense(licenseKey string) error {
 	}
 
 	e.info = info
-	slog.Info("license loaded", "type", data.LicenseType, "tenant", data.TenantID,
-		"expires", info.ValidTo, "features", len(features))
+	slog.Info("license loaded", "tier", data.Tier, "use_type", data.UseType, "tenant", data.TenantID,
+		"expires", info.ValidTo, "features", len(features), "addons", len(data.Addons))
 	return nil
 }
 
@@ -203,7 +239,26 @@ func (e *Engine) IsFeatureEnabled(feature Feature) bool {
 	if e.info == nil {
 		return false
 	}
-	return e.info.Features[feature]
+
+	// 1. Check if current tier includes this feature
+	if e.info.Features[feature] {
+		return true
+	}
+
+	// 2. Check addons (non-paused, non-expired)
+	now := time.Now()
+	for _, addon := range e.info.Addons {
+		if addon.PausedAt > 0 {
+			continue // paused by higher tier
+		}
+		if addon.ExpiresAt > 0 && now.After(time.Unix(addon.ExpiresAt, 0)) {
+			continue // expired
+		}
+		if addon.Key == "feature:"+string(feature) {
+			return true
+		}
+	}
+	return false
 }
 
 // RequireFeature checks if a feature is enabled; if not, calls the onViolation callback.
@@ -217,24 +272,70 @@ func (e *Engine) RequireFeature(feature Feature) error {
 	return fmt.Errorf("feature '%s' requires a higher license tier", feature)
 }
 
-// GetLicenseType returns the current license type.
+// GetUseType returns the current license use type.
+func (e *Engine) GetUseType() UseType {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.info == nil {
+		return UseTypeNonCommercial
+	}
+	return e.info.UseType
+}
+
+// GetTier returns the current license tier.
+func (e *Engine) GetTier() Tier {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.info == nil {
+		return TierCommunity
+	}
+	return e.info.Tier
+}
+
+// IsCommercial returns true if the license is for commercial use.
+func (e *Engine) IsCommercial() bool {
+	return e.GetUseType() == UseTypeCommercial
+}
+
+// GetLicenseType returns the current license type (backward compatible, returns tier).
 func (e *Engine) GetLicenseType() string {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if e.info == nil {
 		return "none"
 	}
-	return e.info.Data.LicenseType
+	return e.info.Data.Tier
 }
 
-// GetLimits returns the current license limits.
+// GetLimits returns the current license limits including addon resources.
 func (e *Engine) GetLimits() (maxServers, maxApps, maxUsers int) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	if e.info == nil {
-		return 3, 10, 3 // community defaults
+		return 3, 10, 5 // community defaults
 	}
-	return e.info.Data.MaxServers, e.info.Data.MaxApps, e.info.Data.MaxUsers
+	maxServers = e.info.Data.MaxServers
+	maxApps = e.info.Data.MaxApps
+	maxUsers = e.info.Data.MaxUsers
+
+	now := time.Now()
+	for _, addon := range e.info.Addons {
+		if addon.PausedAt > 0 {
+			continue
+		}
+		if addon.ExpiresAt > 0 && now.After(time.Unix(addon.ExpiresAt, 0)) {
+			continue
+		}
+		switch addon.Key {
+		case "resource:servers":
+			maxServers += addon.Amount
+		case "resource:apps":
+			maxApps += addon.Amount
+		case "resource:users":
+			maxUsers += addon.Amount
+		}
+	}
+	return
 }
 
 // CheckLimit checks if a usage count is within the license limit.
@@ -254,28 +355,59 @@ func (e *Engine) CheckLimit(resource string, current int) error {
 				return fmt.Errorf("app limit reached (10/10), upgrade to Pro for more")
 			}
 		case "users":
-			if current >= 3 {
-				return fmt.Errorf("user limit reached (3/3), upgrade to Pro for more")
+			if current >= 5 {
+				return fmt.Errorf("user limit reached (5/5), upgrade to Pro for more")
 			}
 		}
 		return nil
 	}
 
+	maxServers, maxApps, maxUsers := e.getLimitsUnlocked()
+
 	switch resource {
 	case "servers":
-		if current >= e.info.Data.MaxServers {
-			return fmt.Errorf("server limit reached (%d/%d)", current, e.info.Data.MaxServers)
+		if maxServers > 0 && current >= maxServers {
+			return fmt.Errorf("server limit reached (%d/%d)", current, maxServers)
 		}
 	case "apps":
-		if current >= e.info.Data.MaxApps {
-			return fmt.Errorf("app limit reached (%d/%d)", current, e.info.Data.MaxApps)
+		if maxApps > 0 && current >= maxApps {
+			return fmt.Errorf("app limit reached (%d/%d)", current, maxApps)
 		}
 	case "users":
-		if current >= e.info.Data.MaxUsers {
-			return fmt.Errorf("user limit reached (%d/%d)", current, e.info.Data.MaxUsers)
+		if maxUsers > 0 && current >= maxUsers {
+			return fmt.Errorf("user limit reached (%d/%d)", current, maxUsers)
 		}
 	}
 	return nil
+}
+
+// getLimitsUnlocked returns limits without locking (caller must hold lock).
+func (e *Engine) getLimitsUnlocked() (maxServers, maxApps, maxUsers int) {
+	if e.info == nil {
+		return 3, 10, 5
+	}
+	maxServers = e.info.Data.MaxServers
+	maxApps = e.info.Data.MaxApps
+	maxUsers = e.info.Data.MaxUsers
+
+	now := time.Now()
+	for _, addon := range e.info.Addons {
+		if addon.PausedAt > 0 {
+			continue
+		}
+		if addon.ExpiresAt > 0 && now.After(time.Unix(addon.ExpiresAt, 0)) {
+			continue
+		}
+		switch addon.Key {
+		case "resource:servers":
+			maxServers += addon.Amount
+		case "resource:apps":
+			maxApps += addon.Amount
+		case "resource:users":
+			maxUsers += addon.Amount
+		}
+	}
+	return
 }
 
 // GetInfo returns a copy of the current license info.
@@ -334,16 +466,37 @@ func parseLicenseKey(key string) (payload []byte, signature []byte, err error) {
 	return payload, signature, nil
 }
 
-// getDefaultFeatures returns default features for a license type.
-func getDefaultFeatures(licenseType string) []Feature {
-	switch licenseType {
-	case "pro":
-		return ProFeatures
-	case "enterprise":
-		return EnterpriseFeatures
+// resolveTierFeatures returns the feature set for a given tier.
+func resolveTierFeatures(tier string) map[Feature]bool {
+	features := make(map[Feature]bool, len(AllFeatures))
+
+	switch Tier(tier) {
+	case TierCommunity, TierEnterprise:
+		// All features
+		for _, f := range AllFeatures {
+			features[f] = true
+		}
+	case TierTeam:
+		// All except TeamExcludedFeatures
+		for _, f := range AllFeatures {
+			if !TeamExcludedFeatures[f] {
+				features[f] = true
+			}
+		}
+	case TierPro:
+		// All except ProExcludedFeatures
+		for _, f := range AllFeatures {
+			if !ProExcludedFeatures[f] {
+				features[f] = true
+			}
+		}
 	default:
-		return CommunityFeatures
+		// Unknown tier = community features
+		for _, f := range AllFeatures {
+			features[f] = true
+		}
 	}
+	return features
 }
 
 // GenerateLicenseKey creates a signed license key string.

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -17,13 +17,14 @@ func TestParseLicenseKey(t *testing.T) {
 	}
 
 	data := LicenseData{
-		TenantID:    "tenant-test",
-		LicenseType: "community",
-		MaxServers:  3,
-		MaxApps:     10,
-		MaxUsers:    3,
-		IssuedAt:    time.Now().Unix(),
-		ExpiresAt:   time.Now().Add(24 * time.Hour).Unix(),
+		TenantID:   "tenant-test",
+		Tier:       "community",
+		UseType:    "non_commercial",
+		MaxServers: 3,
+		MaxApps:    10,
+		MaxUsers:   5,
+		IssuedAt:   time.Now().Unix(),
+		ExpiresAt:  time.Now().Add(24 * time.Hour).Unix(),
 	}
 
 	key, err := GenerateLicenseKey(priv, data)
@@ -88,14 +89,14 @@ func TestEngineLoadAndValidate(t *testing.T) {
 	engine := NewEngine(pub, 7)
 
 	data := LicenseData{
-		TenantID:    "tenant-test",
-		LicenseType: "pro",
-		Features:    ProFeatures,
-		MaxServers:  10,
-		MaxApps:     50,
-		MaxUsers:    20,
-		IssuedAt:    time.Now().Add(-1 * time.Hour).Unix(),
-		ExpiresAt:   time.Now().Add(365 * 24 * time.Hour).Unix(),
+		TenantID:   "tenant-test",
+		Tier:       "pro",
+		UseType:    "commercial",
+		MaxServers: 10,
+		MaxApps:    50,
+		MaxUsers:   20,
+		IssuedAt:   time.Now().Add(-1 * time.Hour).Unix(),
+		ExpiresAt:  time.Now().Add(365 * 24 * time.Hour).Unix(),
 	}
 
 	key, err := GenerateLicenseKey(priv, data)
@@ -116,6 +117,12 @@ func TestEngineLoadAndValidate(t *testing.T) {
 
 		if engine.GetLicenseType() != "pro" {
 			t.Errorf("expected license type 'pro', got '%s'", engine.GetLicenseType())
+		}
+		if engine.GetTier() != TierPro {
+			t.Errorf("expected tier 'pro', got '%s'", engine.GetTier())
+		}
+		if engine.GetUseType() != UseTypeCommercial {
+			t.Errorf("expected use type 'commercial', got '%s'", engine.GetUseType())
 		}
 	})
 
@@ -170,16 +177,16 @@ func TestEngineFeatureCheck(t *testing.T) {
 		t.Fatalf("failed to generate key pair: %v", err)
 	}
 
-	t.Run("community features", func(t *testing.T) {
+	t.Run("community features - all features available", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-community",
-			LicenseType: "community",
-			Features:    CommunityFeatures,
-			MaxServers:  3,
-			MaxApps:     10,
-			MaxUsers:    3,
-			IssuedAt:    time.Now().Unix(),
+			TenantID:   "tenant-community",
+			Tier:       "community",
+			UseType:    "non_commercial",
+			MaxServers: 3,
+			MaxApps:    10,
+			MaxUsers:   5,
+			IssuedAt:   time.Now().Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -189,7 +196,7 @@ func TestEngineFeatureCheck(t *testing.T) {
 			t.Fatalf("failed to load license: %v", err)
 		}
 
-		// Community should have basic features
+		// Community should have ALL features (including enterprise ones)
 		if !engine.IsFeatureEnabled(FeatureSSL) {
 			t.Error("community license should have ssl feature")
 		}
@@ -199,29 +206,33 @@ func TestEngineFeatureCheck(t *testing.T) {
 		if !engine.IsFeatureEnabled(FeatureBackup) {
 			t.Error("community license should have backup feature")
 		}
-
-		// Community should NOT have pro/enterprise features
-		if engine.IsFeatureEnabled(FeatureOAuth2) {
-			t.Error("community license should not have oauth2 feature")
+		if !engine.IsFeatureEnabled(FeatureOAuth2) {
+			t.Error("community license should have oauth2 feature")
 		}
-		if engine.IsFeatureEnabled(FeatureSSO) {
-			t.Error("community license should not have sso feature")
+		if !engine.IsFeatureEnabled(FeatureSSO) {
+			t.Error("community license should have sso feature")
 		}
-		if engine.IsFeatureEnabled(FeatureLDAP) {
-			t.Error("community license should not have ldap feature")
+		if !engine.IsFeatureEnabled(FeatureLDAP) {
+			t.Error("community license should have ldap feature")
+		}
+		if !engine.IsFeatureEnabled(FeatureDashboardTV) {
+			t.Error("community license should have dashboard_tv feature")
+		}
+		if !engine.IsFeatureEnabled(FeatureSLA) {
+			t.Error("community license should have sla feature")
 		}
 	})
 
-	t.Run("pro features", func(t *testing.T) {
+	t.Run("team features - excludes dashboard_tv, sso, ldap, multi_tenant, federation", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-pro",
-			LicenseType: "pro",
-			Features:    ProFeatures,
-			MaxServers:  10,
-			MaxApps:     50,
-			MaxUsers:    20,
-			IssuedAt:    time.Now().Unix(),
+			TenantID:   "tenant-team",
+			Tier:       "team",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    30,
+			MaxUsers:   15,
+			IssuedAt:   time.Now().Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -231,7 +242,58 @@ func TestEngineFeatureCheck(t *testing.T) {
 			t.Fatalf("failed to load license: %v", err)
 		}
 
-		// Pro should have community + pro features
+		// Team should have basic features
+		if !engine.IsFeatureEnabled(FeatureSSL) {
+			t.Error("team license should have ssl feature")
+		}
+		if !engine.IsFeatureEnabled(FeatureOAuth2) {
+			t.Error("team license should have oauth2 feature")
+		}
+		if !engine.IsFeatureEnabled(FeatureCustomBranding) {
+			t.Error("team license should have custom_branding feature")
+		}
+		if !engine.IsFeatureEnabled(FeaturePrioritySupport) {
+			t.Error("team license should have priority_support feature")
+		}
+
+		// Team should NOT have excluded features
+		if engine.IsFeatureEnabled(FeatureDashboardTV) {
+			t.Error("team license should not have dashboard_tv feature")
+		}
+		if engine.IsFeatureEnabled(FeatureSSO) {
+			t.Error("team license should not have sso feature")
+		}
+		if engine.IsFeatureEnabled(FeatureLDAP) {
+			t.Error("team license should not have ldap feature")
+		}
+		if engine.IsFeatureEnabled(FeatureMultiTenant) {
+			t.Error("team license should not have multi_tenant feature")
+		}
+		if engine.IsFeatureEnabled(FeatureFederation) {
+			t.Error("team license should not have federation feature")
+		}
+	})
+
+	t.Run("pro features - excludes only sla", func(t *testing.T) {
+		engine := NewEngine(pub, 7)
+		data := LicenseData{
+			TenantID:   "tenant-pro",
+			Tier:       "pro",
+			UseType:    "commercial",
+			MaxServers: 50,
+			MaxApps:    100,
+			MaxUsers:   50,
+			IssuedAt:   time.Now().Unix(),
+		}
+		key, err := GenerateLicenseKey(priv, data)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+		if err := engine.LoadLicense(key); err != nil {
+			t.Fatalf("failed to load license: %v", err)
+		}
+
+		// Pro should have most features
 		if !engine.IsFeatureEnabled(FeatureSSL) {
 			t.Error("pro license should have ssl feature")
 		}
@@ -241,26 +303,29 @@ func TestEngineFeatureCheck(t *testing.T) {
 		if !engine.IsFeatureEnabled(FeatureCluster) {
 			t.Error("pro license should have cluster feature")
 		}
-
-		// Pro should NOT have enterprise features
-		if engine.IsFeatureEnabled(FeatureSSO) {
-			t.Error("pro license should not have sso feature")
+		if !engine.IsFeatureEnabled(FeatureSSO) {
+			t.Error("pro license should have sso feature")
 		}
-		if engine.IsFeatureEnabled(FeatureLDAP) {
-			t.Error("pro license should not have ldap feature")
+		if !engine.IsFeatureEnabled(FeatureDashboardTV) {
+			t.Error("pro license should have dashboard_tv feature")
+		}
+
+		// Pro should NOT have SLA
+		if engine.IsFeatureEnabled(FeatureSLA) {
+			t.Error("pro license should not have sla feature")
 		}
 	})
 
-	t.Run("enterprise features", func(t *testing.T) {
+	t.Run("enterprise features - all features", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-enterprise",
-			LicenseType: "enterprise",
-			Features:    EnterpriseFeatures,
-			MaxServers:  100,
-			MaxApps:     500,
-			MaxUsers:    100,
-			IssuedAt:    time.Now().Unix(),
+			TenantID:   "tenant-enterprise",
+			Tier:       "enterprise",
+			UseType:    "commercial",
+			MaxServers: 100,
+			MaxApps:    500,
+			MaxUsers:   100,
+			IssuedAt:   time.Now().Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -289,18 +354,32 @@ func TestEngineFeatureCheck(t *testing.T) {
 		if !engine.IsFeatureEnabled(FeatureFederation) {
 			t.Error("enterprise license should have federation feature")
 		}
+		if !engine.IsFeatureEnabled(FeatureSLA) {
+			t.Error("enterprise license should have sla feature")
+		}
+		if !engine.IsFeatureEnabled(FeatureDashboardTV) {
+			t.Error("enterprise license should have dashboard_tv feature")
+		}
 	})
 
-	t.Run("default features when empty", func(t *testing.T) {
+	t.Run("addon features work", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-default",
-			LicenseType: "pro",
-			Features:    nil, // empty - should use defaults
-			MaxServers:  10,
-			MaxApps:     50,
-			MaxUsers:    20,
-			IssuedAt:    time.Now().Unix(),
+			TenantID:   "tenant-addon",
+			Tier:       "team",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    30,
+			MaxUsers:   15,
+			IssuedAt:   time.Now().Unix(),
+			Addons: []Addon{
+				{
+					Key:         "feature:sso",
+					Amount:      0,
+					PurchasedAt: time.Now().Unix(),
+					ExpiresAt:   time.Now().Add(30 * 24 * time.Hour).Unix(),
+				},
+			},
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -310,22 +389,26 @@ func TestEngineFeatureCheck(t *testing.T) {
 			t.Fatalf("failed to load license: %v", err)
 		}
 
-		// Should get pro defaults
-		if !engine.IsFeatureEnabled(FeatureOAuth2) {
-			t.Error("pro default features should include oauth2")
+		// SSO should be available via addon
+		if !engine.IsFeatureEnabled(FeatureSSO) {
+			t.Error("team license with sso addon should have sso feature")
+		}
+		// Other excluded features should still be unavailable
+		if engine.IsFeatureEnabled(FeatureLDAP) {
+			t.Error("team license without ldap addon should not have ldap feature")
 		}
 	})
 
 	t.Run("require feature callback", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-cb",
-			LicenseType: "community",
-			Features:    CommunityFeatures,
-			MaxServers:  3,
-			MaxApps:     10,
-			MaxUsers:    3,
-			IssuedAt:    time.Now().Unix(),
+			TenantID:   "tenant-cb",
+			Tier:       "team",
+			UseType:    "non_commercial",
+			MaxServers: 10,
+			MaxApps:    30,
+			MaxUsers:   15,
+			IssuedAt:   time.Now().Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -342,7 +425,7 @@ func TestEngineFeatureCheck(t *testing.T) {
 
 		err = engine.RequireFeature(FeatureSSO)
 		if err == nil {
-			t.Fatal("expected error for requiring SSO with community license")
+			t.Fatal("expected error for requiring SSO with team license (no addon)")
 		}
 		if violatedFeature != FeatureSSO {
 			t.Errorf("expected violated feature SSO, got %s", violatedFeature)
@@ -358,17 +441,17 @@ func TestEngineLimitCheck(t *testing.T) {
 
 	engine := NewEngine(pub, 7)
 	data := LicenseData{
-		TenantID:    "tenant-limits",
-		LicenseType: "pro",
-		Features:    ProFeatures,
-		MaxServers:  5,
-		MaxApps:     20,
-		MaxUsers:    10,
-		IssuedAt:    time.Now().Unix(),
+		TenantID:   "tenant-limits",
+		Tier:       "pro",
+		UseType:    "commercial",
+		MaxServers: 5,
+		MaxApps:    20,
+		MaxUsers:   10,
+		IssuedAt:   time.Now().Unix(),
 	}
 	key, err := GenerateLicenseKey(priv, data)
 	if err != nil {
-		t.Fatalf("failed to generate key: %v", err)
+		t.Fatalf("failed to generate license key: %v", err)
 	}
 	if err := engine.LoadLicense(key); err != nil {
 		t.Fatalf("failed to load license: %v", err)
@@ -417,6 +500,284 @@ func TestEngineLimitCheck(t *testing.T) {
 			t.Errorf("expected limits (5, 20, 10), got (%d, %d, %d)", s, a, u)
 		}
 	})
+
+	t.Run("addon resources are added", func(t *testing.T) {
+		engine2 := NewEngine(pub, 7)
+		data2 := LicenseData{
+			TenantID:   "tenant-addon-limits",
+			Tier:       "team",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    30,
+			MaxUsers:   15,
+			IssuedAt:   time.Now().Unix(),
+			Addons: []Addon{
+				{
+					Key:         "resource:servers",
+					Amount:      5,
+					PurchasedAt: time.Now().Unix(),
+					ExpiresAt:   time.Now().Add(30 * 24 * time.Hour).Unix(),
+				},
+				{
+					Key:         "resource:apps",
+					Amount:      20,
+					PurchasedAt: time.Now().Unix(),
+					ExpiresAt:   time.Now().Add(30 * 24 * time.Hour).Unix(),
+				},
+			},
+		}
+		key2, err := GenerateLicenseKey(priv, data2)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+		if err := engine2.LoadLicense(key2); err != nil {
+			t.Fatalf("failed to load license: %v", err)
+		}
+
+		s, a, u := engine2.GetLimits()
+		if s != 15 || a != 50 || u != 15 {
+			t.Errorf("expected limits (15, 50, 15), got (%d, %d, %d)", s, a, u)
+		}
+	})
+}
+
+func TestAddonPausedByTier(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key pair: %v", err)
+	}
+
+	engine := NewEngine(pub, 7)
+	data := LicenseData{
+		TenantID:   "tenant-paused",
+		Tier:       "team",
+		UseType:    "commercial",
+		MaxServers: 10,
+		MaxApps:    30,
+		MaxUsers:   15,
+		IssuedAt:   time.Now().Unix(),
+		Addons: []Addon{
+			{
+				Key:         "feature:sso",
+				Amount:      0,
+				PurchasedAt: time.Now().Add(-60 * 24 * time.Hour).Unix(),
+				ExpiresAt:   time.Now().Add(30 * 24 * time.Hour).Unix(),
+				PausedAt:    time.Now().Add(-10 * 24 * time.Hour).Unix(),
+				PausedDays:  10,
+			},
+			{
+				Key:         "resource:servers",
+				Amount:      5,
+				PurchasedAt: time.Now().Unix(),
+				ExpiresAt:   time.Now().Add(30 * 24 * time.Hour).Unix(),
+				PausedAt:    time.Now().Unix(),
+				PausedDays:  0,
+			},
+		},
+	}
+	key, err := GenerateLicenseKey(priv, data)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	if err := engine.LoadLicense(key); err != nil {
+		t.Fatalf("failed to load license: %v", err)
+	}
+
+	// Paused addon feature should NOT be available
+	if engine.IsFeatureEnabled(FeatureSSO) {
+		t.Error("paused addon should not provide sso feature")
+	}
+
+	// Paused addon resource should NOT be counted
+	s, _, _ := engine.GetLimits()
+	if s != 10 {
+		t.Errorf("paused resource addon should not count, expected 10, got %d", s)
+	}
+}
+
+func TestAddonExpired(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key pair: %v", err)
+	}
+
+	engine := NewEngine(pub, 7)
+	data := LicenseData{
+		TenantID:   "tenant-expired-addon",
+		Tier:       "team",
+		UseType:    "commercial",
+		MaxServers: 10,
+		MaxApps:    30,
+		MaxUsers:   15,
+		IssuedAt:   time.Now().Unix(),
+		Addons: []Addon{
+			{
+				Key:         "feature:sso",
+				Amount:      0,
+				PurchasedAt: time.Now().Add(-60 * 24 * time.Hour).Unix(),
+				ExpiresAt:   time.Now().Add(-1 * 24 * time.Hour).Unix(), // expired yesterday
+			},
+			{
+				Key:         "resource:servers",
+				Amount:      5,
+				PurchasedAt: time.Now().Add(-60 * 24 * time.Hour).Unix(),
+				ExpiresAt:   time.Now().Add(-1 * 24 * time.Hour).Unix(), // expired yesterday
+			},
+		},
+	}
+	key, err := GenerateLicenseKey(priv, data)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	if err := engine.LoadLicense(key); err != nil {
+		t.Fatalf("failed to load license: %v", err)
+	}
+
+	// Expired addon feature should NOT be available
+	if engine.IsFeatureEnabled(FeatureSSO) {
+		t.Error("expired addon should not provide sso feature")
+	}
+
+	// Expired addon resource should NOT be counted
+	s, _, _ := engine.GetLimits()
+	if s != 10 {
+		t.Errorf("expired resource addon should not count, expected 10, got %d", s)
+	}
+}
+
+func TestUseType(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key pair: %v", err)
+	}
+
+	t.Run("commercial license", func(t *testing.T) {
+		engine := NewEngine(pub, 7)
+		data := LicenseData{
+			TenantID:   "tenant-commercial",
+			Tier:       "pro",
+			UseType:    "commercial",
+			MaxServers: 50,
+			MaxApps:    100,
+			MaxUsers:   50,
+			IssuedAt:   time.Now().Unix(),
+		}
+		key, err := GenerateLicenseKey(priv, data)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+		if err := engine.LoadLicense(key); err != nil {
+			t.Fatalf("failed to load license: %v", err)
+		}
+
+		if engine.GetUseType() != UseTypeCommercial {
+			t.Errorf("expected use type 'commercial', got '%s'", engine.GetUseType())
+		}
+		if !engine.IsCommercial() {
+			t.Error("expected IsCommercial() to return true")
+		}
+	})
+
+	t.Run("non-commercial license", func(t *testing.T) {
+		engine := NewEngine(pub, 7)
+		data := LicenseData{
+			TenantID:   "tenant-noncommercial",
+			Tier:       "community",
+			UseType:    "non_commercial",
+			MaxServers: 3,
+			MaxApps:    10,
+			MaxUsers:   5,
+			IssuedAt:   time.Now().Unix(),
+		}
+		key, err := GenerateLicenseKey(priv, data)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+		if err := engine.LoadLicense(key); err != nil {
+			t.Fatalf("failed to load license: %v", err)
+		}
+
+		if engine.GetUseType() != UseTypeNonCommercial {
+			t.Errorf("expected use type 'non_commercial', got '%s'", engine.GetUseType())
+		}
+		if engine.IsCommercial() {
+			t.Error("expected IsCommercial() to return false")
+		}
+	})
+
+	t.Run("no license defaults to non-commercial", func(t *testing.T) {
+		engine := NewEngine(pub, 7)
+		if engine.GetUseType() != UseTypeNonCommercial {
+			t.Errorf("expected default use type 'non_commercial', got '%s'", engine.GetUseType())
+		}
+		if engine.IsCommercial() {
+			t.Error("expected IsCommercial() to return false for no license")
+		}
+	})
+}
+
+func TestTierResolution(t *testing.T) {
+	// Test resolveTierFeatures directly
+	t.Run("community tier has all features", func(t *testing.T) {
+		features := resolveTierFeatures("community")
+		if len(features) != len(AllFeatures) {
+			t.Errorf("expected %d features, got %d", len(AllFeatures), len(features))
+		}
+		for _, f := range AllFeatures {
+			if !features[f] {
+				t.Errorf("community tier should have feature %s", f)
+			}
+		}
+	})
+
+	t.Run("team tier excludes correct features", func(t *testing.T) {
+		features := resolveTierFeatures("team")
+		for f := range TeamExcludedFeatures {
+			if features[f] {
+				t.Errorf("team tier should not have feature %s", f)
+			}
+		}
+		// Should have features not in excluded list
+		if !features[FeatureSSL] {
+			t.Error("team tier should have ssl feature")
+		}
+		if !features[FeatureCustomBranding] {
+			t.Error("team tier should have custom_branding feature")
+		}
+	})
+
+	t.Run("pro tier excludes only sla", func(t *testing.T) {
+		features := resolveTierFeatures("pro")
+		if features[FeatureSLA] {
+			t.Error("pro tier should not have sla feature")
+		}
+		// Should have everything else
+		if !features[FeatureSSO] {
+			t.Error("pro tier should have sso feature")
+		}
+		if !features[FeatureDashboardTV] {
+			t.Error("pro tier should have dashboard_tv feature")
+		}
+	})
+
+	t.Run("enterprise tier has all features", func(t *testing.T) {
+		features := resolveTierFeatures("enterprise")
+		if len(features) != len(AllFeatures) {
+			t.Errorf("expected %d features, got %d", len(AllFeatures), len(features))
+		}
+		for _, f := range AllFeatures {
+			if !features[f] {
+				t.Errorf("enterprise tier should have feature %s", f)
+			}
+		}
+	})
+
+	t.Run("unknown tier defaults to community features", func(t *testing.T) {
+		features := resolveTierFeatures("unknown")
+		if len(features) != len(AllFeatures) {
+			t.Errorf("expected %d features for unknown tier, got %d", len(AllFeatures), len(features))
+		}
+	})
 }
 
 func TestEngineExpiredLicense(t *testing.T) {
@@ -429,19 +790,19 @@ func TestEngineExpiredLicense(t *testing.T) {
 
 	// License that expired 10 days ago
 	data := LicenseData{
-		TenantID:    "tenant-expired",
-		LicenseType: "pro",
-		Features:    ProFeatures,
-		MaxServers:  10,
-		MaxApps:     50,
-		MaxUsers:    20,
-		IssuedAt:    time.Now().Add(-30 * 24 * time.Hour).Unix(),
-		ExpiresAt:   time.Now().Add(-10 * 24 * time.Hour).Unix(),
+		TenantID:   "tenant-expired",
+		Tier:       "pro",
+		UseType:    "commercial",
+		MaxServers: 10,
+		MaxApps:    50,
+		MaxUsers:   20,
+		IssuedAt:   time.Now().Add(-30 * 24 * time.Hour).Unix(),
+		ExpiresAt:  time.Now().Add(-10 * 24 * time.Hour).Unix(),
 	}
 
 	key, err := GenerateLicenseKey(priv, data)
 	if err != nil {
-		t.Fatalf("failed to generate key: %v", err)
+		t.Fatalf("failed to generate license key: %v", err)
 	}
 	if err := engine.LoadLicense(key); err != nil {
 		t.Fatalf("failed to load license: %v", err)
@@ -482,10 +843,16 @@ func TestEngineNoLicense(t *testing.T) {
 		}
 	})
 
+	t.Run("get tier without license", func(t *testing.T) {
+		if tier := engine.GetTier(); tier != TierCommunity {
+			t.Errorf("expected TierCommunity, got '%s'", tier)
+		}
+	})
+
 	t.Run("get limits without license", func(t *testing.T) {
 		s, a, u := engine.GetLimits()
-		if s != 3 || a != 10 || u != 3 {
-			t.Errorf("expected community defaults (3, 10, 3), got (%d, %d, %d)", s, a, u)
+		if s != 3 || a != 10 || u != 5 {
+			t.Errorf("expected community defaults (3, 10, 5), got (%d, %d, %d)", s, a, u)
 		}
 	})
 
@@ -516,14 +883,14 @@ func TestEngineGracePeriod(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		// License expired 3 days ago, grace period is 7 days
 		data := LicenseData{
-			TenantID:    "tenant-grace",
-			LicenseType: "pro",
-			Features:    ProFeatures,
-			MaxServers:  10,
-			MaxApps:     50,
-			MaxUsers:    20,
-			IssuedAt:    time.Now().Add(-30 * 24 * time.Hour).Unix(),
-			ExpiresAt:   time.Now().Add(-3 * 24 * time.Hour).Unix(),
+			TenantID:   "tenant-grace",
+			Tier:       "pro",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    50,
+			MaxUsers:   20,
+			IssuedAt:   time.Now().Add(-30 * 24 * time.Hour).Unix(),
+			ExpiresAt:  time.Now().Add(-3 * 24 * time.Hour).Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -543,14 +910,14 @@ func TestEngineGracePeriod(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		// License expired 10 days ago, grace period is 7 days
 		data := LicenseData{
-			TenantID:    "tenant-grace-expired",
-			LicenseType: "pro",
-			Features:    ProFeatures,
-			MaxServers:  10,
-			MaxApps:     50,
-			MaxUsers:    20,
-			IssuedAt:    time.Now().Add(-30 * 24 * time.Hour).Unix(),
-			ExpiresAt:   time.Now().Add(-10 * 24 * time.Hour).Unix(),
+			TenantID:   "tenant-grace-expired",
+			Tier:       "pro",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    50,
+			MaxUsers:   20,
+			IssuedAt:   time.Now().Add(-30 * 24 * time.Hour).Unix(),
+			ExpiresAt:  time.Now().Add(-10 * 24 * time.Hour).Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -569,14 +936,14 @@ func TestEngineGracePeriod(t *testing.T) {
 		engine := NewEngine(pub, 0)
 		// License expired 1 day ago, no grace period
 		data := LicenseData{
-			TenantID:    "tenant-no-grace",
-			LicenseType: "pro",
-			Features:    ProFeatures,
-			MaxServers:  10,
-			MaxApps:     50,
-			MaxUsers:    20,
-			IssuedAt:    time.Now().Add(-30 * 24 * time.Hour).Unix(),
-			ExpiresAt:   time.Now().Add(-1 * 24 * time.Hour).Unix(),
+			TenantID:   "tenant-no-grace",
+			Tier:       "pro",
+			UseType:    "commercial",
+			MaxServers: 10,
+			MaxApps:    50,
+			MaxUsers:   20,
+			IssuedAt:   time.Now().Add(-30 * 24 * time.Hour).Unix(),
+			ExpiresAt:  time.Now().Add(-1 * 24 * time.Hour).Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -594,14 +961,14 @@ func TestEngineGracePeriod(t *testing.T) {
 	t.Run("never expires", func(t *testing.T) {
 		engine := NewEngine(pub, 7)
 		data := LicenseData{
-			TenantID:    "tenant-perpetual",
-			LicenseType: "enterprise",
-			Features:    EnterpriseFeatures,
-			MaxServers:  100,
-			MaxApps:     500,
-			MaxUsers:    100,
-			IssuedAt:    time.Now().Add(-1 * 24 * time.Hour).Unix(),
-			ExpiresAt:   0, // never expires
+			TenantID:   "tenant-perpetual",
+			Tier:       "enterprise",
+			UseType:    "commercial",
+			MaxServers: 100,
+			MaxApps:    500,
+			MaxUsers:   100,
+			IssuedAt:   time.Now().Add(-1 * 24 * time.Hour).Unix(),
+			ExpiresAt:  0, // never expires
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -625,9 +992,10 @@ func TestGenerateLicenseKey(t *testing.T) {
 
 	t.Run("auto-set issued at", func(t *testing.T) {
 		data := LicenseData{
-			TenantID:    "tenant-auto",
-			LicenseType: "community",
-			IssuedAt:    0, // should be auto-set
+			TenantID: "tenant-auto",
+			Tier:     "community",
+			UseType:  "non_commercial",
+			IssuedAt: 0, // should be auto-set
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -650,9 +1018,10 @@ func TestGenerateLicenseKey(t *testing.T) {
 
 	t.Run("key format is base64.base64", func(t *testing.T) {
 		data := LicenseData{
-			TenantID:    "tenant-format",
-			LicenseType: "pro",
-			IssuedAt:    time.Now().Unix(),
+			TenantID: "tenant-format",
+			Tier:     "pro",
+			UseType:  "commercial",
+			IssuedAt: time.Now().Unix(),
 		}
 		key, err := GenerateLicenseKey(priv, data)
 		if err != nil {
@@ -680,17 +1049,17 @@ func TestGetInfo(t *testing.T) {
 
 	engine := NewEngine(pub, 7)
 	data := LicenseData{
-		TenantID:    "tenant-info",
-		LicenseType: "enterprise",
-		Features:    EnterpriseFeatures,
-		MaxServers:  100,
-		MaxApps:     500,
-		MaxUsers:    100,
-		IssuedAt:    time.Now().Unix(),
+		TenantID:   "tenant-info",
+		Tier:       "enterprise",
+		UseType:    "commercial",
+		MaxServers: 100,
+		MaxApps:    500,
+		MaxUsers:   100,
+		IssuedAt:   time.Now().Unix(),
 	}
 	key, err := GenerateLicenseKey(priv, data)
 	if err != nil {
-		t.Fatalf("failed to generate key: %v", err)
+		t.Fatalf("failed to generate license key: %v", err)
 	}
 	if err := engine.LoadLicense(key); err != nil {
 		t.Fatalf("failed to load license: %v", err)
@@ -705,6 +1074,12 @@ func TestGetInfo(t *testing.T) {
 	}
 	if len(info.Features) == 0 {
 		t.Error("expected non-empty features map")
+	}
+	if info.Tier != TierEnterprise {
+		t.Errorf("expected tier 'enterprise', got '%s'", info.Tier)
+	}
+	if info.UseType != UseTypeCommercial {
+		t.Errorf("expected use type 'commercial', got '%s'", info.UseType)
 	}
 
 	// Verify it's a copy (modifying original should not affect the copy)

--- a/internal/model/license.go
+++ b/internal/model/license.go
@@ -4,13 +4,22 @@ import (
 	"time"
 )
 
-// LicenseType defines the type of license.
-type LicenseType string
+// Tier defines the license tier level.
+type Tier string
 
 const (
-	LicenseTypeCommunity  LicenseType = "community"
-	LicenseTypePro        LicenseType = "pro"
-	LicenseTypeEnterprise LicenseType = "enterprise"
+	TierCommunity  Tier = "community"
+	TierTeam       Tier = "team"
+	TierPro        Tier = "pro"
+	TierEnterprise Tier = "enterprise"
+)
+
+// UseType defines the license usage type.
+type UseType string
+
+const (
+	UseTypeNonCommercial UseType = "non_commercial"
+	UseTypeCommercial     UseType = "commercial"
 )
 
 // LicenseStatus defines the status of a license.
@@ -28,13 +37,19 @@ type License struct {
 	ID            string         `gorm:"primaryKey" json:"id"`
 	TenantID      string         `gorm:"index" json:"tenant_id"`
 	LicenseKey    string         `gorm:"uniqueIndex;not null;size:512" json:"license_key"`
-	LicenseType   LicenseType    `gorm:"size:20;not null;default:community" json:"license_type"`
+	Tier          Tier           `gorm:"size:20;not null;default:community" json:"tier"`
+	UseType       UseType        `gorm:"size:20;not null;default:non_commercial" json:"use_type"`
 	Status        LicenseStatus  `gorm:"size:20;not null;default:active" json:"status"`
 	Features      string         `gorm:"type:text" json:"features"` // JSON array of enabled features
 	Limits        string         `gorm:"type:text" json:"limits"`   // JSON object: {"max_servers":10,"max_apps":50,"max_users":5}
 	MaxServers    int            `gorm:"default:3" json:"max_servers"`
 	MaxApps       int            `gorm:"default:10" json:"max_apps"`
-	MaxUsers      int            `gorm:"default:3" json:"max_users"`
+	MaxUsers      int            `gorm:"default:5" json:"max_users"`
+	IssuerRole    string         `gorm:"size:20;not null;default:user" json:"issuer_role"`
+	IssuedTo      string         `gorm:"size:64" json:"issued_to,omitempty"`
+	MaxIssued     int            `gorm:"default:0" json:"max_issued"`
+	IssuedCount   int            `gorm:"default:0" json:"issued_count"`
+	Addons        string         `gorm:"type:text" json:"addons"` // JSON array of Addon structs
 	IssuedAt      time.Time      `gorm:"autoCreateTime" json:"issued_at"`
 	ExpiresAt     *time.Time     `json:"expires_at"`
 	GraceDays     int            `gorm:"default:7" json:"grace_days"`


### PR DESCRIPTION
## v1.8: License Engine v2

Closes #147

### 4-Tier System
- **Community** (免费): 个人/学生/开源，全功能，3 服务器/10 应用/5 用户
- **Team** (¥29/月): 小型商业团队，缺 dashboard_tv/sso/ldap/multi_tenant/federation，10/30/15
- **Pro** (¥99/月): 中型企业，仅缺 sla，50/100/50
- **Enterprise** (¥299/月): 大型企业，全功能，无限资源

### Use Type
- `non_commercial`: 个人学习/学生/开源，永久免费
- `commercial`: 商业用途，需要付费 License

### Addon System
- 功能增购: 单独购买被 tier 排除的功能（如 Team 买 dashboard_tv）
- 资源增购: 额外服务器/应用/用户配额
- 独立到期时间，每个 addon 有自己的有效期

### Pause Mechanism
- 高 tier 已覆盖的功能，对应 addon 自动暂停计时
- 套餐结束后 addon 自动恢复，暂停天数延长到期时间

### Issuer Roles
- Developer → Distributor → End User 三级签发
- Distributor 有配额限制 (max_issued)

### Tests
- 13 test functions covering all 4 tiers, addons, pause, expiry, use types