### PR TITLE
docs: update tool counts, CORS example, Go version, swagger license

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ flowchart LR
 | Layer | Protocol | Purpose |
 |-------|----------|----------|
 | **MCP Server** | stdio | Native AI IDE integration — 52+ tools for deployment, DNS, SSL, monitoring |
-| **REST API** | HTTP + JWT | Programmatic access with full RBAC — 68+ endpoints, Swagger docs at `/swagger/` |
+| **REST API** | HTTP + JWT | Programmatic access with full RBAC — 100+ endpoints, Swagger docs at `/swagger/` |
 | **WebSocket / SSE** | ws://, text/event-stream | Real-time log streaming, SSH terminal, deployment progress |
 
 The embedded **web dashboard** (Vue 3 + TypeScript + Tailwind CSS) provides a full management UI accessible at `http://localhost:8080`.
@@ -156,7 +156,7 @@ The embedded **web dashboard** (Vue 3 + TypeScript + Tailwind CSS) provides a fu
 
 ### MCP Protocol Integration
 
-52+ MCP tools covering the complete deployment lifecycle. AI IDEs connect via stdio transport and can autonomously manage your infrastructure through natural language.
+91+ MCP tools covering the complete deployment lifecycle. AI IDEs connect via stdio transport and can autonomously manage your infrastructure through natural language.
 
 ### Multi-Server Management
 

--- a/docs/ai-guide-reference.md
+++ b/docs/ai-guide-reference.md
@@ -779,7 +779,7 @@ gh api /repos/Yogdunana/deploypilot/contents/internal/service/bridge_test.go \
 
 | 工具 | 版本要求 | 用途 |
 |------|----------|------|
-| Go | 1.23+ | 后端编译 |
+| Go | 1.24+ | 后端编译 |
 | Node.js | 20+ | 前端构建 |
 | npm | 10+ | 前端包管理 |
 | Docker | 20.10+ | 容器化构建/测试 |

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -9,7 +9,7 @@
             "url": "https://github.com/Yogdunana/deploypilot"
         },
         "license": {
-            "name": "MIT",
+            "name": "BSL 1.1",
             "url": "https://github.com/Yogdunana/deploypilot/blob/main/LICENSE"
         },
         "version": "1.0"


### PR DESCRIPTION
Superseded by #306 squash merge which already included these changes.