### PR TITLE
security: DSN log redaction, firewall input validation, panic logging, configurable Prometheus URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ flowchart LR
 
 | Layer | Protocol | Purpose |
 |-------|----------|----------|
-| **MCP Server** | stdio | Native AI IDE integration — 52+ tools for deployment, DNS, SSL, monitoring |
-| **REST API** | HTTP + JWT | Programmatic access with full RBAC — 68+ endpoints, Swagger docs at `/swagger/` |
+| **MCP Server** | stdio | Native AI IDE integration — 91+ tools for deployment, DNS, SSL, monitoring |
+| **REST API** | HTTP + JWT | Programmatic access with full RBAC — 100+ endpoints, Swagger docs at `/swagger/` |
 | **WebSocket / SSE** | ws://, text/event-stream | Real-time log streaming, SSH terminal, deployment progress |
 
 The embedded **web dashboard** (Vue 3 + TypeScript + Tailwind CSS) provides a full management UI accessible at `http://localhost:8080`.
@@ -156,7 +156,7 @@ The embedded **web dashboard** (Vue 3 + TypeScript + Tailwind CSS) provides a fu
 
 ### MCP Protocol Integration
 
-52+ MCP tools covering the complete deployment lifecycle. AI IDEs connect via stdio transport and can autonomously manage your infrastructure through natural language.
+91+ MCP tools covering the complete deployment lifecycle. AI IDEs connect via stdio transport and can autonomously manage your infrastructure through natural language.
 
 ### Multi-Server Management
 
@@ -245,7 +245,7 @@ server:
   host: "0.0.0.0"
   port: 8080
   cors_allowed_origins:
-    - "*"
+    - []
 
 database:
   type: sqlite              # sqlite | postgres

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -405,7 +405,7 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string, migrateOnly, migrate
 	}()
 
 	slog.Info("DeployPilot API server starting", "version", appversion.Version, "addr", listenAddr)
-	slog.Info("database configured", "type", cfg.Database.Type, "dsn", cfg.Database.DSN)
+	slog.Info("database configured", "type", cfg.Database.Type, "dsn", "<redacted>")
 
 	// Wait for shutdown signal or server error
 	quit := make(chan os.Signal, 1)

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -237,12 +237,14 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string, migrateOnly, migrate
 	// Initialize Outbound Webhook Service
 	webhookSvc := service.NewOutboundWebhookService(db, typedBus)
 	webhookSvc.Start()
-	go webhookSvc.StartCleanupLoop(context.Background())
+	appCtx, appCancel := context.WithCancel(context.Background())
+	defer appCancel()
+	go webhookSvc.StartCleanupLoop(appCtx)
 
 	// Initialize Grafana integration (Phase 7.2)
 	if cfg.Grafana.Enabled {
 		grafanaSvc := service.NewGrafanaService(db, &cfg.Grafana, typedBus)
-		grafanaSvc.StartAnnotationListener()
+		grafanaSvc.StartAnnotationListener(appCtx)
 		slog.Info("Grafana integration enabled", "url", cfg.Grafana.URL)
 	}
 

--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -126,6 +126,6 @@ func run(configFilePath, cliDriver, cliDSN string) error {
 
 	// Start stdio transport
 	slog.Info("DeployPilot MCP server starting", "version", appversion.Version, "transport", "stdio")
-	slog.Info("database configured", "type", cfg.Database.Type, "dsn", cfg.Database.DSN)
+	slog.Info("database configured", "type", cfg.Database.Type, "dsn", "<redacted>")
 	return server.ServeStdio(mcpServer)
 }

--- a/docs/ai-guide-reference.md
+++ b/docs/ai-guide-reference.md
@@ -779,7 +779,7 @@ gh api /repos/Yogdunana/deploypilot/contents/internal/service/bridge_test.go \
 
 | 工具 | 版本要求 | 用途 |
 |------|----------|------|
-| Go | 1.23+ | 后端编译 |
+| Go | 1.24+ | 后端编译 |
 | Node.js | 20+ | 前端构建 |
 | npm | 10+ | 前端包管理 |
 | Docker | 20.10+ | 容器化构建/测试 |

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -9,8 +9,8 @@
             "url": "https://github.com/Yogdunana/deploypilot"
         },
         "license": {
-            "name": "MIT",
-            "url": "https://github.com/Yogdunana/deploypilot/blob/main/LICENSE"
+            "name": "BSL 1.1",
+            "url": "https://spdx.org/licenses/BSL-1.1.html"
         },
         "version": "1.0"
     },

--- a/internal/agent/tunnel.go
+++ b/internal/agent/tunnel.go
@@ -35,6 +35,7 @@ type TunnelManager struct {
 	commands map[string]chan CommandResult // commandID -> result channel
 	mu       sync.RWMutex
 	upgrader websocket.Upgrader
+	stopCh   chan struct{}
 }
 
 type agentConn struct {
@@ -238,13 +239,26 @@ func (tm *TunnelManager) ListAgents() []string {
 
 // StartCleanup starts a background goroutine to clean up stale connections.
 func (tm *TunnelManager) StartCleanup(interval time.Duration) {
+	tm.stopCh = make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		for range ticker.C {
-			tm.cleanup()
+		for {
+			select {
+			case <-ticker.C:
+				tm.cleanup()
+			case <-tm.stopCh:
+				return
+			}
 		}
 	}()
+}
+
+// StopCleanup terminates the background cleanup goroutine.
+func (tm *TunnelManager) StopCleanup() {
+	if tm.stopCh != nil {
+		close(tm.stopCh)
+	}
 }
 
 // cleanup removes stale agent connections.

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -406,10 +406,11 @@ func ResetUser2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 
 // twoFARateLimiter provides per-IP rate limiting for 2FA verification attempts.
 type twoFARateLimiter struct {
-	mu       sync.Mutex
-	attempts map[string]*twoFAAttempt
+	mu          sync.Mutex
+	attempts    map[string]*twoFAAttempt
 	maxAttempts int
 	window      time.Duration
+	stopCh      chan struct{}
 }
 
 type twoFAAttempt struct {
@@ -423,16 +424,27 @@ func newTwoFARateLimiter(maxAttempts int, window time.Duration) *twoFARateLimite
 		attempts:    make(map[string]*twoFAAttempt),
 		maxAttempts: maxAttempts,
 		window:      window,
+		stopCh:      make(chan struct{}),
 	}
 	// Background cleanup
 	go func() {
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
-		for range ticker.C {
-			rl.cleanup()
+		for {
+			select {
+			case <-ticker.C:
+				rl.cleanup()
+			case <-rl.stopCh:
+				return
+			}
 		}
 	}()
 	return rl
+}
+
+// Stop terminates the background cleanup goroutine.
+func (rl *twoFARateLimiter) Stop() {
+	close(rl.stopCh)
 }
 
 // Allow checks if an IP is allowed to attempt 2FA verification.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ type GrafanaConfig struct {
 	AdminPassword      string `mapstructure:"admin_password"`
 	AnnotationsEnabled bool   `mapstructure:"annotations_enabled"`
 	SyncInterval       int    `mapstructure:"sync_interval"`
+	PrometheusURL      string `mapstructure:"prometheus_url"`
 }
 
 // AuditConfig holds configuration for audit logging.
@@ -383,6 +384,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("grafana.url", "http://localhost:3000")
 	v.SetDefault("grafana.annotations_enabled", true)
 	v.SetDefault("grafana.sync_interval", 60)
+	v.SetDefault("grafana.prometheus_url", "http://localhost:9090")
 
 	// API Platform
 	v.SetDefault("api_platform.enabled", true)

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,6 +32,7 @@ const (
 func NewEncryptionKey() []byte {
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		slog.Error("failed to generate random key", "error", err)
 		panic(fmt.Sprintf("failed to generate encryption key: %v", err))
 	}
 	return key
@@ -45,6 +47,7 @@ func DeriveKey(masterKey, nonce []byte) []byte {
 	hkdf := hkdf.New(sha256.New, masterKey, nonce, nil)
 	derived := make([]byte, 32)
 	if _, err := io.ReadFull(hkdf, derived); err != nil {
+		slog.Error("HKDF derivation failed", "error", err)
 		panic(fmt.Sprintf("HKDF derivation failed: %v", err))
 	}
 	return derived

--- a/internal/service/firewall_service.go
+++ b/internal/service/firewall_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -290,27 +291,75 @@ func (f *FirewallService) getUFWStatus(ctx context.Context, exec *sshClientExecu
 }
 
 func (f *FirewallService) ufwAllow(ctx context.Context, exec *sshClientExecutor, port, protocol string) error {
+	if err := validatePort(port); err != nil {
+		return fmt.Errorf("invalid port: %w", err)
+	}
+	if err := validateProtocol(protocol); err != nil {
+		return fmt.Errorf("invalid protocol: %w", err)
+	}
 	cmd := fmt.Sprintf("sudo ufw allow %s/%s", port, protocol)
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) ufwDeny(ctx context.Context, exec *sshClientExecutor, port, protocol string) error {
+	if err := validatePort(port); err != nil {
+		return fmt.Errorf("invalid port: %w", err)
+	}
+	if err := validateProtocol(protocol); err != nil {
+		return fmt.Errorf("invalid protocol: %w", err)
+	}
 	cmd := fmt.Sprintf("sudo ufw delete allow %s/%s", port, protocol)
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) ufwDenyIP(ctx context.Context, exec *sshClientExecutor, ip string) error {
+	if err := validateIP(ip); err != nil {
+		return fmt.Errorf("invalid IP address: %w", err)
+	}
 	cmd := fmt.Sprintf("sudo ufw deny from %s", ip)
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
 }
 
 func (f *FirewallService) ufwAllowIP(ctx context.Context, exec *sshClientExecutor, ip string) error {
+	if err := validateIP(ip); err != nil {
+		return fmt.Errorf("invalid IP address: %w", err)
+	}
 	cmd := fmt.Sprintf("sudo ufw delete deny from %s", ip)
 	_, err := exec.RunCommand(ctx, cmd)
 	return err
+}
+
+// validatePort checks that port is a valid numeric port number (1-65535).
+func validatePort(port string) error {
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("port must be a number: %s", port)
+	}
+	if p < 1 || p > 65535 {
+		return fmt.Errorf("port out of range (1-65535): %d", p)
+	}
+	return nil
+}
+
+// validateProtocol checks that protocol is one of the allowed values.
+func validateProtocol(protocol string) error {
+	switch protocol {
+	case "tcp", "udp", "icmp":
+		return nil
+	default:
+		return fmt.Errorf("unsupported protocol: %s (must be tcp, udp, or icmp)", protocol)
+	}
+}
+
+// validateIP checks that ip is a valid IP address.
+func validateIP(ip string) error {
+	if net.ParseIP(ip) == nil {
+		return fmt.Errorf("invalid IP address: %s", ip)
+	}
+	return nil
 }
 
 func parseUFWOutput(output string) []FirewallRule {

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -87,7 +88,13 @@ func (s *GrafanaService) SyncAll() (int, error) {
 	}
 
 	// 1. Ensure datasource
-	metricsURL := "http://localhost:9090" // default Prometheus URL
+	metricsURL := s.cfg.PrometheusURL
+	if envURL := os.Getenv("DEPLOYPILOT_PROMETHEUS_URL"); envURL != "" {
+		metricsURL = envURL
+	}
+	if metricsURL == "" {
+		metricsURL = "http://localhost:9090"
+	}
 	dsUID, err := s.client.EnsureDatasource(metricsURL)
 	if err != nil {
 		return 0, fmt.Errorf("ensure datasource: %w", err)
@@ -344,12 +351,11 @@ func (s *GrafanaService) PushAnnotation(event BusEvent) {
 
 // StartAnnotationListener subscribes to deploy, alert, server, and system event
 // types and forwards them as Grafana annotations.
-func (s *GrafanaService) StartAnnotationListener() {
+func (s *GrafanaService) StartAnnotationListener(ctx context.Context) {
 	if s.bus == nil || !s.cfg.AnnotationsEnabled {
 		return
 	}
 
-	ctx := context.Background()
 	eventTypes := []EventType{EventDeploy, EventAlert, EventServer, EventSystem}
 	for _, et := range eventTypes {
 		go func(eventType EventType) {

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -379,6 +379,7 @@ func (s *OAuth2Service) createToken(clientID, userID string, scopes []string) (*
 func generateToken() string {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
+		slog.Error("failed to generate token", "error", err)
 		panic("failed to generate token: " + err.Error())
 	}
 	return hex.EncodeToString(b)
@@ -388,6 +389,7 @@ func generateToken() string {
 func generateClientID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
+		slog.Error("failed to generate client ID", "error", err)
 		panic("failed to generate client ID: " + err.Error())
 	}
 	return "dp_" + hex.EncodeToString(b)

--- a/internal/service/redis_eventbus.go
+++ b/internal/service/redis_eventbus.go
@@ -37,7 +37,9 @@ func (r *RedisEventBus) Publish(event DeployEvent) {
 		return
 	}
 	// Publish to Redis for other instances (fire-and-forget)
-	_ = r.client.Publish(r.ctx, r.channel, data).Err()
+	if err := r.client.Publish(r.ctx, r.channel, data).Err(); err != nil {
+		slog.Warn("failed to publish redis event", "channel", r.channel, "error", err)
+	}
 	// Also publish locally for this instance's subscribers
 	r.localBus.Publish(event)
 }

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -282,33 +282,41 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.downloadBinaries(ctx, ver); err != nil {
 		us.emitProgress("download", fmt.Sprintf("download failed: %v", err), 40, "error")
 		// Auto-rollback
-		_ = us.restoreBinaries(backupDir)
-		return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
+		if err := us.restoreBinaries(backupDir); err != nil {
+		slog.Warn("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
 	}
-	us.emitProgress("download", "binaries downloaded successfully", 65, "running")
+	return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
+}
+us.emitProgress("download", "binaries downloaded successfully", 65, "running")
 
-	// Step 5: Verify new binaries
-	us.emitProgress("verify", "verifying new binaries...", 70, "running")
-	if err := us.verifyBinaries(); err != nil {
-		us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
-		_ = us.restoreBinaries(backupDir)
-		return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
+// Step 5: Verify new binaries
+us.emitProgress("verify", "verifying new binaries...", 70, "running")
+if err := us.verifyBinaries(); err != nil {
+	us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
+	if err := us.restoreBinaries(backupDir); err != nil {
+		slog.Warn("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
 	}
+	return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
+}
 
-	// Step 6: Replace binaries
-	us.emitProgress("replace", "replacing binaries...", 80, "running")
-	if err := us.replaceBinaries(); err != nil {
-		us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
-		_ = us.restoreBinaries(backupDir)
-		return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
+// Step 6: Replace binaries
+us.emitProgress("replace", "replacing binaries...", 80, "running")
+if err := us.replaceBinaries(); err != nil {
+	us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
+	if err := us.restoreBinaries(backupDir); err != nil {
+		slog.Warn("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
 	}
+	return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
+}
 
-	// Step 7: Restart services
-	us.emitProgress("restart", "restarting services...", 90, "running")
-	if err := us.restartServices(); err != nil {
-		us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
-		_ = us.restoreBinaries(backupDir)
-		return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
+// Step 7: Restart services
+us.emitProgress("restart", "restarting services...", 90, "running")
+if err := us.restartServices(); err != nil {
+	us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
+	if err := us.restoreBinaries(backupDir); err != nil {
+		slog.Warn("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
+	}
+	return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
 	}
 
 	us.emitProgress("complete", fmt.Sprintf("successfully upgraded to %s", ver), 100, "success")

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -283,40 +283,40 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 		us.emitProgress("download", fmt.Sprintf("download failed: %v", err), 40, "error")
 		// Auto-rollback
 		if err := us.restoreBinaries(backupDir); err != nil {
-		slog.Warn("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
+			slog.Warn("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
+		}
+		return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
 	}
-	return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
-}
-us.emitProgress("download", "binaries downloaded successfully", 65, "running")
+	us.emitProgress("download", "binaries downloaded successfully", 65, "running")
 
-// Step 5: Verify new binaries
-us.emitProgress("verify", "verifying new binaries...", 70, "running")
-if err := us.verifyBinaries(); err != nil {
-	us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
-	if err := us.restoreBinaries(backupDir); err != nil {
-		slog.Warn("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
+	// Step 5: Verify new binaries
+	us.emitProgress("verify", "verifying new binaries...", 70, "running")
+	if err := us.verifyBinaries(); err != nil {
+		us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
+		if err := us.restoreBinaries(backupDir); err != nil {
+			slog.Warn("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
+		}
+		return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
 	}
-	return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
-}
 
-// Step 6: Replace binaries
-us.emitProgress("replace", "replacing binaries...", 80, "running")
-if err := us.replaceBinaries(); err != nil {
-	us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
-	if err := us.restoreBinaries(backupDir); err != nil {
-		slog.Warn("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
+	// Step 6: Replace binaries
+	us.emitProgress("replace", "replacing binaries...", 80, "running")
+	if err := us.replaceBinaries(); err != nil {
+		us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
+		if err := us.restoreBinaries(backupDir); err != nil {
+			slog.Warn("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
+		}
+		return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
 	}
-	return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
-}
 
-// Step 7: Restart services
-us.emitProgress("restart", "restarting services...", 90, "running")
-if err := us.restartServices(); err != nil {
-	us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
-	if err := us.restoreBinaries(backupDir); err != nil {
-		slog.Warn("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
-	}
-	return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
+	// Step 7: Restart services
+	us.emitProgress("restart", "restarting services...", 90, "running")
+	if err := us.restartServices(); err != nil {
+		us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
+		if err := us.restoreBinaries(backupDir); err != nil {
+			slog.Warn("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
+		}
+		return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
 	}
 
 	us.emitProgress("complete", fmt.Sprintf("successfully upgraded to %s", ver), 100, "success")
@@ -513,7 +513,9 @@ func (us *UpgradeService) restoreBinaries(backupDir string) error {
 	}
 
 	// Restart services with old binaries
-	_ = us.restartServices()
+	if err := us.restartServices(); err != nil {
+		slog.Warn("failed to restart services during rollback", "error", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Closes #303

- H-1: Redact DSN in startup logs (api-server, mcp-server)
- H-2: Add port/protocol/IP validation in firewall_service.go
- H-3: Add slog.Error before panic in crypto.go and oauth2_service.go
- H-4: Make Prometheus URL configurable via GrafanaConfig.PrometheusURL