### PR TITLE
fix(ci,security,docker): audit batch 1-3 critical fixes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,9 @@ on:
       - 'go.mod'
       - 'go.sum'
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Run Benchmarks

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,11 +3,14 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Update CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,4 +212,4 @@ jobs:
         with:
           node-version: '22'
       - run: npm install -g @commitlint/cli @commitlint/config-conventional
-      - run: echo "npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose"
+      - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Cache Go modules
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
+          CGO_ENABLED: 1
           VERSION: ${{ github.ref_name }}
           GIT_COMMIT: ${{ github.sha }}
           BUILD_TIME: ${{ needs.build-binaries.result != 'skipped' && steps.build.outputs.build_time || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: "1.24"
 
       - name: Cache Go modules
         uses: actions/cache@v5

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -16,7 +16,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync docs/wiki to GitHub Wiki
         uses: spenserblack/actions-wiki@v0.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,9 @@ COPY --from=backend /mcp-server .
 # Change ownership to non-root user
 RUN chown -R appuser:appuser /app
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:8080/api/v1/system/health || exit 1
+
 USER appuser
 
 EXPOSE 8080

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -107,6 +107,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		}
 	}
 
+	// Public health check endpoint (no auth required for Docker healthcheck)
+	api.GET("/system/health", SystemHealth(db))
+
 	// Protected routes (JWT or API Key)
 	protected := api.Group("")
 	protected.Use(auth.APIKeyMiddleware(keySvc))
@@ -446,10 +449,7 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			system.PUT("/security/config", auth.RoleRequired("owner", "admin"), UpdateSecurityConfig())
 		}
 
-	// Public health check endpoint (no auth required for Docker healthcheck)
-	api.GET("/system/health", SystemHealth(db))
-
-		// Deployments (2 endpoints)
+	// Deployments (2 endpoints)
 		deployments := protected.Group("/deployments")
 		{
 			deployments.GET("", ListDeployments(db))

--- a/internal/engine/builder/builder.go
+++ b/internal/engine/builder/builder.go
@@ -8,12 +8,8 @@ import (
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
-
-// shellQuote safely escapes a string for use in a shell command.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
-}
 
 // BuildConfig holds parameters for a build operation.
 type BuildConfig struct {
@@ -115,7 +111,7 @@ func (b *Builder) BuildAndDeploy(ctx context.Context, cfg BuildConfig) (*BuildRe
 	dockerfile := tmpl.GenerateDockerfile(cfg.DockerfileOverrides)
 
 	// Write Dockerfile to project dir
-	_, err = b.executor.RunCommand(ctx, fmt.Sprintf("cat > %s/Dockerfile << 'DEPLOYPilot_EOF'\n%s\nDEPLOYPilot_EOF", shellQuote(cfg.ProjectDir), dockerfile))
+	_, err = b.executor.RunCommand(ctx, fmt.Sprintf("cat > %s/Dockerfile << 'DEPLOYPilot_EOF'\n%s\nDEPLOYPilot_EOF", util.ShellQuote(cfg.ProjectDir), dockerfile))
 	if err != nil {
 		return nil, fmt.Errorf("failed to write Dockerfile: %w", err)
 	}
@@ -132,7 +128,7 @@ func (b *Builder) BuildAndDeploy(ctx context.Context, cfg BuildConfig) (*BuildRe
 	}
 
 	// 6. Get image digest
-	digest, _ := b.executor.RunCommand(ctx, fmt.Sprintf("docker inspect --format='{{.Id}}' %s 2>/dev/null", shellQuote(imageTag)))
+	digest, _ := b.executor.RunCommand(ctx, fmt.Sprintf("docker inspect --format='{{.Id}}' %s 2>/dev/null", util.ShellQuote(imageTag)))
 
 	duration := time.Since(start).Seconds()
 
@@ -161,24 +157,24 @@ func (b *Builder) BuildAndDeploy(ctx context.Context, cfg BuildConfig) (*BuildRe
 // gitClone clones or pulls a git repository.
 func (b *Builder) gitClone(ctx context.Context, cfg BuildConfig) (string, error) {
 	// Check if directory exists
-	output, _ := b.executor.RunCommand(ctx, fmt.Sprintf("test -d %s/.git && echo 'exists'", shellQuote(cfg.ProjectDir)))
+	output, _ := b.executor.RunCommand(ctx, fmt.Sprintf("test -d %s/.git && echo 'exists'", util.ShellQuote(cfg.ProjectDir)))
 
 	if strings.TrimSpace(output) == "exists" {
 		// Pull latest
-		_, err := b.executor.RunCommand(ctx, fmt.Sprintf("cd %s && git fetch origin && git checkout %s && git pull origin %s", shellQuote(cfg.ProjectDir), shellQuote(cfg.Branch), shellQuote(cfg.Branch)))
+		_, err := b.executor.RunCommand(ctx, fmt.Sprintf("cd %s && git fetch origin && git checkout %s && git pull origin %s", util.ShellQuote(cfg.ProjectDir), util.ShellQuote(cfg.Branch), util.ShellQuote(cfg.Branch)))
 		if err != nil {
 			return "", fmt.Errorf("git pull failed: %w", err)
 		}
 	} else {
 		// Clone
-		_, err := b.executor.RunCommand(ctx, fmt.Sprintf("mkdir -p %s && git clone --branch %s --depth 1 %s %s", shellQuote(cfg.ProjectDir), shellQuote(cfg.Branch), shellQuote(cfg.RepoURL), shellQuote(cfg.ProjectDir)))
+		_, err := b.executor.RunCommand(ctx, fmt.Sprintf("mkdir -p %s && git clone --branch %s --depth 1 %s %s", util.ShellQuote(cfg.ProjectDir), util.ShellQuote(cfg.Branch), util.ShellQuote(cfg.RepoURL), util.ShellQuote(cfg.ProjectDir)))
 		if err != nil {
 			return "", fmt.Errorf("git clone failed: %w", err)
 		}
 	}
 
 	// Get commit hash
-	hash, err := b.executor.RunCommand(ctx, fmt.Sprintf("cd %s && git rev-parse HEAD", shellQuote(cfg.ProjectDir)))
+	hash, err := b.executor.RunCommand(ctx, fmt.Sprintf("cd %s && git rev-parse HEAD", util.ShellQuote(cfg.ProjectDir)))
 	if err != nil {
 		return "", fmt.Errorf("failed to get commit hash: %w", err)
 	}
@@ -188,11 +184,11 @@ func (b *Builder) gitClone(ctx context.Context, cfg BuildConfig) (string, error)
 
 // dockerBuild executes docker build.
 func (b *Builder) dockerBuild(ctx context.Context, projectDir, imageTag string, buildArgs map[string]string) (string, error) {
-	cmd := fmt.Sprintf("docker build -t %s", shellQuote(imageTag))
+	cmd := fmt.Sprintf("docker build -t %s", util.ShellQuote(imageTag))
 	for k, v := range buildArgs {
-		cmd += fmt.Sprintf(" --build-arg %s=%s", shellQuote(k), shellQuote(v))
+		cmd += fmt.Sprintf(" --build-arg %s=%s", util.ShellQuote(k), util.ShellQuote(v))
 	}
-	cmd += fmt.Sprintf(" %s", shellQuote(projectDir))
+	cmd += fmt.Sprintf(" %s", util.ShellQuote(projectDir))
 
 	output, err := b.executor.RunCommand(ctx, cmd)
 	return output, err

--- a/internal/engine/deployer/compose.go
+++ b/internal/engine/deployer/compose.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // ComposeDeployer handles docker-compose deployments.
@@ -19,7 +20,7 @@ func NewComposeDeployer(executor CommandExecutor) *ComposeDeployer {
 // ComposeUp writes a compose file and runs docker-compose up -d.
 func (d *ComposeDeployer) ComposeUp(ctx context.Context, workDir, composeContent string, envVars map[string]string) (string, error) {
 	// Write compose file
-	writeCmd := fmt.Sprintf("mkdir -p %s && cat > %s/docker-compose.yml << 'DEPLOYPILOT_COMPOSE_EOF'\n%s\nDEPLOYPILOT_COMPOSE_EOF", workDir, workDir, composeContent)
+	writeCmd := fmt.Sprintf("mkdir -p %s && cat > %s/docker-compose.yml << 'DEPLOYPILOT_COMPOSE_EOF'\n%s\nDEPLOYPILOT_COMPOSE_EOF", util.ShellQuote(workDir), util.ShellQuote(workDir), composeContent)
 	if out, err := d.executor.RunCommand(ctx, writeCmd); err != nil {
 		return "", fmt.Errorf("failed to write compose file: %w, output: %s", err, out)
 	}
@@ -35,7 +36,7 @@ func (d *ComposeDeployer) ComposeUp(ctx context.Context, workDir, composeContent
 	}
 
 	// Run docker-compose up -d
-	cmd := fmt.Sprintf("cd %s && %sdocker-compose up -d --remove-orphans 2>&1", workDir, envCmd)
+	cmd := fmt.Sprintf("cd %s && %sdocker-compose up -d --remove-orphans 2>&1", util.ShellQuote(workDir), envCmd)
 	out, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return out, fmt.Errorf("docker-compose up failed: %w", err)
@@ -45,7 +46,7 @@ func (d *ComposeDeployer) ComposeUp(ctx context.Context, workDir, composeContent
 
 // ComposeDown stops and removes containers defined in compose file.
 func (d *ComposeDeployer) ComposeDown(ctx context.Context, workDir string) (string, error) {
-	cmd := fmt.Sprintf("cd %s && docker-compose down --remove-orphans 2>&1", workDir)
+	cmd := fmt.Sprintf("cd %s && docker-compose down --remove-orphans 2>&1", util.ShellQuote(workDir))
 	out, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return out, fmt.Errorf("docker-compose down failed: %w", err)
@@ -55,7 +56,7 @@ func (d *ComposeDeployer) ComposeDown(ctx context.Context, workDir string) (stri
 
 // ComposePs lists containers managed by docker-compose.
 func (d *ComposeDeployer) ComposePs(ctx context.Context, workDir string) (string, error) {
-	cmd := fmt.Sprintf("cd %s && docker-compose ps --format 'table {{.Name}}\t{{.State}}\t{{.Ports}}' 2>&1", workDir)
+	cmd := fmt.Sprintf("cd %s && docker-compose ps --format 'table {{.Name}}\t{{.State}}\t{{.Ports}}' 2>&1", util.ShellQuote(workDir))
 	out, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return out, fmt.Errorf("docker-compose ps failed: %w", err)
@@ -65,7 +66,7 @@ func (d *ComposeDeployer) ComposePs(ctx context.Context, workDir string) (string
 
 // ComposeLogs fetches logs from compose services.
 func (d *ComposeDeployer) ComposeLogs(ctx context.Context, workDir, service, tail string) (string, error) {
-	cmd := fmt.Sprintf("cd %s && docker-compose logs", workDir)
+	cmd := fmt.Sprintf("cd %s && docker-compose logs", util.ShellQuote(workDir))
 	if service != "" {
 		cmd += " " + service
 	}
@@ -82,7 +83,7 @@ func (d *ComposeDeployer) ComposeLogs(ctx context.Context, workDir, service, tai
 
 // ComposeRestart restarts compose services.
 func (d *ComposeDeployer) ComposeRestart(ctx context.Context, workDir, service string) (string, error) {
-	cmd := fmt.Sprintf("cd %s && docker-compose restart", workDir)
+	cmd := fmt.Sprintf("cd %s && docker-compose restart", util.ShellQuote(workDir))
 	if service != "" {
 		cmd += " " + service
 	}

--- a/internal/engine/deployer/deployer.go
+++ b/internal/engine/deployer/deployer.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // CommandExecutor abstracts SSH command execution for testability.
@@ -72,13 +73,13 @@ func (d *DockerDeployer) Deploy(ctx context.Context, cfg DeployConfig) (*Contain
 	}
 
 	// Step 1: Pull image
-	pullCmd := fmt.Sprintf("docker pull %s", cfg.Image)
+	pullCmd := fmt.Sprintf("docker pull %s", util.ShellQuote(cfg.Image))
 	if _, err := d.executor.RunCommand(ctx, pullCmd); err != nil {
 		return nil, fmt.Errorf("failed to pull image %s: %w", cfg.Image, err)
 	}
 
 	// Step 2: Remove existing container with same name (if any)
-	_, _ = d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s 2>/dev/null || true", cfg.ContainerName))
+	_, _ = d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s 2>/dev/null || true", util.ShellQuote(cfg.ContainerName)))
 
 	// Step 3: Build docker run command
 	runCmd := d.buildRunCommand(cfg)
@@ -112,7 +113,7 @@ func (d *DockerDeployer) Deploy(ctx context.Context, cfg DeployConfig) (*Contain
 
 // GetContainerStatus returns the status of a container by name.
 func (d *DockerDeployer) GetContainerStatus(ctx context.Context, name string) (*ContainerStatus, error) {
-	cmd := fmt.Sprintf("docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' %s 2>/dev/null", name)
+	cmd := fmt.Sprintf("docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' %s 2>/dev/null", util.ShellQuote(name))
 	output, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inspect container %s: %w", name, err)
@@ -144,7 +145,7 @@ func (d *DockerDeployer) GetContainerStatus(ctx context.Context, name string) (*
 
 // Stop stops a running container.
 func (d *DockerDeployer) Stop(ctx context.Context, name string) error {
-	_, err := d.executor.RunCommand(ctx, fmt.Sprintf("docker stop %s", name))
+	_, err := d.executor.RunCommand(ctx, fmt.Sprintf("docker stop %s", util.ShellQuote(name)))
 	if err != nil {
 		return fmt.Errorf("failed to stop container %s: %w", name, err)
 	}
@@ -153,7 +154,7 @@ func (d *DockerDeployer) Stop(ctx context.Context, name string) error {
 
 // Remove removes a container.
 func (d *DockerDeployer) Remove(ctx context.Context, name string) error {
-	_, err := d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s", name))
+	_, err := d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s", util.ShellQuote(name)))
 	if err != nil {
 		return fmt.Errorf("failed to remove container %s: %w", name, err)
 	}
@@ -162,7 +163,7 @@ func (d *DockerDeployer) Remove(ctx context.Context, name string) error {
 
 // GetContainerLogs returns logs for a container.
 func (d *DockerDeployer) GetContainerLogs(ctx context.Context, name string, tail int) (string, error) {
-	cmd := fmt.Sprintf("docker logs --tail %d %s 2>&1", tail, name)
+	cmd := fmt.Sprintf("docker logs --tail %d %s 2>&1", tail, util.ShellQuote(name))
 	output, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return "", fmt.Errorf("failed to get logs for %s: %w", name, err)
@@ -215,49 +216,49 @@ func (d *DockerDeployer) buildRunCommand(cfg DeployConfig) string {
 	args = append(args, "docker run -d")
 
 	// Container name
-	args = append(args, fmt.Sprintf("--name %s", cfg.ContainerName))
+	args = append(args, fmt.Sprintf("--name %s", util.ShellQuote(cfg.ContainerName)))
 
 	// Restart policy
 	if cfg.RestartPolicy == "" {
 		cfg.RestartPolicy = "unless-stopped"
 	}
-	args = append(args, fmt.Sprintf("--restart %s", cfg.RestartPolicy))
+	args = append(args, fmt.Sprintf("--restart %s", util.ShellQuote(cfg.RestartPolicy)))
 
 	// Ports
 	if cfg.Ports != "" {
-		args = append(args, fmt.Sprintf("-p %s", cfg.Ports))
+		args = append(args, fmt.Sprintf("-p %s", util.ShellQuote(cfg.Ports)))
 	}
 
 	// Volumes
 	if cfg.Volumes != "" {
-		args = append(args, fmt.Sprintf("-v %s", cfg.Volumes))
+		args = append(args, fmt.Sprintf("-v %s", util.ShellQuote(cfg.Volumes)))
 	}
 
 	// Environment variables
 	for k, v := range cfg.EnvVars {
-		args = append(args, fmt.Sprintf("-e %s=%s", k, v))
+		args = append(args, fmt.Sprintf("-e %s=%s", util.ShellQuote(k), util.ShellQuote(v)))
 	}
 
 	// Labels
 	for k, v := range cfg.Labels {
-		args = append(args, fmt.Sprintf("-l %s=%s", k, v))
+		args = append(args, fmt.Sprintf("-l %s=%s", util.ShellQuote(k), util.ShellQuote(v)))
 	}
 
 	// Resource limits
 	if cfg.CPU != "" {
-		args = append(args, fmt.Sprintf("--cpus %s", cfg.CPU))
+		args = append(args, fmt.Sprintf("--cpus %s", util.ShellQuote(cfg.CPU)))
 	}
 	if cfg.Memory != "" {
-		args = append(args, fmt.Sprintf("--memory %s", cfg.Memory))
+		args = append(args, fmt.Sprintf("--memory %s", util.ShellQuote(cfg.Memory)))
 	}
 
 	// Network
 	if cfg.Network != "" {
-		args = append(args, fmt.Sprintf("--network %s", cfg.Network))
+		args = append(args, fmt.Sprintf("--network %s", util.ShellQuote(cfg.Network)))
 	}
 
 	// Image
-	args = append(args, cfg.Image)
+	args = append(args, util.ShellQuote(cfg.Image))
 
 	return strings.Join(args, " ")
 }
@@ -291,7 +292,7 @@ type ContainerDetail struct {
 func (d *DockerDeployer) GetContainerDetail(ctx context.Context, name string) (*ContainerDetail, error) {
 	cmd := fmt.Sprintf(
 		`docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' %s 2>/dev/null`,
-		name,
+		util.ShellQuote(name),
 	)
 	output, err := d.executor.RunCommand(ctx, cmd)
 	if err != nil || output == "" {
@@ -316,7 +317,7 @@ func (d *DockerDeployer) GetContainerDetail(ctx context.Context, name string) (*
 
 	// Get restart count separately
 	restartCount := 0
-	restartCmd := fmt.Sprintf("docker inspect --format '{{.RestartCount}}' %s 2>/dev/null", name)
+	restartCmd := fmt.Sprintf("docker inspect --format '{{.RestartCount}}' %s 2>/dev/null", util.ShellQuote(name))
 	if restartOut, err := d.executor.RunCommand(ctx, restartCmd); err == nil {
 		restartCount, _ = strconv.Atoi(strings.TrimSpace(restartOut))
 	}

--- a/internal/engine/deployer/deployer_test.go
+++ b/internal/engine/deployer/deployer_test.go
@@ -30,9 +30,32 @@ func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error)
 
 	m.calls = append(m.calls, cmd)
 
+	// Check for exact error match
+	if m.errors != nil {
+		if err, ok := m.errors[cmd]; ok {
+			return "", err
+		}
+	}
+
 	// Check for prefix matches
 	for pattern, output := range m.responses {
 		if strings.Contains(cmd, pattern) {
+			if err, ok := m.errors[pattern]; ok {
+				return output, err
+			}
+			return output, nil
+		}
+	}
+
+	// Fallback: try with quotes stripped (util.ShellQuote wraps args in single quotes)
+	normalized := strings.ReplaceAll(cmd, "'", "")
+	if m.errors != nil {
+		if err, ok := m.errors[normalized]; ok {
+			return "", err
+		}
+	}
+	for pattern, output := range m.responses {
+		if strings.Contains(normalized, pattern) {
 			if err, ok := m.errors[pattern]; ok {
 				return output, err
 			}
@@ -168,10 +191,10 @@ func TestDeployWithEnvVars(t *testing.T) {
 
 	// Verify env vars are in the run command
 	runCmd := mock.getCall(2) // 0=pull, 1=rm, 2=run
-	if !strings.Contains(runCmd, "-e DB_HOST=localhost") {
+	if !strings.Contains(runCmd, "-e 'DB_HOST'='localhost'") {
 		t.Errorf("run command missing env var, got: %s", runCmd)
 	}
-	if !strings.Contains(runCmd, "-e DB_PORT=5432") {
+	if !strings.Contains(runCmd, "-e 'DB_PORT'='5432'") {
 		t.Errorf("run command missing env var, got: %s", runCmd)
 	}
 }
@@ -196,7 +219,7 @@ func TestDeployWithLabels(t *testing.T) {
 	}
 
 	runCmd := mock.getCall(2)
-	if !strings.Contains(runCmd, "-l app=myapp") {
+	if !strings.Contains(runCmd, "-l 'app'='myapp'") {
 		t.Errorf("run command missing label, got: %s", runCmd)
 	}
 }
@@ -221,10 +244,10 @@ func TestDeployWithResourceLimits(t *testing.T) {
 	}
 
 	runCmd := mock.getCall(2)
-	if !strings.Contains(runCmd, "--cpus 2") {
+	if !strings.Contains(runCmd, "--cpus '2'") {
 		t.Errorf("run command missing CPU limit, got: %s", runCmd)
 	}
-	if !strings.Contains(runCmd, "--memory 4GB") {
+	if !strings.Contains(runCmd, "--memory '4GB'") {
 		t.Errorf("run command missing memory limit, got: %s", runCmd)
 	}
 }
@@ -411,7 +434,7 @@ func TestBuildRunCommandBasic(t *testing.T) {
 
 	cmd := d.buildRunCommand(cfg)
 
-	expected := []string{"docker run -d", "--name my-app", "--restart unless-stopped", "-p 8080:80", "nginx:latest"}
+	expected := []string{"docker run -d", "--name 'my-app'", "--restart 'unless-stopped'", "-p '8080:80'", "'nginx:latest'"}
 	for _, exp := range expected {
 		if !strings.Contains(cmd, exp) {
 			t.Errorf("buildRunCommand() missing %q, got: %s", exp, cmd)
@@ -430,7 +453,7 @@ func TestBuildRunCommandWithNetwork(t *testing.T) {
 	}
 
 	cmd := d.buildRunCommand(cfg)
-	if !strings.Contains(cmd, "--network my-network") {
+	if !strings.Contains(cmd, "--network 'my-network'") {
 		t.Errorf("buildRunCommand() missing network, got: %s", cmd)
 	}
 }
@@ -509,7 +532,7 @@ func TestBuildRunCommand_DefaultRestartPolicy(t *testing.T) {
 	}
 
 	cmd := d.buildRunCommand(cfg)
-	if !strings.Contains(cmd, "--restart unless-stopped") {
+	if !strings.Contains(cmd, "--restart 'unless-stopped'") {
 		t.Errorf("expected default restart policy, got: %s", cmd)
 	}
 }
@@ -525,7 +548,7 @@ func TestBuildRunCommand_WithVolumes(t *testing.T) {
 	}
 
 	cmd := d.buildRunCommand(cfg)
-	if !strings.Contains(cmd, "-v /host/data:/container/data") {
+	if !strings.Contains(cmd, "-v '/host/data:/container/data'") {
 		t.Errorf("expected volume mapping, got: %s", cmd)
 	}
 }
@@ -644,11 +667,11 @@ func TestStop_Error(t *testing.T) {
 
 func TestGetContainerDetail_Success(t *testing.T) {
 	mock := newMockExecutor()
-	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' my-app 2>/dev/null`
+	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' 'my-app' 2>/dev/null`
 	mock.responses[inspectCmd] = "true|1|false|1234|2024-01-01T00:00:00Z|2024-01-01T01:00:00Z|healthy"
-	restartCmd := "docker inspect --format '{{.RestartCount}}' my-app 2>/dev/null"
+	restartCmd := "docker inspect --format '{{.RestartCount}}' 'my-app' 2>/dev/null"
 	mock.responses[restartCmd] = "3"
-	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' my-app 2>/dev/null"
+	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' 'my-app' 2>/dev/null"
 	mock.responses[statusCmd] = "abc123|my-app|nginx:latest|running|2024-01-01T00:00:00Z"
 
 	d := New(mock)
@@ -686,9 +709,9 @@ func TestGetContainerDetail_NotFound(t *testing.T) {
 
 func TestGetContainerDetail_InvalidFormat(t *testing.T) {
 	mock := newMockExecutor()
-	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' bad-format 2>/dev/null`
+	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' 'bad-format' 2>/dev/null`
 	mock.responses[inspectCmd] = "only-two-parts"
-	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' bad-format 2>/dev/null"
+	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' 'bad-format' 2>/dev/null"
 	mock.responses[statusCmd] = "running|abc123|my-app|nginx:latest|2024-01-01T00:00:00Z"
 
 	d := New(mock)
@@ -700,11 +723,11 @@ func TestGetContainerDetail_InvalidFormat(t *testing.T) {
 
 func TestGetContainerDetail_NilHealth(t *testing.T) {
 	mock := newMockExecutor()
-	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' my-app 2>/dev/null`
+	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' 'my-app' 2>/dev/null`
 	mock.responses[inspectCmd] = "false|0|false|1234|2024-01-01T00:00:00Z|2024-01-01T00:00:00Z|<nil>"
-	restartCmd := "docker inspect --format '{{.RestartCount}}' my-app 2>/dev/null"
+	restartCmd := "docker inspect --format '{{.RestartCount}}' 'my-app' 2>/dev/null"
 	mock.responses[restartCmd] = "0"
-	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' my-app 2>/dev/null"
+	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' 'my-app' 2>/dev/null"
 	mock.responses[statusCmd] = "abc123|my-app|nginx:latest|running|2024-01-01T00:00:00Z"
 
 	d := New(mock)
@@ -719,9 +742,9 @@ func TestGetContainerDetail_NilHealth(t *testing.T) {
 
 func TestGetContainerDetail_StatusError(t *testing.T) {
 	mock := newMockExecutor()
-	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' status-fail 2>/dev/null`
+	inspectCmd := `docker inspect --format '{{.State.OOMKilled}}|{{.State.ExitCode}}|{{.State.Restarting}}|{{.State.Pid}}|{{.State.StartedAt}}|{{.State.FinishedAt}}|{{.State.Health.Status}}' 'status-fail' 2>/dev/null`
 	mock.responses[inspectCmd] = "false|0|false|1234|2024-01-01T00:00:00Z|2024-01-01T00:00:00Z|none"
-	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' status-fail 2>/dev/null"
+	statusCmd := "docker inspect --format '{{.Id}}|{{.Name}}|{{.Config.Image}}|{{.State.Status}}|{{.Created}}' 'status-fail' 2>/dev/null"
 	mock.errors[statusCmd] = fmt.Errorf("status error")
 
 	d := New(mock)

--- a/internal/engine/deployer/logs.go
+++ b/internal/engine/deployer/logs.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // LogEntry represents a single log line from a container.
@@ -78,7 +80,7 @@ func NewLogReader(executor CommandExecutor) *LogReader {
 
 // GetHistory retrieves historical logs for a container.
 func (lr *LogReader) GetHistory(ctx context.Context, containerName string, tail int) ([]LogEntry, error) {
-	cmd := fmt.Sprintf("docker logs --tail %d %s 2>&1", tail, containerName)
+	cmd := fmt.Sprintf("docker logs --tail %d %s 2>&1", tail, util.ShellQuote(containerName))
 	output, err := lr.executor.RunCommand(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logs: %w", err)
@@ -90,7 +92,7 @@ func (lr *LogReader) GetHistory(ctx context.Context, containerName string, tail 
 // StreamLogs streams logs in real-time using docker logs --follow.
 // It writes entries to the provided LogStream until context is cancelled.
 func (lr *LogReader) StreamLogs(ctx context.Context, containerName string, stream *LogStream) error {
-	cmd := fmt.Sprintf("docker logs --follow --tail 0 %s 2>&1", containerName)
+	cmd := fmt.Sprintf("docker logs --follow --tail 0 %s 2>&1", util.ShellQuote(containerName))
 
 	// In production, this would use an SSH session with stdin/stdout pipes.
 	// For now, we simulate by running the command and parsing output.

--- a/internal/engine/healer/healer.go
+++ b/internal/engine/healer/healer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // HealingConfig configures the self-healing behavior.
@@ -242,7 +243,7 @@ func (h *Healer) CheckAndHeal(ctx context.Context, containerName string) (*Heali
 
 // RestartContainer restarts a container.
 func (h *Healer) RestartContainer(ctx context.Context, name string) error {
-	_, err := h.executor.RunCommand(ctx, fmt.Sprintf("docker restart %s", name))
+	_, err := h.executor.RunCommand(ctx, fmt.Sprintf("docker restart %s", util.ShellQuote(name)))
 	if err != nil {
 		return fmt.Errorf("failed to restart container %s: %w", name, err)
 	}

--- a/internal/engine/healer/healer_test.go
+++ b/internal/engine/healer/healer_test.go
@@ -26,6 +26,16 @@ func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error)
 			return output, nil
 		}
 	}
+	// Fallback: try with quotes stripped (util.ShellQuote wraps args in single quotes)
+	normalized := strings.ReplaceAll(cmd, "'", "")
+	if err, ok := m.errs[normalized]; ok {
+		return "", err
+	}
+	for pattern, output := range m.responses {
+		if strings.Contains(normalized, pattern) {
+			return output, nil
+		}
+	}
 	return "", fmt.Errorf("no matching command: %s", cmd)
 }
 

--- a/internal/service/backup_service.go
+++ b/internal/service/backup_service.go
@@ -6,19 +6,14 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
 	"github.com/Yogdunana/deploypilot/internal/mcp"
 	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"github.com/google/uuid"
 )
-
-// shellQuote safely escapes a string for use in a shell command.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
-}
 
 // ---------- 35. Backup ----------
 
@@ -38,7 +33,7 @@ func (b *Bridge) Backup(ctx context.Context, appID string) (string, error) {
 	// Attempt a docker-based backup: exec into the container and create a timestamped archive
 	timestamp := time.Now().Format("20060102-150405")
 	backupFile := fmt.Sprintf("/tmp/backup-%s-%s.tar.gz", containerName, timestamp)
-	cmd := fmt.Sprintf("docker exec %s sh -c 'tar czf - /app /data 2>/dev/null' > %s 2>/dev/null || echo 'no_backup_paths'", shellQuote(containerName), shellQuote(backupFile))
+	cmd := fmt.Sprintf("docker exec %s sh -c 'tar czf - /app /data 2>/dev/null' > %s 2>/dev/null || echo 'no_backup_paths'", util.ShellQuote(containerName), util.ShellQuote(backupFile))
 	out, err := b.Executor.RunCommand(ctx, cmd)
 	if err != nil {
 		slog.Warn("backup: container exec failed (may be expected)", "error", err, "output", out)
@@ -82,10 +77,10 @@ func (b *Bridge) Restore(ctx context.Context, backupID string) (*mcp.ContainerSt
 
 	// Stop and remove current container
 	exec := b.Executor
-	if _, err := exec.RunCommand(ctx, fmt.Sprintf("docker stop %s", shellQuote(containerName))); err != nil {
+	if _, err := exec.RunCommand(ctx, fmt.Sprintf("docker stop %s", util.ShellQuote(containerName))); err != nil {
 		slog.WarnContext(ctx, "failed to stop container during restore", "container", containerName, "error", err)
 	}
-	if _, err := exec.RunCommand(ctx, fmt.Sprintf("docker rm -f %s", shellQuote(containerName))); err != nil {
+	if _, err := exec.RunCommand(ctx, fmt.Sprintf("docker rm -f %s", util.ShellQuote(containerName))); err != nil {
 		slog.WarnContext(ctx, "failed to remove container during restore", "container", containerName, "error", err)
 	}
 
@@ -93,7 +88,7 @@ func (b *Bridge) Restore(ctx context.Context, backupID string) (*mcp.ContainerSt
 	timestamp := time.Now().Format("20060102-150405")
 	backupFile := fmt.Sprintf("/tmp/backup-%s-%s.tar.gz", containerName, timestamp)
 	cmd := fmt.Sprintf("docker run --rm -v /tmp:/backup -v %s-data:/data alpine sh -c 'cd /data && tar xzf /backup/%s 2>/dev/null || true'",
-		shellQuote(containerName), shellQuote(filepath.Base(backupFile)))
+		util.ShellQuote(containerName), util.ShellQuote(filepath.Base(backupFile)))
 	output, err := exec.RunCommand(ctx, cmd)
 	if err != nil {
 		slog.Warn("restore extract warning", "error", err, "output", output)

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/plugin"
 	"github.com/Yogdunana/deploypilot/internal/provider/server"
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"golang.org/x/crypto/ssh"
 	"gorm.io/gorm"
 )
@@ -709,7 +710,7 @@ func (b *Bridge) ExecCommand(ctx context.Context, serverID, command string, time
 func (b *Bridge) ListImages(ctx context.Context, serverID, filter string) (string, error) {
 	dockerCmd := `docker images --format "{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}"`
 	if filter != "" {
-		dockerCmd += " | grep " + shellQuote(filter)
+		dockerCmd += " | grep " + util.ShellQuote(filter)
 	}
 
 	execCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
@@ -793,7 +794,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 		}
 
 		sshCmd := fmt.Sprintf("ssh -N -L %d:%s:%d -p %d %s@%s",
-			localPort, remoteHost, remotePort, port, username, host)
+			localPort, remoteHost, remotePort, port, util.ShellQuote(username), util.ShellQuote(host))
 
 		// Execute SSH tunnel in background
 		execCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
@@ -812,7 +813,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 			}()
 
 			tunnelCmd := fmt.Sprintf("ssh -f -N -L %d:%s:%d -p %d %s@%s",
-				localPort, remoteHost, remotePort, port, username, host)
+				localPort, remoteHost, remotePort, port, util.ShellQuote(username), util.ShellQuote(host))
 			if _, err := remoteExec.RunCommand(execCtx, tunnelCmd); err != nil {
 				slog.Error("SSH tunnel command failed", "error", err)
 			}
@@ -847,7 +848,7 @@ func (b *Bridge) PortForward(ctx context.Context, action, serverID string, local
 		}
 
 		// Kill the SSH tunnel process
-		killCmd := fmt.Sprintf("pkill -f 'ssh.*-L %d:%s:%d'", localPort, shellQuote(entry.RemoteHost), entry.RemotePort)
+		killCmd := fmt.Sprintf("pkill -f 'ssh.*-L %d:%s:%d'", localPort, util.ShellQuote(entry.RemoteHost), entry.RemotePort)
 		if _, err := b.Executor.RunCommand(ctx, killCmd); err != nil {
 			slog.Warn("failed to kill SSH tunnel process", "error", err)
 		}

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -27,15 +27,21 @@ func normalizeCmd(cmd string) string {
 }
 
 func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error) {
-	// Strip single quotes from both cmd and keys for matching
-	// (util.ShellQuote wraps args in single quotes)
+	// util.ShellQuote wraps args in single quotes, e.g. "docker inspect 'name'"
+	// Strip quotes from cmd for matching against keys that don't have quotes.
 	nc := normalizeCmd(cmd)
 	if m.err != nil {
+		// Try exact match, then normalized cmd, then normalized key
 		if m.err[cmd] != nil {
 			return "", m.err[cmd]
 		}
 		if m.err[nc] != nil {
 			return "", m.err[nc]
+		}
+		for k, v := range m.err {
+			if normalizeCmd(k) == nc {
+				return "", v
+			}
 		}
 	}
 	if m.output != nil {
@@ -44,6 +50,11 @@ func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error)
 		}
 		if out, ok := m.output[nc]; ok {
 			return out, nil
+		}
+		for k, v := range m.output {
+			if normalizeCmd(k) == nc {
+				return v, nil
+			}
 		}
 	}
 	return "", nil

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -20,12 +20,29 @@ type mockExecutor struct {
 	err    map[string]error  // exact cmd → error
 }
 
+// normalizeCmd removes single quotes added by util.ShellQuote so that
+// mock expectations written without quotes still match.
+func normalizeCmd(cmd string) string {
+	return strings.ReplaceAll(cmd, "'", "")
+}
+
 func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error) {
+	// Try exact match first
 	if m.err != nil && m.err[cmd] != nil {
 		return "", m.err[cmd]
 	}
 	if m.output != nil {
 		if out, ok := m.output[cmd]; ok {
+			return out, nil
+		}
+	}
+	// Fallback: try with quotes stripped (util.ShellQuote wraps args in single quotes)
+	normalized := normalizeCmd(cmd)
+	if m.err != nil && m.err[normalized] != nil {
+		return "", m.err[normalized]
+	}
+	if m.output != nil {
+		if out, ok := m.output[normalized]; ok {
 			return out, nil
 		}
 	}

--- a/internal/service/bridge_test.go
+++ b/internal/service/bridge_test.go
@@ -27,22 +27,22 @@ func normalizeCmd(cmd string) string {
 }
 
 func (m *mockExecutor) RunCommand(_ context.Context, cmd string) (string, error) {
-	// Try exact match first
-	if m.err != nil && m.err[cmd] != nil {
-		return "", m.err[cmd]
+	// Strip single quotes from both cmd and keys for matching
+	// (util.ShellQuote wraps args in single quotes)
+	nc := normalizeCmd(cmd)
+	if m.err != nil {
+		if m.err[cmd] != nil {
+			return "", m.err[cmd]
+		}
+		if m.err[nc] != nil {
+			return "", m.err[nc]
+		}
 	}
 	if m.output != nil {
 		if out, ok := m.output[cmd]; ok {
 			return out, nil
 		}
-	}
-	// Fallback: try with quotes stripped (util.ShellQuote wraps args in single quotes)
-	normalized := normalizeCmd(cmd)
-	if m.err != nil && m.err[normalized] != nil {
-		return "", m.err[normalized]
-	}
-	if m.output != nil {
-		if out, ok := m.output[normalized]; ok {
+		if out, ok := m.output[nc]; ok {
 			return out, nil
 		}
 	}

--- a/internal/service/file_manager_service.go
+++ b/internal/service/file_manager_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"gorm.io/gorm"
 )
 
@@ -85,7 +86,7 @@ func (f *FileManagerService) ListFiles(ctx context.Context, serverID, remotePath
 		return nil, fmt.Errorf("access denied: path %s is in a restricted system directory", remotePath)
 	}
 
-	cmd := fmt.Sprintf("ls -la --time-style=long-iso %s 2>/dev/null || ls -la %s 2>/dev/null", shellQuote(remotePath), shellQuote(remotePath))
+	cmd := fmt.Sprintf("ls -la --time-style=long-iso %s 2>/dev/null || ls -la %s 2>/dev/null", util.ShellQuote(remotePath), util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -115,7 +116,7 @@ func (f *FileManagerService) ReadFile(ctx context.Context, serverID, remotePath 
 		limit = fmt.Sprintf(" | head -c %d", maxBytes)
 	}
 
-	cmd := fmt.Sprintf("cat %s%s", shellQuote(remotePath), limit)
+	cmd := fmt.Sprintf("cat %s%s", util.ShellQuote(remotePath), limit)
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -132,7 +133,7 @@ func (f *FileManagerService) ReadFile(ctx context.Context, serverID, remotePath 
 	}
 
 	// Get file size
-	sizeCmd := fmt.Sprintf("stat -c %%s %s 2>/dev/null || wc -c < %s", shellQuote(remotePath), shellQuote(remotePath))
+	sizeCmd := fmt.Sprintf("stat -c %%s %s 2>/dev/null || wc -c < %s", util.ShellQuote(remotePath), util.ShellQuote(remotePath))
 	sizeOutput, _ := exec.RunCommand(ctx, sizeCmd)
 	size, _ := strconv.ParseInt(strings.TrimSpace(sizeOutput), 10, 64)
 
@@ -151,7 +152,7 @@ func (f *FileManagerService) WriteFile(ctx context.Context, serverID, remotePath
 
 	// Use base64 encoding to safely transfer content via SSH
 	encoded := base64Encode(content)
-	cmd := fmt.Sprintf("echo '%s' | base64 -d > %s", encoded, shellQuote(remotePath))
+	cmd := fmt.Sprintf("echo '%s' | base64 -d > %s", encoded, util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -175,7 +176,7 @@ func (f *FileManagerService) DeleteFile(ctx context.Context, serverID, remotePat
 		return fmt.Errorf("access denied: path %s is in a restricted system directory", remotePath)
 	}
 
-	cmd := fmt.Sprintf("rm -rf %s", shellQuote(remotePath))
+	cmd := fmt.Sprintf("rm -rf %s", util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -199,7 +200,7 @@ func (f *FileManagerService) CreateDirectory(ctx context.Context, serverID, remo
 		return fmt.Errorf("access denied: path %s is in a restricted system directory", remotePath)
 	}
 
-	cmd := fmt.Sprintf("mkdir -p %s", shellQuote(remotePath))
+	cmd := fmt.Sprintf("mkdir -p %s", util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -223,7 +224,7 @@ func (f *FileManagerService) MoveFile(ctx context.Context, serverID, srcPath, ds
 		return fmt.Errorf("access denied: path is in a restricted system directory")
 	}
 
-	cmd := fmt.Sprintf("mv %s %s", shellQuote(srcPath), shellQuote(dstPath))
+	cmd := fmt.Sprintf("mv %s %s", util.ShellQuote(srcPath), util.ShellQuote(dstPath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -243,7 +244,7 @@ func (f *FileManagerService) MoveFile(ctx context.Context, serverID, srcPath, ds
 
 // GetDiskUsage returns disk usage information for a remote path.
 func (f *FileManagerService) GetDiskUsage(ctx context.Context, serverID, remotePath string) (*DiskUsage, error) {
-	cmd := fmt.Sprintf("df -B1 --output=size,used,avail,pcent %s 2>/dev/null | tail -1", shellQuote(remotePath))
+	cmd := fmt.Sprintf("df -B1 --output=size,used,avail,pcent %s 2>/dev/null | tail -1", util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -268,7 +269,7 @@ func (f *FileManagerService) GetFileInfo(ctx context.Context, serverID, remotePa
 		return nil, fmt.Errorf("access denied: path %s is in a restricted system directory", remotePath)
 	}
 
-	cmd := fmt.Sprintf("stat -c '%%A %%U %%G %%s %%Y' %s 2>/dev/null", shellQuote(remotePath))
+	cmd := fmt.Sprintf("stat -c '%%A %%U %%G %%s %%Y' %s 2>/dev/null", util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}
@@ -299,7 +300,7 @@ func (f *FileManagerService) SearchFiles(ctx context.Context, serverID, searchPa
 	}
 
 	cmd := fmt.Sprintf("find %s -name '*%s*' -type f%s 2>/dev/null",
-		shellQuote(searchPath), pattern, limit)
+		util.ShellQuote(searchPath), pattern, limit)
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}

--- a/internal/service/firewall_service.go
+++ b/internal/service/firewall_service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"gorm.io/gorm"
 )
 
@@ -351,25 +352,25 @@ func (f *FirewallService) getFirewalldStatus(ctx context.Context, exec *sshClien
 }
 
 func (f *FirewallService) firewalldOpenPort(ctx context.Context, exec *sshClientExecutor, port, protocol string) error {
-	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --add-port=%s/%s && sudo firewall-cmd --reload", port, protocol)
+	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --add-port=%s/%s && sudo firewall-cmd --reload", util.ShellQuote(port), util.ShellQuote(protocol))
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) firewalldClosePort(ctx context.Context, exec *sshClientExecutor, port, protocol string) error {
-	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --remove-port=%s/%s && sudo firewall-cmd --reload", port, protocol)
+	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --remove-port=%s/%s && sudo firewall-cmd --reload", util.ShellQuote(port), util.ShellQuote(protocol))
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) firewalldBlockIP(ctx context.Context, exec *sshClientExecutor, ip string) error {
-	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --add-rich-rule='rule family=ipv4 source address=%s reject' && sudo firewall-cmd --reload", ip)
+	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --add-rich-rule='rule family=ipv4 source address=%s reject' && sudo firewall-cmd --reload", util.ShellQuote(ip))
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) firewalldUnblockIP(ctx context.Context, exec *sshClientExecutor, ip string) error {
-	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --remove-rich-rule='rule family=ipv4 source address=%s reject' && sudo firewall-cmd --reload", ip)
+	cmd := fmt.Sprintf("sudo firewall-cmd --permanent --remove-rich-rule='rule family=ipv4 source address=%s reject' && sudo firewall-cmd --reload", util.ShellQuote(ip))
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -166,7 +166,9 @@ func (s *OutboundWebhookService) Deliver(ctx context.Context, webhook *model.Out
 	} else {
 		webhook.LastStatus = "failed"
 	}
-	_ = s.db.WithContext(ctx).Save(webhook)
+	if err := s.db.WithContext(ctx).Save(webhook).Error; err != nil {
+		slog.Error("failed to save webhook delivery status", "webhook_id", webhook.ID, "error", err)
+	}
 
 	// Log result
 	if delivery.Success {
@@ -252,7 +254,9 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 		delivery.LatencyMs = int(latency.Milliseconds())
 		delivery.Success = success
 		delivery.ErrorResponse = respBody
-		_ = s.db.Save(delivery)
+		if err := s.db.Save(delivery).Error; err != nil {
+			slog.Error("failed to save webhook delivery retry", "delivery_id", delivery.ID, "error", err)
+		}
 
 		// Update webhook last delivery info
 		now := time.Now()
@@ -262,7 +266,9 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 		} else {
 			webhook.LastStatus = "failed"
 		}
-		_ = s.db.Save(webhook)
+		if err := s.db.Save(webhook).Error; err != nil {
+			slog.Error("failed to save webhook after retry", "webhook_id", webhook.ID, "error", err)
+		}
 
 		if success {
 			slog.Info("webhook retry succeeded",

--- a/internal/service/process_service.go
+++ b/internal/service/process_service.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -80,7 +81,7 @@ func (p *ProcessService) ListProcesses(ctx context.Context, serverID string, fil
 	cmd := "ps aux --no-headers 2>/dev/null || ps aux 2>/dev/null"
 	if filter != "" {
 		cmd = fmt.Sprintf("ps aux --no-headers 2>/dev/null | grep -E %s | grep -v grep || ps aux 2>/dev/null | grep -E %s | grep -v grep",
-			shellQuote(filter), shellQuote(filter))
+			util.ShellQuote(filter), util.ShellQuote(filter))
 	}
 
 	output, err := exec.RunCommand(ctx, cmd)
@@ -149,7 +150,7 @@ func (p *ProcessService) SearchProcesses(ctx context.Context, serverID, pattern 
 	}
 	defer func() { _ = exec.Close() }()
 
-	cmd := fmt.Sprintf("ps aux --no-headers 2>/dev/null | grep -E %s | grep -v grep || echo ''", shellQuote(pattern))
+	cmd := fmt.Sprintf("ps aux --no-headers 2>/dev/null | grep -E %s | grep -v grep || echo ''", util.ShellQuote(pattern))
 	output, err := exec.RunCommand(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search processes: %w", err)

--- a/internal/service/snapshot_service.go
+++ b/internal/service/snapshot_service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -114,7 +115,7 @@ func (s *SnapshotService) CreateSnapshot(ctx context.Context, serverID, name, de
 	var totalSize int64
 
 	for _, path := range config.Paths {
-		cmd := fmt.Sprintf("find %s -type f 2>/dev/null | head -500", shellQuote(path))
+		cmd := fmt.Sprintf("find %s -type f 2>/dev/null | head -500", util.ShellQuote(path))
 		output, err := exec.RunCommand(ctx, cmd)
 		if err != nil {
 			s.logger.Warn("failed to list files in path", "path", path, "error", err)
@@ -322,7 +323,7 @@ func (s *SnapshotService) isExcluded(path string, excludes []string) bool {
 
 func (s *SnapshotService) getFileInfo(ctx context.Context, exec *sshClientExecutor, path string, config *SnapshotConfig) (*SnapshotFile, error) {
 	// Get stat info
-	cmd := fmt.Sprintf("stat -c '%%s %%Y %%a' %s 2>/dev/null", shellQuote(path))
+	cmd := fmt.Sprintf("stat -c '%%s %%Y %%a' %s 2>/dev/null", util.ShellQuote(path))
 	output, err := exec.RunCommand(ctx, cmd)
 	if err != nil || output == "" {
 		return nil, fmt.Errorf("failed to stat %s", path)
@@ -344,7 +345,7 @@ func (s *SnapshotService) getFileInfo(ctx context.Context, exec *sshClientExecut
 	// Get checksum (md5)
 	checksum := ""
 	if size < 10*1024*1024 { // Only checksum files < 10MB
-		cmd = fmt.Sprintf("md5sum %s 2>/dev/null | awk '{print $1}'", shellQuote(path))
+		cmd = fmt.Sprintf("md5sum %s 2>/dev/null | awk '{print $1}'", util.ShellQuote(path))
 		if output, err := exec.RunCommand(ctx, cmd); err == nil {
 			checksum = strings.TrimSpace(output)
 		}
@@ -364,7 +365,7 @@ func (s *SnapshotService) collectFiles(ctx context.Context, exec *sshClientExecu
 	var files []SnapshotFile
 
 	for _, path := range config.Paths {
-		cmd := fmt.Sprintf("find %s -type f 2>/dev/null | head -500", shellQuote(path))
+		cmd := fmt.Sprintf("find %s -type f 2>/dev/null | head -500", util.ShellQuote(path))
 		output, err := exec.RunCommand(ctx, cmd)
 		if err != nil {
 			continue

--- a/internal/service/ssh_service.go
+++ b/internal/service/ssh_service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"gorm.io/gorm"
 )
 
@@ -175,12 +176,12 @@ func (s *SSHService) AuthorizeKey(ctx context.Context, keyPairID, serverID, user
 
 	// Add to authorized_keys
 	cmd := fmt.Sprintf("mkdir -p /home/%s/.ssh && echo %s >> /home/%s/.ssh/authorized_keys && chmod 600 /home/%s/.ssh/authorized_keys && chown %s:%s /home/%s/.ssh/authorized_keys",
-		shellQuote(user), shellQuote(keyPair.PublicKey), shellQuote(user), shellQuote(user), user, user, shellQuote(user))
+		util.ShellQuote(user), util.ShellQuote(keyPair.PublicKey), util.ShellQuote(user), util.ShellQuote(user), user, user, util.ShellQuote(user))
 
 	// For root user, use /root/.ssh
 	if user == "root" {
 		cmd = fmt.Sprintf("mkdir -p /root/.ssh && echo %s >> /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys",
-			shellQuote(keyPair.PublicKey))
+			util.ShellQuote(keyPair.PublicKey))
 	}
 
 	if _, err := exec.RunCommand(ctx, cmd); err != nil {
@@ -227,7 +228,7 @@ func (s *SSHService) RevokeKey(ctx context.Context, keyPairID, serverID, user st
 		sshDir = "/root/.ssh"
 	}
 
-	cmd := fmt.Sprintf("sed -i '/%s/d' %s/authorized_keys 2>/dev/null || true", shellQuote(keyComment), shellQuote(sshDir))
+	cmd := fmt.Sprintf("sed -i '/%s/d' %s/authorized_keys 2>/dev/null || true", util.ShellQuote(keyComment), util.ShellQuote(sshDir))
 	if _, err := exec.RunCommand(ctx, cmd); err != nil {
 		return fmt.Errorf("failed to revoke key: %w", err)
 	}

--- a/internal/service/system_service.go
+++ b/internal/service/system_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // ---------- 11. DetectEnv ----------
@@ -60,7 +61,7 @@ func (b *Bridge) DetectEnv(ctx context.Context, level int, ports []int, services
 			if svc == "" {
 				continue
 			}
-			cmd := fmt.Sprintf("timeout 2 bash -c 'echo > /dev/tcp/%s' 2>/dev/null && echo ok || echo fail", strings.TrimPrefix(svc, "tcp://"))
+			cmd := fmt.Sprintf("timeout 2 bash -c 'echo > /dev/tcp/%s' 2>/dev/null && echo ok || echo fail", util.ShellQuote(strings.TrimPrefix(svc, "tcp://")))
 			if out, err := b.Executor.RunCommand(ctx, cmd); err == nil && strings.Contains(out, "ok") {
 				svcResults[svc] = true
 			} else {

--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -1,0 +1,8 @@
+package util
+
+import "strings"
+
+// ShellQuote safely escapes a string for use in a shell command.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}


### PR DESCRIPTION
Closes #268
Closes #269
Closes #270

## Batch 1: CI/CD Critical (S-1, S-2)
- release.yml + e2e.yml: Go 1.23→1.24
- ci.yml: commitlint actually runs (was echo placeholder)

## Batch 2: Security (S-3, S-4, S-5)
- Extract `shellQuote()` to `internal/util/shell.go`
- Add `util.ShellQuote()` to firewall_service, system_service, deployer, compose, logs, healer, bridge SSH
- Fix outbound_webhook_service DB save errors (log instead of ignore)
- Move health endpoint outside protected group

## Batch 3: Docker + CI (H-1, H-2, H-8, M-12)
- release.yml: CGO_ENABLED=0→1 (match Dockerfile)
- Dockerfile: add HEALTHCHECK
- benchmark.yml + changelog.yml: add permissions
- changelog.yml + wiki-sync.yml: checkout@v4→@v6