### PR TITLE
refactor: migrate sessions.go and refresh.go to respondError/respondSuccess

### DIFF
--- a/internal/api/refresh.go
+++ b/internal/api/refresh.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -82,36 +83,25 @@ func RefreshToken() gin.HandlerFunc {
 		}
 
 		if refreshToken == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"status":  "error",
-				"message": "refresh token is required",
-			})
+			respondError(c, http.StatusUnauthorized, "refresh token is required")
 			return
 		}
 
 		if refreshStore == nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"status":  "error",
-				"message": "refresh token store not configured",
-			})
+			respondError(c, http.StatusInternalServerError, "refresh token store not configured")
 			return
 		}
 
 		// Look up the refresh token
 		entry, err := refreshStore.Retrieve(refreshToken)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"status":  "error",
-				"message": "failed to validate refresh token",
-			})
+			slog.Error("failed to validate refresh token", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to validate refresh token")
 			return
 		}
 		if entry == nil {
 			clearAuthCookies(c)
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"status":  "error",
-				"message": "invalid or expired refresh token",
-			})
+			respondError(c, http.StatusUnauthorized, "invalid or expired refresh token")
 			return
 		}
 
@@ -121,20 +111,16 @@ func RefreshToken() gin.HandlerFunc {
 		// Generate new access token
 		accessToken, err := auth.GenerateToken(entry.UserID, entry.Role)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"status":  "error",
-				"message": "failed to generate access token",
-			})
+			slog.Error("failed to generate access token", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to generate access token")
 			return
 		}
 
 		// Generate new refresh token
 		newRefreshID, err := auth.GenerateRefreshTokenID()
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"status":  "error",
-				"message": "failed to generate refresh token",
-			})
+			slog.Error("failed to generate refresh token", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to generate refresh token")
 			return
 		}
 
@@ -148,23 +134,18 @@ func RefreshToken() gin.HandlerFunc {
 			ExpiresAt:  time.Now().Add(7 * 24 * time.Hour),
 		}
 		if err := refreshStore.Store(newEntry); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"status":  "error",
-				"message": "failed to store refresh token",
-			})
+			slog.Error("failed to store refresh token", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to store refresh token")
 			return
 		}
 
 		// Set cookies
 		setAuthCookies(c, accessToken, newRefreshID)
 
-		c.JSON(http.StatusOK, gin.H{
-			"status": "success",
-			"data": gin.H{
-				"token":         accessToken,
-				"refresh_token": newRefreshID,
-				"expires_in":    86400, // 24h in seconds
-			},
+		respondSuccess(c, gin.H{
+			"token":         accessToken,
+			"refresh_token": newRefreshID,
+			"expires_in":    86400, // 24h in seconds
 		})
 	}
 }
@@ -176,7 +157,7 @@ func LogoutAllDevices() gin.HandlerFunc {
 		userID, _ := c.Get(string(auth.UserIDKey))
 		uid, _ := userID.(string)
 		if uid == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": "unauthorized"})
+			respondError(c, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -36,7 +37,7 @@ func ListSessions() gin.HandlerFunc {
 		userID, _ := c.Get(string(auth.UserIDKey))
 		uid, _ := userID.(string)
 		if uid == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": "unauthorized"})
+			respondError(c, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
@@ -47,7 +48,8 @@ func ListSessions() gin.HandlerFunc {
 
 		entries, err := refreshStore.ListForUser(uid)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "failed to list sessions"})
+			slog.Error("failed to list sessions", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to list sessions")
 			return
 		}
 
@@ -100,38 +102,40 @@ func KickSession() gin.HandlerFunc {
 		userID, _ := c.Get(string(auth.UserIDKey))
 		uid, _ := userID.(string)
 		if uid == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": "unauthorized"})
+			respondError(c, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
 		tokenID := c.Param("token_id")
 		if tokenID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"status": "error", "message": "token_id is required"})
+			respondError(c, http.StatusBadRequest, "token_id is required")
 			return
 		}
 
 		if refreshStore == nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "session store not configured"})
+			respondError(c, http.StatusInternalServerError, "session store not configured")
 			return
 		}
 
 		// Verify the token belongs to the current user
 		entry, err := refreshStore.Retrieve(tokenID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "failed to retrieve session"})
+			slog.Error("failed to retrieve session", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to retrieve session")
 			return
 		}
 		if entry == nil {
-			c.JSON(http.StatusNotFound, gin.H{"status": "error", "message": "session not found"})
+			respondError(c, http.StatusNotFound, "session not found")
 			return
 		}
 		if entry.UserID != uid {
-			c.JSON(http.StatusForbidden, gin.H{"status": "error", "message": "cannot kick another user's session"})
+			respondError(c, http.StatusForbidden, "cannot kick another user's session")
 			return
 		}
 
 		if err := refreshStore.Revoke(tokenID); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "failed to revoke session"})
+			slog.Error("failed to revoke session", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to revoke session")
 			return
 		}
 
@@ -157,7 +161,7 @@ func ListLoginHistory(auditSvc *service.AuditService) gin.HandlerFunc {
 		userID, _ := c.Get(string(auth.UserIDKey))
 		uid, _ := userID.(string)
 		if uid == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"status": "error", "message": "unauthorized"})
+			respondError(c, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 
@@ -186,7 +190,8 @@ func ListLoginHistory(auditSvc *service.AuditService) gin.HandlerFunc {
 			PageSize: pageSize,
 		})
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"status": "error", "message": "failed to query login history"})
+			slog.Error("failed to query login history", "error", err)
+			respondError(c, http.StatusInternalServerError, "failed to query login history")
 			return
 		}
 


### PR DESCRIPTION
Closes #334

Migrate 19 direct c.JSON error responses to unified respondError/respondSuccess helpers:
- sessions.go: 11 places (ListSessions, KickSession, ListLoginHistory)
- refresh.go: 8 places (RefreshToken, LogoutAllDevices)
- Add slog.Error logging to all error paths

First batch of the ~63 handler migration (Issue #334).