### PR TITLE
fix(docker): upgrade Go 1.23.6→1.24.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY web/ ./
 RUN npm run build
 
 # Stage 2: Build Go backend
-FROM --platform=$BUILDPLATFORM golang:1.23.6 AS backend
+FROM --platform=$BUILDPLATFORM golang:1.24.0 AS backend
 
 # Install xx for cross-compilation support
 COPY --from=tonistiigi/xx / /


### PR DESCRIPTION
## Problem

`build-and-push` CI fails with:
```
go: go.mod requires go >= 1.24.0 (running go 1.23.6; GOTOOLCHAIN=local)
```

PR #261 upgraded `go.mod` to Go 1.24 but missed the Dockerfile.

## Fix

- `Dockerfile`: `golang:1.23.6` → `golang:1.24.0`