### PR TITLE
fix: error response consistency, info leak, cookie config race, test tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,8 @@
 # ─── REQUIRED ───────────────────────────────────────────────
 # JWT secret for signing tokens (min 16 characters)
 # Generate: openssl rand -base64 24
-JWT_SECRET=change-me-to-a-random-string-at-least-16-chars
+JWT_SECRET=
+# IMPORTANT: Set a strong random string (at least 16 characters) before running
 
 # ─── Server ─────────────────────────────────────────────────
 DEPLOYPILOT_SERVER_HOST=0.0.0.0

--- a/internal/api/refresh.go
+++ b/internal/api/refresh.go
@@ -3,6 +3,7 @@ package api
 import (
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
@@ -27,17 +28,16 @@ type cookieConfig struct {
 	MaxAge   int // seconds; 0 = session cookie
 }
 
-var defaultCookieConfig = cookieConfig{
-	Secure:   true,
-	HTTPOnly: true,
-	SameSite: http.SameSiteLaxMode,
-	Path:     "/",
-	MaxAge:   0,
-}
+var (
+	defaultCookieConfig cookieConfig
+	cookieConfigOnce   sync.Once
+)
 
 // SetCookieConfig updates the cookie configuration.
 func SetCookieConfig(cfg cookieConfig) {
-	defaultCookieConfig = cfg
+	cookieConfigOnce.Do(func() {
+		defaultCookieConfig = cfg
+	})
 }
 
 // setAuthCookies sets both access and refresh token cookies on the response.

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -341,7 +342,8 @@ func TriggerBackup(backupSvc *backup.Service) gin.HandlerFunc {
 		}
 		record, err := backupSvc.CreateBackup(c.Request.Context(), "manual")
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": err.Error()})
+			slog.Error("failed to create backup", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "success", "data": record})
@@ -369,7 +371,8 @@ func ListBackupRecords(backupSvc *backup.Service) gin.HandlerFunc {
 		}
 		records, err := backupSvc.ListRecords(limit)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": err.Error()})
+			slog.Error("failed to list backup records", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "success", "data": records})
@@ -426,7 +429,8 @@ func DownloadCloudBackup(backupSvc *backup.Service) gin.HandlerFunc {
 		id := c.Param("id")
 		localPath, err := backupSvc.DownloadFromCloud(c.Request.Context(), id)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": err.Error()})
+			slog.Error("failed to download cloud backup", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "internal server error"})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"status": "success", "message": "backup downloaded", "local_path": localPath})
@@ -477,7 +481,8 @@ func GetAuditLogsByTraceID(auditSvc *service.AuditService) gin.HandlerFunc {
 		traceID := c.Param("trace_id")
 		logs, total, err := auditSvc.ListByTraceID(c.Request.Context(), traceID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			slog.Error("failed to get audit logs by trace ID", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "internal server error"})
 			return
 		}
 		if logs == nil {

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -321,13 +321,13 @@ func LogStreamWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketS
 		// 1. Authenticate via ticket (preferred) or JWT token (backward compat)
 		userID, role, err := authenticateWS(c, ticketStore)
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": err.Error()})
 			return
 		}
 		// 2. Check resource-level authorization
 		appID := c.Param("app_id")
 		if !authorizeAppAccessCached(bridge, c.Request.Context(), appID, role, userID) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "no permission to access this app"})
+			c.JSON(http.StatusForbidden, gin.H{"status": "error", "message": "no permission to access this app"})
 			return
 		}
 
@@ -430,7 +430,7 @@ func AgentTunnelWS(bridge *service.Bridge, ticketStore *auth.WSTicketStore) gin.
 		// Authenticate via ticket (preferred) or JWT token (backward compat)
 		_, _, err := authenticateWS(c, ticketStore)
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": err.Error()})
 			return
 		}
 
@@ -440,7 +440,7 @@ func AgentTunnelWS(bridge *service.Bridge, ticketStore *auth.WSTicketStore) gin.
 		if bridge.TunnelManager != nil {
 			bridge.TunnelManager.HandleTunnel(c.Writer, c.Request, serverID)
 		} else {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "agent tunnel not configured"})
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "error", "message": "agent tunnel not configured"})
 		}
 	}
 }
@@ -507,13 +507,13 @@ func TerminalWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketSt
 		// 1. Authenticate via ticket (preferred) or JWT token (backward compat)
 		userID, role, err := authenticateWS(c, ticketStore)
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": err.Error()})
 			return
 		}
 		// 2. Check resource-level authorization
 		serverID := c.Param("server_id")
 		if !authorizeServerAccessCached(bridge, c.Request.Context(), serverID, role, userID) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "no permission to access this server"})
+			c.JSON(http.StatusForbidden, gin.H{"status": "error", "message": "no permission to access this server"})
 			return
 		}
 

--- a/internal/engine/builder/push_test.go
+++ b/internal/engine/builder/push_test.go
@@ -202,7 +202,7 @@ func TestPushImage_GHCR(t *testing.T) {
 		AppName:     "myowner/myapp",
 		RegistryURL: "https://ghcr.io",
 		RegistryUser: "myowner",
-		RegistryPass: "ghp_token",
+		RegistryPass: "test_token_push",
 	}
 
 	ref, err := b.PushImage(context.Background(), cfg, "myapp:abc12345")

--- a/internal/provider/registry/ghcr_test.go
+++ b/internal/provider/registry/ghcr_test.go
@@ -26,7 +26,7 @@ func newGHCRTestServer(t *testing.T) *httptest.Server {
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/OWNER/myapp/tags/list" {
 			// Verify Bearer token (GitHub token) is present
 			auth := r.Header.Get("Authorization")
-			if auth != "Bearer ghp_testtoken123" {
+			if auth != "Bearer test_token_123" {
 				w.WriteHeader(http.StatusUnauthorized)
 				w.Write([]byte(`{"errors":[{"message":"unauthorized"}]}`))
 				return
@@ -41,7 +41,7 @@ func newGHCRTestServer(t *testing.T) *httptest.Server {
 		// Tags list for empty repo
 		if r.Method == http.MethodGet && r.URL.Path == "/v2/OWNER/empty/tags/list" {
 			auth := r.Header.Get("Authorization")
-			if auth != "Bearer ghp_testtoken123" {
+			if auth != "Bearer test_token_123" {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
@@ -89,7 +89,7 @@ func TestGHCRPing(t *testing.T) {
 	ts := newGHCRTestServer(t)
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	err := g.Ping(ctx)
@@ -146,7 +146,7 @@ func TestGHCRListTags(t *testing.T) {
 	ts := newGHCRTestServer(t)
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	tags, err := g.ListTags(ctx, "OWNER/myapp")
@@ -180,7 +180,7 @@ func TestGHCRListTagsEmpty(t *testing.T) {
 	ts := newGHCRTestServer(t)
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	tags, err := g.ListTags(ctx, "OWNER/empty")
@@ -216,7 +216,7 @@ func TestGHCRListTagsInvalidJSON(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	_, err := g.ListTags(ctx, "OWNER/myapp")
@@ -231,7 +231,7 @@ func TestGHCRListTagsNotFound(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	_, err := g.ListTags(ctx, "OWNER/nonexistent")
@@ -252,7 +252,7 @@ func TestGHCRListTagsBearerToken(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "ghp_testtoken123")
+	g := NewGHCRProvider(ts.URL+"/v2/", "OWNER", "test_token_123")
 	ctx := context.Background()
 
 	_, err := g.ListTags(ctx, "OWNER/myapp")
@@ -260,8 +260,8 @@ func TestGHCRListTagsBearerToken(t *testing.T) {
 		t.Fatalf("ListTags() error = %v", err)
 	}
 
-	if capturedAuth != "Bearer ghp_testtoken123" {
-		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer ghp_testtoken123")
+	if capturedAuth != "Bearer test_token_123" {
+		t.Errorf("Authorization = %q, want %q", capturedAuth, "Bearer test_token_123")
 	}
 }
 


### PR DESCRIPTION
Closes #333

- E-1: Unify ws.go error response format to {status, message}
- E-2: Replace err.Error() with generic message in 500 responses, add slog.Error logging
- E-3: Add sync.Once to defaultCookieConfig in refresh.go
- E-4: Replace ghp_ prefix test tokens with non-real-prefix values
- E-5: Set .env.example JWT_SECRET to empty with security warning