### PR TITLE
fix: http client timeout, audit secret, error handling, DB pool

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -109,18 +109,20 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 		if refreshStore != nil {
 			refreshID, rErr := auth.GenerateRefreshTokenID()
 			if rErr == nil {
-				_ = refreshStore.Store(auth.RefreshTokenEntry{
+				if err := refreshStore.Store(auth.RefreshTokenEntry{
 					TokenID: refreshID, UserID: user.ID, Role: "viewer",
 					DeviceInfo: c.GetHeader("User-Agent"), IPAddress: c.ClientIP(),
 					CreatedAt: time.Now(), ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
-				})
+				}); err != nil {
+					slog.Warn("failed to store refresh token", "error", err)
+				}
 				setAuthCookies(c, token, refreshID)
 			}
 		}
 
 		// Record register audit event
 		if auditSvcForAuth != nil {
-			_ = auditSvcForAuth.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvcForAuth.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(user.ID),
 				Username:     user.Username,
 				Action:       "user.register",
@@ -128,7 +130,9 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 				ResourceID:   user.ID,
 				IPAddress:    c.ClientIP(),
 				UserAgent:    c.GetHeader("User-Agent"),
-			})
+			}); err != nil {
+				slog.Warn("failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{
@@ -339,18 +343,20 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 		if refreshStore != nil {
 			refreshID, rErr := auth.GenerateRefreshTokenID()
 			if rErr == nil {
-				_ = refreshStore.Store(auth.RefreshTokenEntry{
+				if err := refreshStore.Store(auth.RefreshTokenEntry{
 					TokenID: refreshID, UserID: user.ID, Role: roleName,
 					DeviceInfo: c.GetHeader("User-Agent"), IPAddress: c.ClientIP(),
 					CreatedAt: time.Now(), ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
-				})
+				}); err != nil {
+					slog.Warn("failed to store refresh token", "error", err)
+				}
 				setAuthCookies(c, token, refreshID)
 			}
 		}
 
 		// Record login audit event
 		if auditSvcForAuth != nil {
-			_ = auditSvcForAuth.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvcForAuth.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(user.ID),
 				Username:     user.Username,
 				Action:       "user.login",
@@ -358,7 +364,9 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 				ResourceID:   user.ID,
 				IPAddress:    c.ClientIP(),
 				UserAgent:    c.GetHeader("User-Agent"),
-			})
+			}); err != nil {
+				slog.Warn("failed to record audit log", "error", err)
+			}
 		}
 
 		// Detect first login and update last_login_at

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -3,6 +3,7 @@ package database
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -58,6 +59,8 @@ func Connect(driver, dsn string) (*gorm.DB, error) {
 	}
 	sqlDB.SetMaxIdleConns(10)
 	sqlDB.SetMaxOpenConns(50)
+	sqlDB.SetConnMaxLifetime(5 * time.Minute)
+	sqlDB.SetConnMaxIdleTime(10 * time.Minute)
 
 	return db, nil
 }

--- a/internal/engine/deployer/logs.go
+++ b/internal/engine/deployer/logs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io"
 	"strings"
 	"sync"
 	"time"
@@ -249,6 +248,5 @@ func parseLogLines(containerName, output string) []LogEntry {
 // detectStream guesses stdout vs stderr from log content.
 func detectStream(line string) string {
 	// Docker prefixes stderr lines, but in combined mode we just default to stdout
-	_ = io.EOF // suppress unused import
 	return "stdout"
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -116,10 +117,16 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	r.Use(middleware.DeviceCheckMiddleware(deviceSvc))
 
 	// Audit verification & compliance (Issue #155)
-	auditSecretKey := []byte("deploypilot-audit-chain-secret")
-	if cfg.Auth.JWTSecret != "" {
-		// Derive audit chain key from JWT secret for persistence
-		auditSecretKey = []byte(cfg.Auth.JWTSecret + "-audit-chain")
+	auditSecretKey := []byte(cfg.Auth.JWTSecret)
+	if len(auditSecretKey) == 0 {
+		key := make([]byte, 32)
+		if _, err := rand.Read(key); err != nil {
+			slog.Warn("failed to generate random audit key, using fallback")
+			auditSecretKey = []byte("deploypilot-fallback-audit-key-change-me")
+		} else {
+			auditSecretKey = key
+			slog.Warn("JWT_SECRET not set, using random audit chain key (audit chain will break on restart)")
+		}
 	}
 	api.SetAuditVerificationAPI(api.NewAuditVerificationAPI(db, &cfg.Audit, auditSecretKey))
 

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
 // OutboundWebhookService manages outbound webhook CRUD, delivery, retry, and event subscription.
@@ -123,7 +124,7 @@ func (s *OutboundWebhookService) Deliver(ctx context.Context, webhook *model.Out
 
 	// Send request
 	startTime := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := util.DefaultClient.Do(req)
 	latency := time.Since(startTime)
 
 	// Read response body for error recording
@@ -133,9 +134,9 @@ func (s *OutboundWebhookService) Deliver(ctx context.Context, webhook *model.Out
 		statusCode = 0
 		respBody = err.Error()
 	} else {
+		defer resp.Body.Close()
 		statusCode = resp.StatusCode
 		respBytes, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		respBody = string(respBytes)
 	}
 
@@ -231,7 +232,7 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 		req.Header.Set("User-Agent", "DeployPilot-Webhook/1.0")
 
 		startTime := time.Now()
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := util.DefaultClient.Do(req)
 		latency := time.Since(startTime)
 
 		var respBody string
@@ -240,9 +241,9 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 			statusCode = 0
 			respBody = err.Error()
 		} else {
+			defer resp.Body.Close()
 			statusCode = resp.StatusCode
 			respBytes, _ := io.ReadAll(resp.Body)
-			_ = resp.Body.Close()
 			respBody = string(respBytes)
 		}
 
@@ -343,7 +344,7 @@ func (s *OutboundWebhookService) TestDelivery(ctx context.Context, webhookID str
 	req.Header.Set("User-Agent", "DeployPilot-Webhook/1.0")
 
 	startTime := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := util.DefaultClient.Do(req)
 	latency := time.Since(startTime)
 
 	var respBody string
@@ -352,9 +353,9 @@ func (s *OutboundWebhookService) TestDelivery(ctx context.Context, webhookID str
 		statusCode = 0
 		respBody = err.Error()
 	} else {
+		defer resp.Body.Close()
 		statusCode = resp.StatusCode
 		respBytes, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
 		respBody = string(respBytes)
 	}
 

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -134,7 +134,7 @@ func (s *OutboundWebhookService) Deliver(ctx context.Context, webhook *model.Out
 		statusCode = 0
 		respBody = err.Error()
 	} else {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		statusCode = resp.StatusCode
 		respBytes, _ := io.ReadAll(resp.Body)
 		respBody = string(respBytes)
@@ -241,7 +241,7 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 			statusCode = 0
 			respBody = err.Error()
 		} else {
-			defer resp.Body.Close()
+			defer func() { _ = resp.Body.Close() }()
 			statusCode = resp.StatusCode
 			respBytes, _ := io.ReadAll(resp.Body)
 			respBody = string(respBytes)
@@ -353,7 +353,7 @@ func (s *OutboundWebhookService) TestDelivery(ctx context.Context, webhookID str
 		statusCode = 0
 		respBody = err.Error()
 	} else {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		statusCode = resp.StatusCode
 		respBytes, _ := io.ReadAll(resp.Body)
 		respBody = string(respBytes)

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"github.com/Yogdunana/deploypilot/internal/version"
 )
 
@@ -118,7 +119,7 @@ func fetchLatestRelease(ctx context.Context) (*GitHubRelease, error) {
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "DeployPilot/"+version.Version)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := util.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch release: %w", err)
 	}
@@ -516,7 +517,7 @@ func downloadFile(ctx context.Context, url, destPath string) error {
 	}
 	req.Header.Set("User-Agent", "DeployPilot/"+version.Version)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := util.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("download: %w", err)
 	}

--- a/internal/util/httpclient.go
+++ b/internal/util/httpclient.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"net/http"
+	"time"
+)
+
+// DefaultClient is an HTTP client with sensible timeouts.
+var DefaultClient = &http.Client{
+	Timeout: 30 * time.Second,
+	Transport: &http.Transport{
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     90 * time.Second,
+	},
+}


### PR DESCRIPTION
Closes #295

- H-1/H-2: Create shared httpclient.DefaultClient with 30s timeout
- M-1: Remove hardcoded audit chain secret, generate random key as fallback
- M-2: Remove fake io import in deployer/logs.go
- M-3: Log ignored audit/token storage errors in auth.go
- M-4: Use defer for resp.Body.Close in webhook service
- M-5: Add ConnMaxLifetime/ConnMaxIdleTime to DB pool