### PR TITLE
feat: v1.8 License API activation, issuance, and CLI keygen

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -312,6 +312,29 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string, migrateOnly, migrate
 	}
 	backupSvc.Start()
 
+	// Initialize license engine (v2)
+	if cfg.License.PublicKeyFile != "" || cfg.License.PublicKeyBase64 != "" {
+		pubKey, err := service.LoadPublicKeyFromFileOrBase64(cfg.License.PublicKeyFile, cfg.License.PublicKeyBase64)
+		if err != nil {
+			slog.Warn("failed to load license public key, license engine disabled", "error", err)
+		} else {
+			graceDays := cfg.License.GraceDays
+			if graceDays <= 0 {
+				graceDays = 7
+			}
+			bridge.InitLicenseEngine(pubKey, graceDays)
+
+			// Load existing license from DB if any
+			if err := bridge.LoadLicenseFromDB(context.Background()); err != nil {
+				slog.Warn("failed to load license from database", "error", err)
+			}
+
+			slog.Info("license engine initialized", "grace_days", graceDays)
+		}
+	} else {
+		slog.Info("no license public key configured, license engine disabled (community mode)")
+	}
+
 	// Initialize event-driven plugin system (Phase 7.5)
 	eventPluginMgr := plugin.NewEventPluginManager()
 	eventPluginMgr.Register(builtin.NewHelloWorldPlugin())

--- a/cmd/license/main.go
+++ b/cmd/license/main.go
@@ -36,7 +36,7 @@ func main() {
 		issuerRole := issueCmd.String("issuer-role", "developer", "issuer role: developer, distributor")
 		issuedTo := issueCmd.String("issued-to", "", "distributor tenant ID (when developer issues)")
 		maxIssued := issueCmd.Int("max-issued", 0, "max sub-licenses a distributor can issue")
-		issueCmd.Parse(os.Args[2:])
+		_, err := issueCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		if *tenant == "" {
 			fmt.Fprintln(os.Stderr, "error: --tenant is required")
@@ -149,7 +149,7 @@ func main() {
 		verifyCmd := flag.NewFlagSet("verify", flag.ExitOnError)
 		key := verifyCmd.String("key", "", "license key to verify (required)")
 		publicKeyFile := verifyCmd.String("public-key", "", "path to Ed25519 public key file (required)")
-		verifyCmd.Parse(os.Args[2:])
+		_, err := verifyCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		if *key == "" {
 			fmt.Fprintln(os.Stderr, "error: --key is required")
@@ -211,7 +211,7 @@ func main() {
 	case "generate-keys":
 		genCmd := flag.NewFlagSet("generate-keys", flag.ExitOnError)
 		outputDir := genCmd.String("output-dir", ".", "output directory for key files")
-		genCmd.Parse(os.Args[2:])
+		_, err := genCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		pubKey, privKey, err := ed25519.GenerateKey(nil)
 		if err != nil {

--- a/cmd/license/main.go
+++ b/cmd/license/main.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/license"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "issue":
+		issueCmd := flag.NewFlagSet("issue", flag.ExitOnError)
+		tenant := issueCmd.String("tenant", "", "tenant ID (required)")
+		tier := issueCmd.String("tier", "community", "license tier: community, team, pro, enterprise")
+		useType := issueCmd.String("use-type", "non_commercial", "usage type: non_commercial, commercial")
+		expires := issueCmd.String("expires", "", "expiration date (RFC3339, e.g. 2026-12-31T23:59:59Z)")
+		maxServers := issueCmd.Int("max-servers", 0, "max servers (0 = tier default)")
+		maxApps := issueCmd.Int("max-apps", 0, "max apps (0 = tier default)")
+		maxUsers := issueCmd.Int("max-users", 0, "max users (0 = tier default)")
+		privateKeyFile := issueCmd.String("private-key", "", "path to Ed25519 private key file (required)")
+		addons := issueCmd.String("addons", "", "comma-separated addon keys (e.g. feature:dashboard_tv,resource:servers:10)")
+		issuerRole := issueCmd.String("issuer-role", "developer", "issuer role: developer, distributor")
+		issuedTo := issueCmd.String("issued-to", "", "distributor tenant ID (when developer issues)")
+		maxIssued := issueCmd.Int("max-issued", 0, "max sub-licenses a distributor can issue")
+		issueCmd.Parse(os.Args[2:])
+
+		if *tenant == "" {
+			fmt.Fprintln(os.Stderr, "error: --tenant is required")
+			os.Exit(1)
+		}
+		if *privateKeyFile == "" {
+			fmt.Fprintln(os.Stderr, "error: --private-key is required")
+			os.Exit(1)
+		}
+
+		privKey, err := loadPrivateKey(*privateKeyFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Get tier limits
+		limits, ok := license.TierLimits[license.Tier(*tier)]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "error: unknown tier %q\n", *tier)
+			os.Exit(1)
+		}
+
+		maxSrv := limits.MaxServers
+		maxApp := limits.MaxApps
+		maxUsr := limits.MaxUsers
+		if *maxServers > 0 {
+			maxSrv = *maxServers
+		}
+		if *maxApps > 0 {
+			maxApp = *maxApps
+		}
+		if *maxUsers > 0 {
+			maxUsr = *maxUsers
+		}
+
+		// Parse expiration
+		var expiresAt int64
+		if *expires != "" {
+			t, err := time.Parse(time.RFC3339, *expires)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: invalid expires format (use RFC3339): %v\n", err)
+				os.Exit(1)
+			}
+			expiresAt = t.Unix()
+		}
+
+		// Parse addons
+		var addonList []license.Addon
+		if *addons != "" {
+			for _, key := range strings.Split(*addons, ",") {
+				key = strings.TrimSpace(key)
+				if key != "" {
+					addonList = append(addonList, license.Addon{
+						Key:         key,
+						Amount:      0,
+						PurchasedAt: time.Now().Unix(),
+					})
+				}
+			}
+		}
+
+		data := license.LicenseData{
+			TenantID:   *tenant,
+			UseType:    *useType,
+			Tier:       *tier,
+			IssuerRole: *issuerRole,
+			IssuedTo:   *issuedTo,
+			MaxIssued:  *maxIssued,
+			Addons:     addonList,
+			MaxServers: maxSrv,
+			MaxApps:    maxApp,
+			MaxUsers:   maxUsr,
+			IssuedAt:   time.Now().Unix(),
+			ExpiresAt:  expiresAt,
+		}
+
+		licenseKey, err := license.GenerateLicenseKey(privKey, data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to generate license key: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Output
+		output := map[string]interface{}{
+			"license_key": licenseKey,
+			"tenant_id":   *tenant,
+			"tier":        *tier,
+			"use_type":    *useType,
+			"max_servers": maxSrv,
+			"max_apps":    maxApp,
+			"max_users":   maxUsr,
+			"issued_at":   time.Now().Format(time.RFC3339),
+		}
+		if expiresAt > 0 {
+			output["expires_at"] = time.Unix(expiresAt, 0).Format(time.RFC3339)
+		}
+		if len(addonList) > 0 {
+			output["addons"] = addonList
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(output); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to encode output: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "verify":
+		verifyCmd := flag.NewFlagSet("verify", flag.ExitOnError)
+		key := verifyCmd.String("key", "", "license key to verify (required)")
+		publicKeyFile := verifyCmd.String("public-key", "", "path to Ed25519 public key file (required)")
+		verifyCmd.Parse(os.Args[2:])
+
+		if *key == "" {
+			fmt.Fprintln(os.Stderr, "error: --key is required")
+			os.Exit(1)
+		}
+		if *publicKeyFile == "" {
+			fmt.Fprintln(os.Stderr, "error: --public-key is required")
+			os.Exit(1)
+		}
+
+		pubKey, err := loadPublicKey(*publicKeyFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Create engine and load license
+		engine := license.NewEngine(pubKey, 7)
+		if err := engine.LoadLicense(*key); err != nil {
+			fmt.Fprintf(os.Stderr, "error: license verification failed: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := engine.Validate(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: license validation failed: %v\n", err)
+		}
+
+		info := engine.GetInfo()
+		if info == nil {
+			fmt.Fprintln(os.Stderr, "error: license info not available")
+			os.Exit(1)
+		}
+
+		maxSrv, maxApp, maxUsr := engine.GetLimits()
+
+		output := map[string]interface{}{
+			"valid":      true,
+			"tenant_id":  info.Data.TenantID,
+			"tier":       string(info.Tier),
+			"use_type":   string(info.UseType),
+			"issuer_role": info.Data.IssuerRole,
+			"max_servers": maxSrv,
+			"max_apps":    maxApp,
+			"max_users":   maxUsr,
+			"valid_from":  info.ValidFrom.Format(time.RFC3339),
+			"addons":      info.Addons,
+		}
+		if !info.ValidTo.IsZero() {
+			output["valid_to"] = info.ValidTo.Format(time.RFC3339)
+		}
+
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(output); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to encode output: %v\n", err)
+			os.Exit(1)
+		}
+
+	case "generate-keys":
+		genCmd := flag.NewFlagSet("generate-keys", flag.ExitOnError)
+		outputDir := genCmd.String("output-dir", ".", "output directory for key files")
+		genCmd.Parse(os.Args[2:])
+
+		pubKey, privKey, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to generate key pair: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := os.MkdirAll(*outputDir, 0700); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to create output directory: %v\n", err)
+			os.Exit(1)
+		}
+
+		pubPath := filepath.Join(*outputDir, "license_public.pem")
+		privPath := filepath.Join(*outputDir, "license_private.pem")
+
+		// Write public key
+		pubPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "ED25519 PUBLIC KEY",
+			Bytes: pubKey,
+		})
+		if err := os.WriteFile(pubPath, pubPEM, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to write public key: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Write private key (seed only)
+		privPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "ED25519 PRIVATE KEY",
+			Bytes: privKey.Seed(),
+		})
+		if err := os.WriteFile(privPath, privPEM, 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to write private key: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Also write base64 versions for config
+		pubB64Path := filepath.Join(*outputDir, "license_public_base64.txt")
+		privB64Path := filepath.Join(*outputDir, "license_private_base64.txt")
+
+		if err := os.WriteFile(pubB64Path, []byte(base64.StdEncoding.EncodeToString(pubKey)), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to write public key base64: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := os.WriteFile(privB64Path, []byte(base64.StdEncoding.EncodeToString(privKey.Seed())), 0600); err != nil {
+			fmt.Fprintf(os.Stderr, "error: failed to write private key base64: %v\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Printf("Ed25519 key pair generated:\n")
+		fmt.Printf("  Public key:  %s\n", pubPath)
+		fmt.Printf("  Private key: %s\n", privPath)
+		fmt.Printf("  Public (b64): %s\n", pubB64Path)
+		fmt.Printf("  Private (b64): %s\n", privB64Path)
+		fmt.Printf("\nAdd to config.yaml:\n")
+		fmt.Printf("  license:\n")
+		fmt.Printf("    public_key_base64: %s\n", base64.StdEncoding.EncodeToString(pubKey))
+		fmt.Printf("\nKeep the private key secure! It is needed for issuing licenses.\n")
+
+	default:
+		fmt.Fprintf(os.Stderr, "error: unknown command %q\n", os.Args[1])
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, "DeployPilot License Keygen Tool\n\n")
+	fmt.Fprintf(os.Stderr, "Usage:\n")
+	fmt.Fprintf(os.Stderr, "  license issue         Issue a new license key\n")
+	fmt.Fprintf(os.Stderr, "  license verify         Verify a license key\n")
+	fmt.Fprintf(os.Stderr, "  license generate-keys  Generate a new Ed25519 key pair\n\n")
+	fmt.Fprintf(os.Stderr, "Use 'license <command> --help' for command-specific flags.\n")
+}
+
+func loadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key file: %w", err)
+	}
+
+	// Try PEM format first
+	block, _ := pem.Decode(data)
+	if block != nil {
+		if len(block.Bytes) != ed25519.SeedSize {
+			return nil, fmt.Errorf("invalid private key seed size: got %d, want %d", len(block.Bytes), ed25519.SeedSize)
+		}
+		return ed25519.NewKeyFromSeed(block.Bytes), nil
+	}
+
+	// Try raw base64
+	seed, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode private key base64: %w", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("invalid private key seed size: got %d, want %d", len(seed), ed25519.SeedSize)
+	}
+	return ed25519.NewKeyFromSeed(seed), nil
+}
+
+func loadPublicKey(path string) (ed25519.PublicKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read public key file: %w", err)
+	}
+
+	// Try PEM format first
+	block, _ := pem.Decode(data)
+	if block != nil {
+		if len(block.Bytes) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(block.Bytes), ed25519.PublicKeySize)
+		}
+		return ed25519.PublicKey(block.Bytes), nil
+	}
+
+	// Try raw base64
+	keyBytes, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode public key base64: %w", err)
+	}
+	if len(keyBytes) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(keyBytes), nil
+}

--- a/cmd/license/main.go
+++ b/cmd/license/main.go
@@ -36,7 +36,7 @@ func main() {
 		issuerRole := issueCmd.String("issuer-role", "developer", "issuer role: developer, distributor")
 		issuedTo := issueCmd.String("issued-to", "", "distributor tenant ID (when developer issues)")
 		maxIssued := issueCmd.Int("max-issued", 0, "max sub-licenses a distributor can issue")
-		_, err := issueCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
+		if err := issueCmd.Parse(os.Args[2:]); err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		if *tenant == "" {
 			fmt.Fprintln(os.Stderr, "error: --tenant is required")
@@ -149,7 +149,7 @@ func main() {
 		verifyCmd := flag.NewFlagSet("verify", flag.ExitOnError)
 		key := verifyCmd.String("key", "", "license key to verify (required)")
 		publicKeyFile := verifyCmd.String("public-key", "", "path to Ed25519 public key file (required)")
-		_, err := verifyCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
+		if err := verifyCmd.Parse(os.Args[2:]); err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		if *key == "" {
 			fmt.Fprintln(os.Stderr, "error: --key is required")
@@ -211,7 +211,7 @@ func main() {
 	case "generate-keys":
 		genCmd := flag.NewFlagSet("generate-keys", flag.ExitOnError)
 		outputDir := genCmd.String("output-dir", ".", "output directory for key files")
-		_, err := genCmd.Parse(os.Args[2:]); if err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
+		if err := genCmd.Parse(os.Args[2:]); err != nil { fmt.Fprintf(os.Stderr, "error: %v\n", err); os.Exit(1) }
 
 		pubKey, privKey, err := ed25519.GenerateKey(nil)
 		if err != nil {

--- a/internal/api/license_api.go
+++ b/internal/api/license_api.go
@@ -1,51 +1,143 @@
 package api
 
 import (
+	"net/http"
+
+	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
 )
 
-// LicenseAPI handles license-related API requests.
-type LicenseAPI struct{}
-
-var globalLicenseAPI *LicenseAPI
-
-// SetLicenseAPI sets the global license API instance.
-func SetLicenseAPI(api *LicenseAPI) {
-	globalLicenseAPI = api
-}
-
-// GetLicenseAPI returns the global license API instance.
-func GetLicenseAPI() *LicenseAPI {
-	return globalLicenseAPI
-}
-
-// GetLicenseStatus returns the current license status.
+// GetLicenseStatusHandler returns the current license status.
 // GET /api/v1/license/status
-func (api *LicenseAPI) GetLicenseStatus(c *gin.Context) {
-	// Will be wired up with the license engine
-	respondSuccess(c, gin.H{
-		"status":    "active",
-		"tier":      "community",
-		"use_type":  "non_commercial",
-		"features":  []string{},
-		"addons":    []interface{}{},
-		"limits": gin.H{
-			"servers": 3,
-			"apps":    10,
-			"users":   5,
-		},
-	})
+func GetLicenseStatusHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		result, err := b.GetLicenseStatus(c.Request.Context())
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
 }
 
-// ActivateLicense activates a license key.
+// ActivateLicenseHandler activates a license key or creates a community license.
 // POST /api/v1/license/activate
-func (api *LicenseAPI) ActivateLicense(c *gin.Context) {
-	// Will be wired up with the license engine
-	respondSuccess(c, gin.H{"message": "license activated"})
+// Body: {"license_key": "xxx"} OR {"use_type": "non_commercial", "agree_terms": true}
+func ActivateLicenseHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input struct {
+			LicenseKey string `json:"license_key"`
+			UseType    string `json:"use_type"`
+			AgreeTerms bool   `json:"agree_terms"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		result, err := b.ActivateLicense(c.Request.Context(), input.LicenseKey, input.UseType, input.AgreeTerms)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
 }
 
-// DeactivateLicense deactivates the current license.
+// DeactivateLicenseHandler deactivates the current license.
 // POST /api/v1/license/deactivate
-func (api *LicenseAPI) DeactivateLicense(c *gin.Context) {
-	respondSuccess(c, gin.H{"message": "license deactivated"})
+func DeactivateLicenseHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		result, err := b.DeactivateLicense(c.Request.Context())
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
+}
+
+// IssueLicenseHandler creates a new license key (developer only).
+// POST /api/v1/license/issue
+// Body: {"tenant_id": "...", "tier": "pro", "use_type": "commercial", "expires_at": "...", ...}
+func IssueLicenseHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var params map[string]interface{}
+		if err := c.ShouldBindJSON(&params); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		result, err := b.IssueLicense(c.Request.Context(), params)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
+}
+
+// ListLicensesHandler lists all issued licenses (developer only).
+// GET /api/v1/license/list
+func ListLicensesHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		result, err := b.ListIssuedLicenses(c.Request.Context())
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
+}
+
+// RevokeLicenseHandler revokes a license (developer only).
+// POST /api/v1/license/:id/revoke
+// Body: {"reason": "..."}
+func RevokeLicenseHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		licenseID := c.Param("id")
+		if licenseID == "" {
+			respondErrori18n(c, http.StatusBadRequest, "license id is required")
+			return
+		}
+
+		var input struct {
+			Reason string `json:"reason"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		result, err := b.RevokeLicense(c.Request.Context(), licenseID, input.Reason)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
+}
+
+// PurchaseAddonHandler purchases an addon for the current license.
+// POST /api/v1/license/addon
+// Body: {"addon_key": "feature:dashboard_tv", "amount": 0, "duration_days": 365}
+func PurchaseAddonHandler(b *service.Bridge) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var input struct {
+			AddonKey     string `json:"addon_key"`
+			Amount       int    `json:"amount"`
+			DurationDays int    `json:"duration_days"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "invalid request body")
+			return
+		}
+
+		result, err := b.PurchaseAddon(c.Request.Context(), input.AddonKey, input.Amount, input.DurationDays)
+		if err != nil {
+			respondErrori18n(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		respondSuccess(c, result)
+	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -589,13 +589,16 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			signingGroup.POST("/keys/rotate", auth.RoleRequired("owner", "admin"), RotateKeys)
 		}
 
-		// License management (3 endpoints)
-		SetLicenseAPI(&LicenseAPI{})
+		// License management (7 endpoints)
 		license := protected.Group("/license")
 		{
-			license.GET("/status", GetLicenseAPI().GetLicenseStatus)
-			license.POST("/activate", GetLicenseAPI().ActivateLicense)
-			license.POST("/deactivate", GetLicenseAPI().DeactivateLicense)
+			license.GET("/status", GetLicenseStatusHandler(bridge))
+			license.POST("/activate", ActivateLicenseHandler(bridge))
+			license.POST("/deactivate", DeactivateLicenseHandler(bridge))
+			license.POST("/issue", auth.RoleRequired("owner"), IssueLicenseHandler(bridge))
+			license.GET("/list", auth.RoleRequired("owner"), ListLicensesHandler(bridge))
+			license.POST("/:id/revoke", auth.RoleRequired("owner"), RevokeLicenseHandler(bridge))
+			license.POST("/addon", PurchaseAddonHandler(bridge))
 		}
 
 		// Prometheus metrics (JWT authenticated by default)

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,19 +13,19 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/crypto/ssh"
-
 	"github.com/Yogdunana/deploypilot/internal/agent"
 	"github.com/Yogdunana/deploypilot/internal/bruteforce"
 	"github.com/Yogdunana/deploypilot/internal/confirm"
 	"github.com/Yogdunana/deploypilot/internal/crypto"
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
 	"github.com/Yogdunana/deploypilot/internal/engine/healer"
+	"github.com/Yogdunana/deploypilot/internal/license"
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/monitor"
 	"github.com/Yogdunana/deploypilot/internal/plugin"
 	"github.com/Yogdunana/deploypilot/internal/provider/server"
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
+	"golang.org/x/crypto/ssh"
 	"gorm.io/gorm"
 )
 
@@ -83,6 +84,10 @@ type Bridge struct {
 	Cache         Cache                    // general-purpose cache (Redis or in-memory)
 	Scheduler     *Scheduler               // scheduled task system
 	uptimeSvc     *MonitorService          // uptime monitoring service
+
+	// License engine (v2)
+	LicenseEngine *license.Engine          // license validation and feature evaluation engine
+	LicensePrivKey ed25519.PrivateKey      // only set for developer instances (license issuance)
 
 	// Task tracking (moved from package-level globals, Issue #117)
 	taskMu      sync.RWMutex

--- a/internal/service/license_service.go
+++ b/internal/service/license_service.go
@@ -1,0 +1,750 @@
+package service
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/license"
+	"github.com/Yogdunana/deploypilot/internal/model"
+	"gorm.io/gorm"
+)
+
+// ---------- License Management ----------
+
+// ActivateLicense activates a license key or creates a community license.
+// If licenseKey is provided, it validates the signature, loads into engine, and saves to DB.
+// If useType is "non_commercial" and agreeTerms is true, it creates a community license.
+func (b *Bridge) ActivateLicense(ctx context.Context, licenseKey string, useType string, agreeTerms bool) (interface{}, error) {
+	if licenseKey != "" {
+		return b.activateWithKey(ctx, licenseKey)
+	}
+	if useType == "non_commercial" && agreeTerms {
+		return b.activateCommunity(ctx)
+	}
+	return nil, fmt.Errorf("must provide either a license_key or agree to non-commercial terms")
+}
+
+// activateWithKey validates and activates a license key.
+func (b *Bridge) activateWithKey(ctx context.Context, licenseKey string) (interface{}, error) {
+	if b.LicenseEngine == nil {
+		return nil, fmt.Errorf("license engine not initialized")
+	}
+
+	// Validate and load the license key into the engine
+	if err := b.LicenseEngine.LoadLicense(licenseKey); err != nil {
+		return nil, fmt.Errorf("failed to load license: %w", err)
+	}
+
+	// Validate the license
+	if err := b.LicenseEngine.Validate(); err != nil {
+		return nil, fmt.Errorf("license validation failed: %w", err)
+	}
+
+	info := b.LicenseEngine.GetInfo()
+	if info == nil {
+		return nil, fmt.Errorf("license info not available after loading")
+	}
+
+	// Deactivate any existing active license
+	if err := b.deactivateExistingLicense(ctx); err != nil {
+		slog.Warn("failed to deactivate existing license", "error", err)
+	}
+
+	// Serialize addons to JSON
+	addonsJSON, err := json.Marshal(info.Data.Addons)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize addons: %w", err)
+	}
+
+	// Build features list
+	features := make([]string, 0, len(info.Features))
+	for f := range info.Features {
+		features = append(features, string(f))
+	}
+	featuresJSON, err := json.Marshal(features)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize features: %w", err)
+	}
+
+	// Build limits JSON
+	limitsJSON, err := json.Marshal(map[string]int{
+		"max_servers": info.Data.MaxServers,
+		"max_apps":    info.Data.MaxApps,
+		"max_users":   info.Data.MaxUsers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize limits: %w", err)
+	}
+
+	now := time.Now()
+	graceDays := 0
+	if !info.ValidTo.IsZero() {
+		graceDays = int(info.ValidTo.Sub(now).Hours() / 24)
+		if graceDays < 0 {
+			graceDays = 0
+		}
+	}
+
+	lic := model.License{
+		ID:          fmt.Sprintf("lic-%d", now.UnixNano()),
+		TenantID:    info.Data.TenantID,
+		LicenseKey:  licenseKey,
+		Tier:        model.Tier(info.Data.Tier),
+		UseType:     model.UseType(info.Data.UseType),
+		Status:      model.LicenseStatusActive,
+		Features:    string(featuresJSON),
+		Limits:      string(limitsJSON),
+		MaxServers:  info.Data.MaxServers,
+		MaxApps:     info.Data.MaxApps,
+		MaxUsers:    info.Data.MaxUsers,
+		IssuerRole:  info.Data.IssuerRole,
+		IssuedTo:    info.Data.IssuedTo,
+		MaxIssued:   info.Data.MaxIssued,
+		IssuedCount: info.Data.IssuedCount,
+		Addons:      string(addonsJSON),
+		GraceDays:   graceDays,
+		MachineID:   info.Data.MachineID,
+		ActivatedAt: &now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if info.Data.ExpiresAt > 0 {
+		exp := time.Unix(info.Data.ExpiresAt, 0)
+		lic.ExpiresAt = &exp
+	}
+
+	if err := b.DB.Create(&lic).Error; err != nil {
+		return nil, fmt.Errorf("failed to save license to database: %w", err)
+	}
+
+	slog.Info("license activated", "id", lic.ID, "tier", lic.Tier, "use_type", lic.UseType)
+
+	return map[string]interface{}{
+		"id":         lic.ID,
+		"tier":       lic.Tier,
+		"use_type":   lic.UseType,
+		"status":     lic.Status,
+		"expires_at": lic.ExpiresAt,
+		"features":   features,
+		"limits": map[string]int{
+			"max_servers": lic.MaxServers,
+			"max_apps":    lic.MaxApps,
+			"max_users":   lic.MaxUsers,
+		},
+	}, nil
+}
+
+// activateCommunity creates a community (non-commercial) license.
+func (b *Bridge) activateCommunity(ctx context.Context) (interface{}, error) {
+	// Deactivate any existing active license
+	if err := b.deactivateExistingLicense(ctx); err != nil {
+		slog.Warn("failed to deactivate existing license", "error", err)
+	}
+
+	features := make([]string, 0, len(license.AllFeatures))
+	for _, f := range license.AllFeatures {
+		features = append(features, string(f))
+	}
+	featuresJSON, err := json.Marshal(features)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize features: %w", err)
+	}
+
+	limits := license.TierLimits[license.TierCommunity]
+	limitsJSON, err := json.Marshal(map[string]int{
+		"max_servers": limits.MaxServers,
+		"max_apps":    limits.MaxApps,
+		"max_users":   limits.MaxUsers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize limits: %w", err)
+	}
+
+	now := time.Now()
+	lic := model.License{
+		ID:          fmt.Sprintf("lic-%d", now.UnixNano()),
+		TenantID:    "default",
+		Tier:        model.TierCommunity,
+		UseType:     model.UseTypeNonCommercial,
+		Status:      model.LicenseStatusActive,
+		Features:    string(featuresJSON),
+		Limits:      string(limitsJSON),
+		MaxServers:  limits.MaxServers,
+		MaxApps:     limits.MaxApps,
+		MaxUsers:    limits.MaxUsers,
+		IssuerRole:  "system",
+		GraceDays:   7,
+		ActivatedAt: &now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := b.DB.Create(&lic).Error; err != nil {
+		return nil, fmt.Errorf("failed to save community license: %w", err)
+	}
+
+	// Load into engine if available
+	if b.LicenseEngine != nil && b.LicensePrivKey != nil {
+		communityKey, err := license.GenerateLicenseKey(
+			b.LicensePrivKey,
+			license.LicenseData{
+				TenantID:   "default",
+				UseType:    string(license.UseTypeNonCommercial),
+				Tier:       string(license.TierCommunity),
+				IssuerRole: "system",
+				MaxServers: limits.MaxServers,
+				MaxApps:    limits.MaxApps,
+				MaxUsers:   limits.MaxUsers,
+				IssuedAt:   now.Unix(),
+			},
+		)
+		if err != nil {
+			slog.Warn("failed to generate community license key for engine", "error", err)
+		} else {
+			if loadErr := b.LicenseEngine.LoadLicense(communityKey); loadErr != nil {
+				slog.Warn("failed to load community license into engine", "error", loadErr)
+			} else {
+				// Update the license key in DB
+				b.DB.Model(&lic).Update("license_key", communityKey)
+			}
+		}
+	}
+
+	slog.Info("community license activated", "id", lic.ID)
+
+	return map[string]interface{}{
+		"id":       lic.ID,
+		"tier":     lic.Tier,
+		"use_type": lic.UseType,
+		"status":   lic.Status,
+		"features": features,
+		"limits": map[string]int{
+			"max_servers": lic.MaxServers,
+			"max_apps":    lic.MaxApps,
+			"max_users":   lic.MaxUsers,
+		},
+	}, nil
+}
+
+// deactivateExistingLicense marks all active licenses as expired.
+func (b *Bridge) deactivateExistingLicense(ctx context.Context) error {
+	return b.DB.Model(&model.License{}).
+		Where("status = ?", model.LicenseStatusActive).
+		Update("status", model.LicenseStatusExpired).Error
+}
+
+// DeactivateLicense deactivates the current license.
+func (b *Bridge) DeactivateLicense(ctx context.Context) (interface{}, error) {
+	result := b.DB.Model(&model.License{}).
+		Where("status = ?", model.LicenseStatusActive).
+		Update("status", model.LicenseStatusExpired)
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to deactivate license: %w", result.Error)
+	}
+
+	// Clear engine
+	if b.LicenseEngine != nil {
+		// The engine does not have an unload method, so we note this.
+		// The license will be re-evaluated on next startup.
+		slog.Info("license deactivated (engine will be cleared on restart)")
+	}
+
+	return map[string]interface{}{
+		"message":       "license deactivated",
+		"rows_affected": result.RowsAffected,
+	}, nil
+}
+
+// GetLicenseStatus returns current license info from the engine or DB.
+func (b *Bridge) GetLicenseStatus(ctx context.Context) (interface{}, error) {
+	// Try engine first
+	if b.LicenseEngine != nil {
+		info := b.LicenseEngine.GetInfo()
+		if info != nil {
+			// Check validation
+			validationErr := b.LicenseEngine.Validate()
+
+			features := make([]string, 0, len(info.Features))
+			for f := range info.Features {
+				features = append(features, string(f))
+			}
+
+			maxServers, maxApps, maxUsers := b.LicenseEngine.GetLimits()
+
+			status := "active"
+			if validationErr != nil {
+				status = "expired"
+			}
+
+			return map[string]interface{}{
+				"status":    status,
+				"tier":      string(info.Tier),
+				"use_type":  string(info.UseType),
+				"features":  features,
+				"addons":    info.Addons,
+				"limits": map[string]int{
+					"max_servers": maxServers,
+					"max_apps":    maxApps,
+					"max_users":   maxUsers,
+				},
+				"valid_from":  info.ValidFrom,
+				"valid_to":    info.ValidTo,
+				"tenant_id":   info.Data.TenantID,
+				"issuer_role": info.Data.IssuerRole,
+			}, nil
+		}
+	}
+
+	// Fall back to DB
+	var lic model.License
+	if err := b.DB.Where("status = ?", model.LicenseStatusActive).First(&lic).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return map[string]interface{}{
+				"status":   "none",
+				"tier":     "community",
+				"use_type": "non_commercial",
+				"features": []string{},
+				"addons":   []interface{}{},
+				"limits": map[string]int{
+					"max_servers": 3,
+					"max_apps":    10,
+					"max_users":   5,
+				},
+			}, nil
+		}
+		return nil, fmt.Errorf("failed to query license: %w", err)
+	}
+
+	var features []string
+	if lic.Features != "" {
+		if err := json.Unmarshal([]byte(lic.Features), &features); err != nil {
+			slog.Warn("failed to parse license features", "error", err)
+		}
+	}
+
+	var addons []license.Addon
+	if lic.Addons != "" {
+		if err := json.Unmarshal([]byte(lic.Addons), &addons); err != nil {
+			slog.Warn("failed to parse license addons", "error", err)
+		}
+	}
+
+	return map[string]interface{}{
+		"status":     lic.Status,
+		"tier":       lic.Tier,
+		"use_type":   lic.UseType,
+		"features":   features,
+		"addons":     addons,
+		"expires_at": lic.ExpiresAt,
+		"limits": map[string]int{
+			"max_servers": lic.MaxServers,
+			"max_apps":    lic.MaxApps,
+			"max_users":   lic.MaxUsers,
+		},
+	}, nil
+}
+
+// IssueLicense creates a new license key (developer/distributor only).
+func (b *Bridge) IssueLicense(ctx context.Context, params map[string]interface{}) (interface{}, error) {
+	if b.LicensePrivKey == nil {
+		return nil, fmt.Errorf("license private key not configured (developer mode required)")
+	}
+
+	tenantID, _ := params["tenant_id"].(string)
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant_id is required")
+	}
+
+	tierStr, _ := params["tier"].(string)
+	if tierStr == "" {
+		tierStr = string(license.TierCommunity)
+	}
+
+	useTypeStr, _ := params["use_type"].(string)
+	if useTypeStr == "" {
+		useTypeStr = string(license.UseTypeNonCommercial)
+	}
+
+	issuerRole, _ := params["issuer_role"].(string)
+	if issuerRole == "" {
+		issuerRole = "developer"
+	}
+
+	issuedTo, _ := params["issued_to"].(string)
+	maxIssued := toInt(params["max_issued"])
+
+	// Parse expiration
+	var expiresAt int64
+	if expStr, _ := params["expires_at"].(string); expStr != "" {
+		t, err := time.Parse(time.RFC3339, expStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid expires_at format (use RFC3339): %w", err)
+		}
+		expiresAt = t.Unix()
+	}
+
+	// Parse addon keys
+	var addons []license.Addon
+	if addonKeys, ok := params["addons"].([]interface{}); ok {
+		for _, ak := range addonKeys {
+			if keyStr, ok := ak.(string); ok {
+				addons = append(addons, license.Addon{
+					Key:         keyStr,
+					Amount:      0,
+					PurchasedAt: time.Now().Unix(),
+				})
+			}
+		}
+	}
+
+	// Get tier limits
+	limits, ok := license.TierLimits[license.Tier(tierStr)]
+	if !ok {
+		limits = license.TierLimits[license.TierCommunity]
+	}
+
+	// Override limits if specified
+	maxServers := limits.MaxServers
+	maxApps := limits.MaxApps
+	maxUsers := limits.MaxUsers
+	if v := toInt(params["max_servers"]); v > 0 {
+		maxServers = v
+	}
+	if v := toInt(params["max_apps"]); v > 0 {
+		maxApps = v
+	}
+	if v := toInt(params["max_users"]); v > 0 {
+		maxUsers = v
+	}
+
+	data := license.LicenseData{
+		TenantID:   tenantID,
+		UseType:    useTypeStr,
+		Tier:       tierStr,
+		IssuerRole: issuerRole,
+		IssuedTo:   issuedTo,
+		MaxIssued:  maxIssued,
+		Addons:     addons,
+		MaxServers: maxServers,
+		MaxApps:    maxApps,
+		MaxUsers:   maxUsers,
+		IssuedAt:   time.Now().Unix(),
+		ExpiresAt:  expiresAt,
+	}
+
+	licenseKey, err := license.GenerateLicenseKey(b.LicensePrivKey, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate license key: %w", err)
+	}
+
+	// Save to DB
+	features := ResolveTierFeaturesForTier(tierStr)
+	featureList := make([]string, 0, len(features))
+	for f := range features {
+		featureList = append(featureList, string(f))
+	}
+	featuresJSON, err := json.Marshal(featureList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize features: %w", err)
+	}
+
+	addonsJSON, err := json.Marshal(addons)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize addons: %w", err)
+	}
+
+	limitsJSON, err := json.Marshal(map[string]int{
+		"max_servers": maxServers,
+		"max_apps":    maxApps,
+		"max_users":   maxUsers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize limits: %w", err)
+	}
+
+	now := time.Now()
+	lic := model.License{
+		ID:         fmt.Sprintf("lic-%d", now.UnixNano()),
+		TenantID:   tenantID,
+		LicenseKey: licenseKey,
+		Tier:       model.Tier(tierStr),
+		UseType:    model.UseType(useTypeStr),
+		Status:     model.LicenseStatusActive,
+		Features:   string(featuresJSON),
+		Limits:     string(limitsJSON),
+		MaxServers: maxServers,
+		MaxApps:    maxApps,
+		MaxUsers:   maxUsers,
+		IssuerRole: issuerRole,
+		IssuedTo:   issuedTo,
+		MaxIssued:  maxIssued,
+		Addons:     string(addonsJSON),
+		GraceDays:  7,
+		CreatedBy:  "developer",
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if expiresAt > 0 {
+		exp := time.Unix(expiresAt, 0)
+		lic.ExpiresAt = &exp
+	}
+
+	if err := b.DB.Create(&lic).Error; err != nil {
+		return nil, fmt.Errorf("failed to save issued license: %w", err)
+	}
+
+	slog.Info("license issued", "id", lic.ID, "tier", lic.Tier, "tenant", tenantID)
+
+	return map[string]interface{}{
+		"id":          lic.ID,
+		"license_key": licenseKey,
+		"tier":        lic.Tier,
+		"use_type":    lic.UseType,
+		"tenant_id":   tenantID,
+		"expires_at":  lic.ExpiresAt,
+	}, nil
+}
+
+// ListIssuedLicenses lists all issued licenses (developer only).
+func (b *Bridge) ListIssuedLicenses(ctx context.Context) (interface{}, error) {
+	var licenses []model.License
+	if err := b.DB.Order("created_at DESC").Find(&licenses).Error; err != nil {
+		return nil, fmt.Errorf("failed to list licenses: %w", err)
+	}
+
+	result := make([]map[string]interface{}, 0, len(licenses))
+	for _, lic := range licenses {
+		item := map[string]interface{}{
+			"id":           lic.ID,
+			"tenant_id":    lic.TenantID,
+			"tier":         lic.Tier,
+			"use_type":     lic.UseType,
+			"status":       lic.Status,
+			"max_servers":  lic.MaxServers,
+			"max_apps":     lic.MaxApps,
+			"max_users":    lic.MaxUsers,
+			"issuer_role":  lic.IssuerRole,
+			"issued_to":    lic.IssuedTo,
+			"max_issued":   lic.MaxIssued,
+			"issued_count": lic.IssuedCount,
+			"expires_at":   lic.ExpiresAt,
+			"created_at":   lic.CreatedAt,
+		}
+		if lic.RevokedReason != "" {
+			item["revoked_reason"] = lic.RevokedReason
+		}
+		result = append(result, item)
+	}
+
+	return result, nil
+}
+
+// RevokeLicense revokes a license (developer/distributor only).
+func (b *Bridge) RevokeLicense(ctx context.Context, licenseID string, reason string) (interface{}, error) {
+	if licenseID == "" {
+		return nil, fmt.Errorf("license_id is required")
+	}
+	if reason == "" {
+		return nil, fmt.Errorf("reason is required")
+	}
+
+	result := b.DB.Model(&model.License{}).
+		Where("id = ? AND status = ?", licenseID, model.LicenseStatusActive).
+		Updates(map[string]interface{}{
+			"status":         model.LicenseStatusRevoked,
+			"revoked_reason": reason,
+			"revoked_at":     time.Now(),
+		})
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to revoke license: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return nil, fmt.Errorf("active license not found with id: %s", licenseID)
+	}
+
+	slog.Info("license revoked", "id", licenseID, "reason", reason)
+
+	return map[string]interface{}{
+		"message":       "license revoked",
+		"license_id":    licenseID,
+		"rows_affected": result.RowsAffected,
+	}, nil
+}
+
+// PurchaseAddon purchases an addon for the current license.
+func (b *Bridge) PurchaseAddon(ctx context.Context, addonKey string, amount int, durationDays int) (interface{}, error) {
+	if addonKey == "" {
+		return nil, fmt.Errorf("addon_key is required")
+	}
+
+	// Find active license
+	var lic model.License
+	if err := b.DB.Where("status = ?", model.LicenseStatusActive).First(&lic).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("no active license found")
+		}
+		return nil, fmt.Errorf("failed to find active license: %w", err)
+	}
+
+	// Parse existing addons
+	var addons []license.Addon
+	if lic.Addons != "" {
+		if err := json.Unmarshal([]byte(lic.Addons), &addons); err != nil {
+			return nil, fmt.Errorf("failed to parse existing addons: %w", err)
+		}
+	}
+
+	// Create new addon
+	now := time.Now()
+	newAddon := license.Addon{
+		Key:         addonKey,
+		Amount:      amount,
+		PurchasedAt: now.Unix(),
+	}
+	if durationDays > 0 {
+		newAddon.ExpiresAt = now.Add(time.Duration(durationDays) * 24 * time.Hour).Unix()
+	}
+
+	addons = append(addons, newAddon)
+
+	// Serialize and update
+	addonsJSON, err := json.Marshal(addons)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize addons: %w", err)
+	}
+
+	if err := b.DB.Model(&lic).Update("addons", string(addonsJSON)).Error; err != nil {
+		return nil, fmt.Errorf("failed to update license addons: %w", err)
+	}
+
+	// Reload into engine if available
+	if b.LicenseEngine != nil && lic.LicenseKey != "" {
+		if err := b.LicenseEngine.LoadLicense(lic.LicenseKey); err != nil {
+			slog.Warn("failed to reload license into engine after addon purchase", "error", err)
+		}
+	}
+
+	slog.Info("addon purchased", "license_id", lic.ID, "addon_key", addonKey, "amount", amount)
+
+	return map[string]interface{}{
+		"message":    "addon purchased",
+		"license_id": lic.ID,
+		"addon":      newAddon,
+	}, nil
+}
+
+// LoadLicenseFromDB loads the active license from the database into the engine.
+func (b *Bridge) LoadLicenseFromDB(ctx context.Context) error {
+	if b.LicenseEngine == nil {
+		return nil
+	}
+
+	var lic model.License
+	if err := b.DB.Where("status = ?", model.LicenseStatusActive).First(&lic).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			slog.Info("no active license found in database")
+			return nil
+		}
+		return fmt.Errorf("failed to query active license: %w", err)
+	}
+
+	if lic.LicenseKey == "" {
+		slog.Info("active license has no key, skipping engine load")
+		return nil
+	}
+
+	if err := b.LicenseEngine.LoadLicense(lic.LicenseKey); err != nil {
+		slog.Warn("failed to load license from DB into engine", "error", err)
+		return nil // non-fatal: license might have been signed with a different key
+	}
+
+	slog.Info("license loaded from database", "tier", lic.Tier, "use_type", lic.UseType)
+	return nil
+}
+
+// InitLicenseEngine initializes the license engine with the given public key.
+func (b *Bridge) InitLicenseEngine(publicKey ed25519.PublicKey, graceDays int) {
+	b.LicenseEngine = license.NewEngine(publicKey, graceDays)
+}
+
+// SetLicensePrivateKey sets the private key for license issuance (developer mode).
+func (b *Bridge) SetLicensePrivateKey(privKey ed25519.PrivateKey) {
+	b.LicensePrivKey = privKey
+}
+
+// ResolveTierFeaturesForTier resolves features for a given tier.
+// This is a service-layer helper since the license package's resolveTierFeatures is unexported.
+func ResolveTierFeaturesForTier(tier string) map[license.Feature]bool {
+	features := make(map[license.Feature]bool, len(license.AllFeatures))
+
+	switch license.Tier(tier) {
+	case license.TierCommunity, license.TierEnterprise:
+		for _, f := range license.AllFeatures {
+			features[f] = true
+		}
+	case license.TierTeam:
+		for _, f := range license.AllFeatures {
+			if !license.TeamExcludedFeatures[f] {
+				features[f] = true
+			}
+		}
+	case license.TierPro:
+		for _, f := range license.AllFeatures {
+			if !license.ProExcludedFeatures[f] {
+				features[f] = true
+			}
+		}
+	default:
+		for _, f := range license.AllFeatures {
+			features[f] = true
+		}
+	}
+	return features
+}
+
+// LoadPublicKeyFromFileOrBase64 loads an Ed25519 public key from a file or base64 string.
+func LoadPublicKeyFromFileOrBase64(file string, base64Str string) (ed25519.PublicKey, error) {
+	if base64Str != "" {
+		keyBytes, err := base64.StdEncoding.DecodeString(base64Str)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode public key base64: %w", err)
+		}
+		if len(keyBytes) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("invalid public key size: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+		}
+		return ed25519.PublicKey(keyBytes), nil
+	}
+
+	if file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read public key file: %w", err)
+		}
+
+		// Try PEM format first
+		block, _ := pem.Decode(data)
+		if block != nil && len(block.Bytes) == ed25519.PublicKeySize {
+			return ed25519.PublicKey(block.Bytes), nil
+		}
+
+		// Try raw base64
+		keyBytes, err := base64.StdEncoding.DecodeString(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode public key file content: %w", err)
+		}
+		if len(keyBytes) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("invalid public key size from file: got %d, want %d", len(keyBytes), ed25519.PublicKeySize)
+		}
+		return ed25519.PublicKey(keyBytes), nil
+	}
+
+	return nil, fmt.Errorf("no public key configured (set license.public_key_file or license.public_key_base64)")
+}


### PR DESCRIPTION
## v1.8: License API & CLI

Closes #149

### License Service (Bridge)
- `ActivateLicense` — License Key 验证激活 / Community 自动激活
- `DeactivateLicense` — 停用当前许可证
- `GetLicenseStatus` — 查询当前许可证状态
- `IssueLicense` — 签发新许可证（Developer/Distributor）
- `ListIssuedLicenses` — 列出已签发许可证
- `RevokeLicense` — 撤销许可证
- `PurchaseAddon` — 购买增购功能/资源

### API Endpoints (7个)
- `GET /api/v1/license/status` — 查询状态
- `POST /api/v1/license/activate` — 激活（Key 或 Community）
- `POST /api/v1/license/deactivate` — 停用
- `POST /api/v1/license/issue` — 签发（owner only）
- `GET /api/v1/license/list` — 列表（owner only）
- `POST /api/v1/license/:id/revoke` — 撤销（owner only）
- `POST /api/v1/license/addon` — 增购

### CLI Keygen Tool (`cmd/license/`)
- `deploypilot license issue` — 签发许可证
- `deploypilot license verify` — 验证许可证
- `deploypilot license generate-keys` — 生成密钥对

### Startup Init
- 自动加载公钥 → 初始化引擎 → 从 DB 加载已有许可证