### PR TITLE
fix: register missing ToolboxAPI routes, fix StatusBadge i18n

### DIFF
--- a/internal/api/routes_servers.go
+++ b/internal/api/routes_servers.go
@@ -93,5 +93,11 @@ func registerServerRoutes(protected *gin.RouterGroup, db *gorm.DB, bridge *servi
 		servers.GET("/:id/toolbox/detect", tbAPI.DetectEnvironment)
 		servers.POST("/:id/toolbox/run", tbAPI.RunScript)
 		servers.POST("/:id/toolbox/builtin", tbAPI.RunBuiltInScript)
+		servers.GET("/:id/toolbox/builtin-scripts", tbAPI.ListBuiltInScripts)
+		servers.GET("/:id/toolbox/scripts", tbAPI.ListScripts)
+		servers.POST("/:id/toolbox/scripts", tbAPI.CreateScript)
+		servers.GET("/:id/toolbox/scripts/:script_id", tbAPI.GetScript)
+		servers.PUT("/:id/toolbox/scripts/:script_id", tbAPI.UpdateScript)
+		servers.DELETE("/:id/toolbox/scripts/:script_id", tbAPI.DeleteScript)
 
 }

--- a/internal/api/toolbox_api.go
+++ b/internal/api/toolbox_api.go
@@ -121,9 +121,9 @@ func (t *ToolboxAPI) ListScripts(c *gin.Context) {
 }
 
 // GetScript gets a custom script by ID.
-// GET /api/v1/toolbox/scripts/:id
+// GET /api/v1/servers/:id/toolbox/scripts/:script_id
 func (t *ToolboxAPI) GetScript(c *gin.Context) {
-	id := c.Param("id")
+	id := c.Param("script_id")
 
 	script, err := t.tbSvc.GetScript(c.Request.Context(), id)
 	if err != nil {
@@ -135,9 +135,9 @@ func (t *ToolboxAPI) GetScript(c *gin.Context) {
 }
 
 // UpdateScript updates a custom script.
-// PUT /api/v1/toolbox/scripts/:id
+// PUT /api/v1/servers/:id/toolbox/scripts/:script_id
 func (t *ToolboxAPI) UpdateScript(c *gin.Context) {
-	id := c.Param("id")
+	id := c.Param("script_id")
 
 	var script service.ToolboxScript
 	if err := c.ShouldBindJSON(&script); err != nil {
@@ -155,9 +155,9 @@ func (t *ToolboxAPI) UpdateScript(c *gin.Context) {
 }
 
 // DeleteScript deletes a custom script.
-// DELETE /api/v1/toolbox/scripts/:id
+// DELETE /api/v1/servers/:id/toolbox/scripts/:script_id
 func (t *ToolboxAPI) DeleteScript(c *gin.Context) {
-	id := c.Param("id")
+	id := c.Param("script_id")
 
 	if err := t.tbSvc.DeleteScript(c.Request.Context(), id); err != nil {
 		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")

--- a/web/src/components/common/StatusBadge.test.ts
+++ b/web/src/components/common/StatusBadge.test.ts
@@ -1,9 +1,38 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'status.running': '运行中',
+        'status.stopped': '已停止',
+        'status.error': '错误',
+        'status.deploying': '部署中',
+        'status.success': '成功',
+        'status.active': '活跃',
+        'status.healthy': '健康',
+        'status.online': '在线',
+        'status.completed': '已完成',
+        'status.enabled': '已启用',
+        'status.failed': '失败',
+        'status.expired': '已过期',
+        'status.disabled': '已禁用',
+        'status.offline': '离线',
+        'status.pending': '等待中',
+        'status.renewing': '续期中',
+        'status.building': '构建中',
+        'status.warning': '警告',
+        'status.unknown': '未知',
+        'status.inactive': '未激活',
+      }
+      return map[key] || key
+    },
+  }),
+}))
+
 describe('StatusBadge', () => {
-  // 辅助函数：创建包装器
   function createWrapper(status?: string) {
     return mount(StatusBadge, {
       props: { status },

--- a/web/src/components/common/StatusBadge.vue
+++ b/web/src/components/common/StatusBadge.vue
@@ -37,7 +37,8 @@ const variantMap: Record<string, 'success' | 'destructive' | 'warning' | 'second
 const mapped = computed(() => {
   const s = (props.status || '').toLowerCase()
   const variant = variantMap[s] || 'secondary'
-  const label = t(`status.${s}`) || props.status || s
+  const translated = t(`status.${s}`)
+  const label = translated !== `status.${s}` ? translated : (props.status || s)
   return { variant, label }
 })
 </script>

--- a/web/src/components/common/StatusBadge.vue
+++ b/web/src/components/common/StatusBadge.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import Badge from '@/components/ui/Badge.vue'
 
 interface Props {
@@ -8,33 +9,36 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+const { t } = useI18n()
 
-const statusMap: Record<string, { variant: 'success' | 'destructive' | 'warning' | 'secondary'; label: string }> = {
-  running: { variant: 'success', label: '运行中' },
-  success: { variant: 'success', label: '成功' },
-  active: { variant: 'success', label: '活跃' },
-  healthy: { variant: 'success', label: '健康' },
-  online: { variant: 'success', label: '在线' },
-  completed: { variant: 'success', label: '已完成' },
-  enabled: { variant: 'success', label: '已启用' },
-  failed: { variant: 'destructive', label: '失败' },
-  error: { variant: 'destructive', label: '错误' },
-  expired: { variant: 'destructive', label: '已过期' },
-  disabled: { variant: 'destructive', label: '已禁用' },
-  offline: { variant: 'destructive', label: '离线' },
-  deploying: { variant: 'warning', label: '部署中' },
-  pending: { variant: 'warning', label: '等待中' },
-  renewing: { variant: 'warning', label: '续期中' },
-  building: { variant: 'warning', label: '构建中' },
-  warning: { variant: 'warning', label: '警告' },
-  stopped: { variant: 'secondary', label: '已停止' },
-  unknown: { variant: 'secondary', label: '未知' },
-  inactive: { variant: 'secondary', label: '未激活' },
+const variantMap: Record<string, 'success' | 'destructive' | 'warning' | 'secondary'> = {
+  running: 'success',
+  success: 'success',
+  active: 'success',
+  healthy: 'success',
+  online: 'success',
+  completed: 'success',
+  enabled: 'success',
+  failed: 'destructive',
+  error: 'destructive',
+  expired: 'destructive',
+  disabled: 'destructive',
+  offline: 'destructive',
+  deploying: 'warning',
+  pending: 'warning',
+  renewing: 'warning',
+  building: 'warning',
+  warning: 'warning',
+  stopped: 'secondary',
+  unknown: 'secondary',
+  inactive: 'secondary',
 }
 
 const mapped = computed(() => {
   const s = (props.status || '').toLowerCase()
-  return statusMap[s] || { variant: 'secondary' as const, label: props.status || s }
+  const variant = variantMap[s] || 'secondary'
+  const label = t(`status.${s}`) || props.status || s
+  return { variant, label }
 })
 </script>
 


### PR DESCRIPTION
Closes #329

- R-1: Register 6 missing ToolboxAPI routes (scripts CRUD + builtin-scripts)
- R-2: Fix toolbox_api.go param names for script_id
- R-3: StatusBadge.vue now uses vue-i18n t() for status labels
- R-4: StatusBadge.test.ts mocks vue-i18n for test compatibility