### PR TITLE
docs: add Swagger annotations for security-related endpoints

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -10,7 +10,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ListAPIKeys returns all API keys for the authenticated user.
+// ListAPIKeys godoc
+// @Summary      List API keys
+// @Description  Get all API keys for the authenticated user
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "list of API keys"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /api-keys [get]
 func ListAPIKeys(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -29,7 +39,19 @@ func ListAPIKeys(keySvc *service.APIKeyService) gin.HandlerFunc {
 	}
 }
 
-// CreateAPIKey generates a new API key and returns it (raw key shown only once).
+// CreateAPIKey godoc
+// @Summary      Create API key
+// @Description  Generate a new API key and return it (raw key shown only once)
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{name=string,scopes=[]string,allowed_ips=[]string,expires_in_days=int} true "API key creation request"
+// @Success      200 {object} map[string]interface{} "created API key with raw key"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /api-keys [post]
 func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -97,7 +119,18 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 	}
 }
 
-// DeleteAPIKey revokes an API key.
+// DeleteAPIKey godoc
+// @Summary      Delete API key
+// @Description  Revoke an API key by its ID
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "API key ID"
+// @Success      200 {object} map[string]interface{} "revocation confirmation"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /api-keys/{id} [delete]
 func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -127,8 +160,18 @@ func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 	}
 }
 
-// GetAPIKey returns a single API key's details.
-// GET /api/v1/api-keys/:id
+// GetAPIKey godoc
+// @Summary      Get API key
+// @Description  Get details of a single API key by its ID
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "API key ID"
+// @Success      200 {object} map[string]interface{} "API key details"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      404 {object} map[string]interface{} "not found"
+// @Router       /api-keys/{id} [get]
 func GetAPIKey(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -149,8 +192,20 @@ func GetAPIKey(keySvc *service.APIKeyService) gin.HandlerFunc {
 	}
 }
 
-// UpdateAPIKey updates an API key's metadata (name, scopes, allowed_ips, expires_at).
-// PATCH /api/v1/api-keys/:id
+// UpdateAPIKey godoc
+// @Summary      Update API key
+// @Description  Update an API key's metadata (name, scopes, allowed IPs, expiration)
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "API key ID"
+// @Param        request body object{name=string,scopes=[]string,allowed_ips=[]string,expires_in_days=int} true "API key update request"
+// @Success      200 {object} map[string]interface{} "update confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /api-keys/{id} [patch]
 func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -225,8 +280,18 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 	}
 }
 
-// GetAPIKeyStats returns usage statistics for a specific API key.
-// GET /api/v1/api-keys/:id/stats
+// GetAPIKeyStats godoc
+// @Summary      Get API key stats
+// @Description  Get usage statistics for a specific API key
+// @Tags         API Keys
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "API key ID"
+// @Success      200 {object} map[string]interface{} "API key usage statistics"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      404 {object} map[string]interface{} "not found"
+// @Router       /api-keys/{id}/stats [get]
 func GetAPIKeyStats(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))

--- a/internal/api/device_api.go
+++ b/internal/api/device_api.go
@@ -32,8 +32,17 @@ func GetGlobalDeviceAPI() *DeviceAPI {
 	return globalDeviceAPI
 }
 
-// ListDevices returns all devices for the authenticated user.
-// GET /api/v1/devices
+// ListDevices godoc
+// @Summary      List devices
+// @Description  Get all devices for the authenticated user
+// @Tags         Devices
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "list of devices"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /devices [get]
 func ListDevices(c *gin.Context) {
 	if globalDeviceAPI == nil {
 		respondError(c, http.StatusInternalServerError, "device service not initialized")
@@ -55,8 +64,19 @@ func ListDevices(c *gin.Context) {
 	respondSuccess(c, devices)
 }
 
-// RevokeDevice removes trust from a device owned by the authenticated user.
-// DELETE /api/v1/devices/:id
+// RevokeDevice godoc
+// @Summary      Revoke device
+// @Description  Remove trust from a device owned by the authenticated user
+// @Tags         Devices
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Device ID"
+// @Success      200 {object} map[string]interface{} "revocation confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request or revoke failed"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /devices/{id} [delete]
 func RevokeDevice(c *gin.Context) {
 	if globalDeviceAPI == nil {
 		respondError(c, http.StatusInternalServerError, "device service not initialized")
@@ -83,8 +103,20 @@ func RevokeDevice(c *gin.Context) {
 	respondSuccess(c, gin.H{"revoked": true})
 }
 
-// TrustDevice marks a device as trusted for N days.
-// POST /api/v1/devices/:id/trust
+// TrustDevice godoc
+// @Summary      Trust device
+// @Description  Mark a device as trusted for a specified number of days (default 30)
+// @Tags         Devices
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Device ID"
+// @Param        request body object{days=int} false "Trust duration in days (default 30)"
+// @Success      200 {object} map[string]interface{} "trust confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request or trust failed"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /devices/{id}/trust [post]
 func TrustDevice(c *gin.Context) {
 	if globalDeviceAPI == nil {
 		respondError(c, http.StatusInternalServerError, "device service not initialized")
@@ -122,8 +154,17 @@ func TrustDevice(c *gin.Context) {
 	respondSuccess(c, gin.H{"trusted": true, "days": input.Days})
 }
 
-// CurrentDevice returns the current device info based on User-Agent and IP.
-// GET /api/v1/devices/current
+// CurrentDevice godoc
+// @Summary      Get current device
+// @Description  Get the current device info based on User-Agent and IP
+// @Tags         Devices
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "current device info"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /devices/current [get]
 func CurrentDevice(c *gin.Context) {
 	if globalDeviceAPI == nil {
 		respondError(c, http.StatusInternalServerError, "device service not initialized")

--- a/internal/api/ip_whitelist_api.go
+++ b/internal/api/ip_whitelist_api.go
@@ -26,8 +26,17 @@ func SetIPWhitelistAPI(api *IPWhitelistAPI) {
 	globalIPWhitelistAPI = api
 }
 
-// ListIPWhitelist returns all whitelist entries for the current user.
-// GET /api/v1/settings/ip-whitelist
+// ListIPWhitelist godoc
+// @Summary      List IP whitelist
+// @Description  Get all whitelist entries for the current user
+// @Tags         IP Whitelist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "list of IP whitelist entries"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /settings/ip-whitelist [get]
 func ListIPWhitelist(c *gin.Context) {
 	if globalIPWhitelistAPI == nil {
 		respondError(c, http.StatusInternalServerError, "ip whitelist service not initialized")
@@ -49,8 +58,19 @@ func ListIPWhitelist(c *gin.Context) {
 	respondSuccess(c, entries)
 }
 
-// AddIPWhitelist creates a new whitelist entry for the current user.
-// POST /api/v1/settings/ip-whitelist
+// AddIPWhitelist godoc
+// @Summary      Add IP whitelist entry
+// @Description  Create a new whitelist entry for the current user
+// @Tags         IP Whitelist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{description=string,cidr=string} true "IP whitelist entry (cidr is required)"
+// @Success      200 {object} map[string]interface{} "created whitelist entry"
+// @Failure      400 {object} map[string]interface{} "invalid request or creation failed"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /settings/ip-whitelist [post]
 func AddIPWhitelist(c *gin.Context) {
 	if globalIPWhitelistAPI == nil {
 		respondError(c, http.StatusInternalServerError, "ip whitelist service not initialized")
@@ -87,8 +107,19 @@ func AddIPWhitelist(c *gin.Context) {
 	respondSuccess(c, entry)
 }
 
-// DeleteIPWhitelist removes a whitelist entry owned by the current user.
-// DELETE /api/v1/settings/ip-whitelist/:id
+// DeleteIPWhitelist godoc
+// @Summary      Delete IP whitelist entry
+// @Description  Remove a whitelist entry owned by the current user
+// @Tags         IP Whitelist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Whitelist entry ID"
+// @Success      200 {object} map[string]interface{} "deletion confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request or deletion failed"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /settings/ip-whitelist/{id} [delete]
 func DeleteIPWhitelist(c *gin.Context) {
 	if globalIPWhitelistAPI == nil {
 		respondError(c, http.StatusInternalServerError, "ip whitelist service not initialized")
@@ -115,8 +146,17 @@ func DeleteIPWhitelist(c *gin.Context) {
 	respondSuccess(c, gin.H{"deleted": true})
 }
 
-// CheckIPAccess returns the current user's IP and whitelist status.
-// GET /api/v1/settings/ip-whitelist/check
+// CheckIPAccess godoc
+// @Summary      Check IP access
+// @Description  Get the current user's IP and whitelist enforcement status
+// @Tags         IP Whitelist
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "IP access status with enforcement info"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /settings/ip-whitelist/check [get]
 func CheckIPAccess(c *gin.Context) {
 	if globalIPWhitelistAPI == nil {
 		respondError(c, http.StatusInternalServerError, "ip whitelist service not initialized")

--- a/internal/api/security_config.go
+++ b/internal/api/security_config.go
@@ -22,8 +22,15 @@ func SetSecurityConfig(cfg *config.SecurityConfig) {
 	securityCfg = cfg
 }
 
-// GetSecurityConfig returns the current security configuration (read-only).
-// GET /api/v1/system/security/config
+// GetSecurityConfig godoc
+// @Summary      Get security config
+// @Description  Get the current security configuration (read-only)
+// @Tags         Security
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "security configuration settings"
+// @Router       /system/security/config [get]
 func GetSecurityConfig() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		securityCfgMu.RLock()
@@ -55,8 +62,20 @@ func GetSecurityConfig() gin.HandlerFunc {
 	}
 }
 
-// UpdateSecurityConfig updates the security configuration at runtime.
-// PUT /api/v1/system/security/config
+// UpdateSecurityConfig godoc
+// @Summary      Update security config
+// @Description  Update the security configuration at runtime (requires owner or admin role)
+// @Tags         Security
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{security_entrance=string,allowed_domains=[]string,allowed_ips=[]string,password_min_len=int,password_require_upper=bool,password_require_lower=bool,password_require_digit=bool,password_require_special=bool,password_max_age_days=int,force_2fa=bool,force_2fa_roles=[]string,force_2fa_grace_days=int} true "Security config update request (only non-nil fields are updated)"
+// @Success      200 {object} map[string]interface{} "update confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      403 {object} map[string]interface{} "forbidden"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /system/security/config [put]
 func UpdateSecurityConfig() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input struct {

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -20,8 +20,17 @@ type sessionResponse struct {
 	IsCurrent  bool      `json:"is_current"`
 }
 
-// ListSessions returns all active sessions for the authenticated user.
-// GET /api/v1/sessions
+// ListSessions godoc
+// @Summary      List sessions
+// @Description  Get all active sessions for the authenticated user
+// @Tags         Sessions
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "list of active sessions"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /sessions [get]
 func ListSessions() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -71,8 +80,21 @@ func ListSessions() gin.HandlerFunc {
 	}
 }
 
-// KickSession revokes a single session (refresh token) for the authenticated user.
-// DELETE /api/v1/sessions/:token_id
+// KickSession godoc
+// @Summary      Kick session
+// @Description  Revoke a single session (refresh token) for the authenticated user
+// @Tags         Sessions
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        token_id path string true "Refresh token ID"
+// @Success      200 {object} map[string]interface{} "revocation confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      403 {object} map[string]interface{} "cannot kick another user's session"
+// @Failure      404 {object} map[string]interface{} "session not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /sessions/{token_id} [delete]
 func KickSession() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -117,8 +139,19 @@ func KickSession() gin.HandlerFunc {
 	}
 }
 
-// ListLoginHistory returns the login history for the authenticated user.
-// GET /api/v1/login-history
+// ListLoginHistory godoc
+// @Summary      List login history
+// @Description  Get paginated login history for the authenticated user
+// @Tags         Sessions
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        page query int false "Page number (default 1)"
+// @Param        page_size query int false "Page size (default 20, max 100)"
+// @Success      200 {object} map[string]interface{} "paginated login history"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /login-history [get]
 func ListLoginHistory(auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -29,7 +29,19 @@ func encryptionKey() []byte {
 	return encryptionKeyVal
 }
 
-// Verify2FA handles the second step of 2FA login.
+// Verify2FA godoc
+// @Summary      Verify 2FA
+// @Description  Handle the second step of 2FA login by verifying TOTP code or backup code
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Param        request body object{two_fa_token=string,code=string} true "2FA verification request"
+// @Success      200 {object} map[string]interface{} "user info and JWT token"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "invalid token or 2FA code"
+// @Failure      429 {object} map[string]interface{} "too many attempts"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /auth/2fa/verify [post]
 func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input struct {
@@ -93,7 +105,18 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// Setup2FA generates a new TOTP secret and backup codes.
+// Setup2FA godoc
+// @Summary      Setup 2FA
+// @Description  Generate a new TOTP secret and backup codes for the authenticated user
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "TOTP secret, QR code URL, and backup codes"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /2fa/setup [post]
 func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -155,7 +178,20 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// Confirm2FA enables 2FA after the user verifies a TOTP code.
+// Confirm2FA godoc
+// @Summary      Confirm 2FA
+// @Description  Enable 2FA after the user verifies a TOTP code
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{code=string} true "TOTP code confirmation request"
+// @Success      200 {object} map[string]interface{} "2FA enabled confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request"
+// @Failure      401 {object} map[string]interface{} "unauthorized or invalid 2FA code"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /2fa/confirm [post]
 func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -205,7 +241,20 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// Disable2FA turns off 2FA for the user.
+// Disable2FA godoc
+// @Summary      Disable 2FA
+// @Description  Turn off 2FA for the authenticated user (requires current TOTP code)
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{code=string} true "TOTP code to disable 2FA"
+// @Success      200 {object} map[string]interface{} "2FA disabled confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request or 2FA not enabled"
+// @Failure      401 {object} map[string]interface{} "unauthorized or invalid 2FA code"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /2fa/disable [post]
 func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -262,8 +311,20 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	}
 }
 
-// RegenerateBackupCodes generates new backup codes for the user (requires current 2FA code).
-// POST /api/v1/2fa/regenerate-backup-codes
+// RegenerateBackupCodes godoc
+// @Summary      Regenerate backup codes
+// @Description  Generate new backup codes for the authenticated user (requires current TOTP code)
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body object{code=string} true "Current TOTP code"
+// @Success      200 {object} map[string]interface{} "new backup codes"
+// @Failure      400 {object} map[string]interface{} "invalid request or 2FA not enabled"
+// @Failure      401 {object} map[string]interface{} "unauthorized or invalid 2FA code"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /2fa/regenerate-backup-codes [post]
 func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -325,8 +386,17 @@ func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.Hand
 	}
 }
 
-// Get2FAStatus returns the current 2FA status and backup code count for the user.
-// GET /api/v1/2fa/status
+// Get2FAStatus godoc
+// @Summary      Get 2FA status
+// @Description  Get the current 2FA status and backup code count for the authenticated user
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} map[string]interface{} "2FA status and backup code count"
+// @Failure      401 {object} map[string]interface{} "unauthorized"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Router       /2fa/status [get]
 func Get2FAStatus(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
@@ -357,8 +427,19 @@ func Get2FAStatus(db *gorm.DB) gin.HandlerFunc {
 	}
 }
 
-// ResetUser2FA allows an admin/owner to reset another user's 2FA.
-// POST /api/v1/users/:id/reset-2fa
+// ResetUser2FA godoc
+// @Summary      Reset user 2FA
+// @Description  Allow an admin or owner to reset another user's 2FA (requires owner or admin role)
+// @Tags         2FA
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Target user ID"
+// @Success      200 {object} map[string]interface{} "reset confirmation"
+// @Failure      400 {object} map[string]interface{} "invalid request or 2FA not enabled"
+// @Failure      404 {object} map[string]interface{} "user not found"
+// @Failure      500 {object} map[string]interface{} "internal error"
+// @Router       /users/{id}/reset-2fa [post]
 func ResetUser2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		targetUserID := c.Param("id")
@@ -494,7 +575,13 @@ func (rl *twoFARateLimiter) cleanup() {
 // Global 2FA rate limiter: max 10 attempts per IP per 5 minutes.
 var twoFARL = newTwoFARateLimiter(10, 5*time.Minute)
 
-// Check2FARateLimit is a middleware that rate-limits 2FA verification attempts.
+// Check2FARateLimit godoc
+// @Summary      Check 2FA rate limit
+// @Description  Middleware that rate-limits 2FA verification attempts (max 10 per IP per 5 minutes)
+// @Tags         2FA
+// @Produce      json
+// @Failure      429 {object} map[string]interface{} "too many 2FA attempts"
+// @Router       /auth/2fa/verify [post]
 func Check2FARateLimit() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ip := c.ClientIP()


### PR DESCRIPTION
Closes #315

Add Swagger annotations to 27 handlers across 6 files:
- apikeys.go (6): List, Create, Delete, Get, Update, Stats
- sessions.go (3): List, Kick, LoginHistory
- twofa.go (8): Verify, Setup, Confirm, Disable, BackupCodes, Status, Reset, RateLimit
- device_api.go (4): List, Revoke, Trust, Current
- ip_whitelist_api.go (4): List, Add, Delete, Check
- security_config.go (2): Get, Update

This is the first batch of Swagger annotation updates.