### PR TITLE
docs: update Milestone, Roadmap, .gitignore, docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,6 @@ web/dist/
 # Build cache
 /tmp/
 
-# Prevent ANSI escape code pollution from script output
-*\033*
-*\x1b*
-*\[*
-
 # Build artifacts
 /api-server
 /deploypilot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   deploypilot:
     image: ghcr.io/yogdunana/deploypilot:latest

--- a/docs/ai-guide-reference.md
+++ b/docs/ai-guide-reference.md
@@ -422,6 +422,7 @@ Dependabot PR **必须**经过 `make check` 验证后再合并。
 | 8 | v1.8: Commercial & Licensing | License Key、OpenCore、Feature Flags、Pro/Free | Closed | 0 | 7 |
 | 9 | v1.9: Security Hardening | 审计验证、IP 白名单、设备绑定、代码签名、密钥轮换 | Closed | 0 | 11 |
 | 10 | v1.10: Engineering Quality | 迁移策略、测试体系、开发环境、社区建设、Changelog 自动化 | Closed | 0 | 9 |
+| 11 | v1.1 — 安全与稳定性 | 安全与稳定性（旧版 Milestone） | Closed | 0 | 4 |
 | 12 | v1.11: Security Hardening & DevEx | CI 安全扫描、SSH root fallback、Changelog 自动化、性能基准 | Closed | 0 | 3 |
 
 #### 管理规则


### PR DESCRIPTION
Closes #279

- M-2: Milestone docs updated (12 milestones, all closed)
- M-3: Roadmap timeline updated with actual dates
- L-1: Phase 7.1 OpenClaw marked as planned
- L-2: MCP tool count 52+ -> 91+
- L-3: .gitignore fixed
- L-4: docker-compose.yml version field removed