### PR TITLE
fix: upgrade rollback errors, goroutine leaks, ignored errors, context handling

### DIFF
--- a/internal/engine/deployer/deployer.go
+++ b/internal/engine/deployer/deployer.go
@@ -3,9 +3,11 @@ package deployer
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
+
 	"github.com/Yogdunana/deploypilot/internal/util"
 )
 
@@ -79,7 +81,9 @@ func (d *DockerDeployer) Deploy(ctx context.Context, cfg DeployConfig) (*Contain
 	}
 
 	// Step 2: Remove existing container with same name (if any)
-	_, _ = d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s 2>/dev/null || true", util.ShellQuote(cfg.ContainerName)))
+	if _, err := d.executor.RunCommand(ctx, fmt.Sprintf("docker rm -f %s 2>/dev/null || true", util.ShellQuote(cfg.ContainerName))); err != nil {
+		slog.Warn("failed to remove existing container", "container", cfg.ContainerName, "error", err)
+	}
 
 	// Step 3: Build docker run command
 	runCmd := d.buildRunCommand(cfg)

--- a/internal/engine/deployer/health.go
+++ b/internal/engine/deployer/health.go
@@ -195,7 +195,9 @@ func (h *HealthChecker) Rollback(ctx context.Context, containerName, previousIma
 	if previousImage == "" {
 		// No previous image, just stop
 		deployer := New(h.executor)
-		_ = deployer.Stop(ctx, containerName)
+		if err := deployer.Stop(ctx, containerName); err != nil {
+			slog.Warn("failed to stop container during rollback", "container", containerName, "error", err)
+		}
 		return &RollbackResult{
 			Success:    false,
 			Message:    "no previous image to rollback to, container stopped",
@@ -205,8 +207,12 @@ func (h *HealthChecker) Rollback(ctx context.Context, containerName, previousIma
 
 	// Stop current container
 	deployer := New(h.executor)
-	_ = deployer.Stop(ctx, containerName)
-	_ = deployer.Remove(ctx, containerName)
+	if err := deployer.Stop(ctx, containerName); err != nil {
+		slog.Warn("failed to stop container during rollback", "container", containerName, "error", err)
+	}
+	if err := deployer.Remove(ctx, containerName); err != nil {
+		slog.Warn("failed to remove container during rollback", "container", containerName, "error", err)
+	}
 
 	// Redeploy with previous image
 	rollbackCfg := DeployConfig{

--- a/internal/service/bridge.go
+++ b/internal/service/bridge.go
@@ -237,7 +237,9 @@ func (b *Bridge) ComposeDeploy(ctx context.Context, appID string) (string, error
 	// Parse env vars from JSON string
 	var envVars map[string]string
 	if app.EnvVars != "" {
-		_ = json.Unmarshal([]byte(app.EnvVars), &envVars)
+		if err := json.Unmarshal([]byte(app.EnvVars), &envVars); err != nil {
+			slog.Warn("failed to unmarshal app env vars", "app_id", app.ID, "error", err)
+		}
 	}
 
 	deployer := deployer.NewComposeDeployer(executor)


### PR DESCRIPTION
Closes #304

- M-1: Log errors in upgrade.go restoreBinaries/restartServices
- M-2: Add stop channel to goroutine cleanup loops (twofa.go, tunnel.go)
- M-3: Replace context.Background() with app lifecycle context
- M-4: Fix ignored errors in redis_eventbus, bridge, health, deployer