### PR TITLE
security: fix SearchFiles injection, API Key fail-open, scopes validation

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -52,6 +52,11 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 
 		if len(input.Scopes) == 0 {
 			input.Scopes = []string{"read"}
+		} else {
+			input.Scopes = auth.ValidateScopes(input.Scopes)
+			if len(input.Scopes) == 0 {
+				input.Scopes = []string{"read"}
+			}
 		}
 
 		apiKey, rawKey, err := keySvc.Create(c.Request.Context(), uid, "tenant-default", input.Name, input.Scopes, input.ExpiresInDays)

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -70,7 +70,8 @@ func APIKeyMiddleware(keySvc *service.APIKeyService) gin.HandlerFunc {
 func isIPAllowed(clientIP string, allowedIPsJSON string) bool {
 	var allowedIPs []string
 	if err := json.Unmarshal([]byte(allowedIPsJSON), &allowedIPs); err != nil {
-		return true // if parse fails, allow (fail open)
+		slog.Warn("failed to parse allowed IPs JSON, denying access", "error", err)
+		return false
 	}
 	if len(allowedIPs) == 0 {
 		return true

--- a/internal/service/file_manager_service.go
+++ b/internal/service/file_manager_service.go
@@ -300,8 +300,8 @@ func (f *FileManagerService) SearchFiles(ctx context.Context, serverID, searchPa
 		limit = fmt.Sprintf(" | head -n %d", maxResults)
 	}
 
-	cmd := fmt.Sprintf("find %s -name '*%s*' -type f%s 2>/dev/null",
-		util.ShellQuote(searchPath), pattern, limit)
+	cmd := fmt.Sprintf("find %s -name %s -type f%s 2>/dev/null",
+		util.ShellQuote(searchPath), util.ShellQuote("*"+pattern+"*"), limit)
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)
 	}


### PR DESCRIPTION
Closes #319

- H-1: ShellQuote pattern parameter in SearchFiles to prevent command injection
- H-2: Change isIPAllowed from fail-open to fail-close on JSON parse error
- H-3: Add scope validation using auth.ValidateScopes() in CreateAPIKey