### PR TITLE
fix: rate limiter cleanup, CIDR matching, .env.dev JWT

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -17,7 +17,7 @@ GIN_MODE=debug
 PORT=8080
 
 # ─── Auth ───────────────────────────────────────────────
-JWT_SECRET=dev-secret-key-at-least-16-chars
+JWT_SECRET=
 
 # ─── Encryption ─────────────────────────────────────────
 # Generate a stable key for dev: openssl rand -base64 32

--- a/internal/middleware/hardening.go
+++ b/internal/middleware/hardening.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -146,33 +147,15 @@ func isIPAllowed(ip string, allowed []string) bool {
 	return false
 }
 
-// matchCIDR performs basic CIDR matching for common subnet masks.
-func matchCIDR(ip, cidr string) bool {
-	// Parse CIDR
-	parts := strings.SplitN(cidr, "/", 2)
-	if len(parts) != 2 {
+// matchCIDR performs CIDR matching using standard library.
+func matchCIDR(ipStr, cidrStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
 		return false
 	}
-	network := parts[0]
-
-	// Simple prefix match for the network part
-	ipParts := strings.Split(ip, ".")
-	netParts := strings.Split(network, ".")
-	if len(ipParts) != 4 || len(netParts) != 4 {
+	_, network, err := net.ParseCIDR(cidrStr)
+	if err != nil {
 		return false
 	}
-
-	switch parts[1] {
-	case "8":
-		return ipParts[0] == netParts[0]
-	case "16":
-		return ipParts[0] == netParts[0] && ipParts[1] == netParts[1]
-	case "24":
-		return ipParts[0] == netParts[0] && ipParts[1] == netParts[1] && ipParts[2] == netParts[2]
-	case "32":
-		return ip == network
-	default:
-		// For non-standard CIDR, do exact match
-		return ip == network
-	}
+	return network.Contains(ip)
 }

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -12,10 +12,12 @@ import (
 
 // RateLimiter implements token bucket rate limiting.
 type RateLimiter struct {
-	buckets     map[string]*bucket
-	mu          sync.Mutex
-	rates       map[string]int // role -> rate per minute
-	defaultRate int
+	buckets         map[string]*bucket
+	mu              sync.Mutex
+	rates           map[string]int // role -> rate per minute
+	defaultRate     int
+	cleanupInterval time.Duration
+	stopCleanup     chan struct{}
 }
 
 type bucket struct {
@@ -26,15 +28,53 @@ type bucket struct {
 
 // NewRateLimiter creates a new RateLimiter with per-role rate limits.
 func NewRateLimiter(defaultRate, ownerRate, adminRate, devRate, viewerRate int) *RateLimiter {
-	return &RateLimiter{
-		buckets: make(map[string]*bucket),
+	rl := &RateLimiter{
+		buckets:         make(map[string]*bucket),
 		rates: map[string]int{
 			"owner":  ownerRate,
 			"admin":  adminRate,
 			"dev":    devRate,
 			"viewer": viewerRate,
 		},
-		defaultRate: defaultRate,
+		defaultRate:     defaultRate,
+		cleanupInterval: 5 * time.Minute,
+		stopCleanup:     make(chan struct{}),
+	}
+	rl.startCleanup()
+	return rl
+}
+
+// Stop gracefully stops the cleanup goroutine.
+func (rl *RateLimiter) Stop() {
+	close(rl.stopCleanup)
+}
+
+// startCleanup launches a background goroutine to remove stale buckets.
+func (rl *RateLimiter) startCleanup() {
+	go func() {
+		ticker := time.NewTicker(rl.cleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				rl.cleanup()
+			case <-rl.stopCleanup:
+				return
+			}
+		}
+	}()
+}
+
+// cleanup removes buckets that have not been refilled for 2x the cleanup interval.
+func (rl *RateLimiter) cleanup() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	threshold := time.Now().Add(-2 * rl.cleanupInterval)
+	for key, b := range rl.buckets {
+		if b.lastRefill.Before(threshold) {
+			delete(rl.buckets, key)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #277

- M-6: Add periodic cleanup of stale rate limiter buckets (5min interval, 10min expiry)
- M-7: Replace naive CIDR matching with net.ParseCIDR/net.IPNet.Contains
- M-14: Remove hardcoded JWT_SECRET from .env.dev