### PR TITLE
perf: add pagination to ListUsers, ListApps, ListDeployments, ListSSL, ListProviders

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -91,19 +91,45 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 // @Router       /apps [get]
 func ListApps(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+		if page < 1 {
+			page = 1
+		}
+		if pageSize < 1 || pageSize > 100 {
+			pageSize = 20
+		}
+
 		var apps []model.App
+		var total int64
+
 		query := db.Model(&model.App{})
 		if env := c.Query("environment"); env != "" {
 			query = query.Where("environment = ?", env)
 		}
-		if err := query.Find(&apps).Error; err != nil {
+
+		if err := query.Count(&total).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if err := query.Offset((page - 1) * pageSize).Limit(pageSize).Find(&apps).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 		if apps == nil {
 			apps = []model.App{}
 		}
-		respondSuccess(c, apps)
+		// Return paginated response with data key for backward compatibility
+		c.JSON(http.StatusOK, gin.H{
+			"status": "success",
+			"data":   apps,
+			"pagination": gin.H{
+				"page":      page,
+				"page_size": pageSize,
+				"total":     total,
+			},
+		})
 	}
 }
 

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/gin-gonic/gin"
@@ -22,7 +23,18 @@ import (
 // @Router       /deployments [get]
 func ListDeployments(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+		if page < 1 {
+			page = 1
+		}
+		if pageSize < 1 || pageSize > 100 {
+			pageSize = 20
+		}
+
 		var records []model.DeploymentRecord
+		var total int64
+
 		query := db.Model(&model.DeploymentRecord{})
 
 		if appID := c.Query("app_id"); appID != "" {
@@ -32,14 +44,28 @@ func ListDeployments(db *gorm.DB) gin.HandlerFunc {
 			query = query.Where("status = ?", status)
 		}
 
-		if err := query.Order("created_at DESC").Find(&records).Error; err != nil {
+		if err := query.Count(&total).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if err := query.Order("created_at DESC").Offset((page - 1) * pageSize).Limit(pageSize).Find(&records).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 		if records == nil {
 			records = []model.DeploymentRecord{}
 		}
-		respondSuccess(c, records)
+		// Return paginated response with data key for backward compatibility
+		c.JSON(http.StatusOK, gin.H{
+			"status": "success",
+			"data":   records,
+			"pagination": gin.H{
+				"page":      page,
+				"page_size": pageSize,
+				"total":     total,
+			},
+		})
 	}
 }
 

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/gin-gonic/gin"
@@ -22,19 +23,45 @@ import (
 // @Router       /providers [get]
 func ListProviders(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+		if page < 1 {
+			page = 1
+		}
+		if pageSize < 1 || pageSize > 100 {
+			pageSize = 20
+		}
+
 		var providers []model.Provider
+		var total int64
+
 		query := db.Model(&model.Provider{})
 		if pType := c.Query("type"); pType != "" {
 			query = query.Where("type = ?", pType)
 		}
-		if err := query.Find(&providers).Error; err != nil {
+
+		if err := query.Count(&total).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if err := query.Offset((page - 1) * pageSize).Limit(pageSize).Find(&providers).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 		if providers == nil {
 			providers = []model.Provider{}
 		}
-		respondSuccess(c, providers)
+		// Return paginated response with data key for backward compatibility
+		c.JSON(http.StatusOK, gin.H{
+			"status": "success",
+			"data":   providers,
+			"pagination": gin.H{
+				"page":      page,
+				"page_size": pageSize,
+				"total":     total,
+			},
+		})
 	}
 }
 

--- a/internal/api/ssl.go
+++ b/internal/api/ssl.go
@@ -19,12 +19,37 @@ import (
 // @Security     BearerAuth
 func ListSSLCertificates(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+		if page < 1 {
+			page = 1
+		}
+		if pageSize < 1 || pageSize > 100 {
+			pageSize = 20
+		}
+
 		var certs []model.SSLCertificate
-		if result := db.Find(&certs); result.Error != nil {
+		var total int64
+
+		if err := db.Model(&model.SSLCertificate{}).Count(&total).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.ssl.failed_to_list_certificates")
 			return
 		}
-		respondSuccess(c, certs)
+
+		if result := db.Offset((page - 1) * pageSize).Limit(pageSize).Find(&certs); result.Error != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.ssl.failed_to_list_certificates")
+			return
+		}
+		// Return paginated response with data key for backward compatibility
+		c.JSON(http.StatusOK, gin.H{
+			"status": "success",
+			"data":   certs,
+			"pagination": gin.H{
+				"page":      page,
+				"page_size": pageSize,
+				"total":     total,
+			},
+		})
 	}
 }
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
 	"github.com/Yogdunana/deploypilot/internal/model"
@@ -59,15 +60,40 @@ func GetCurrentUser(c *gin.Context) {
 // @Router       /users [get]
 func ListUsers(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+		if page < 1 {
+			page = 1
+		}
+		if pageSize < 1 || pageSize > 100 {
+			pageSize = 20
+		}
+
 		var users []model.User
-		if err := db.Preload("Role").Find(&users).Error; err != nil {
+		var total int64
+
+		if err := db.Model(&model.User{}).Count(&total).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		if err := db.Preload("Role").Offset((page - 1) * pageSize).Limit(pageSize).Find(&users).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 		if users == nil {
 			users = []model.User{}
 		}
-		respondSuccess(c, users)
+		// Return paginated response with data key for backward compatibility
+		c.JSON(http.StatusOK, gin.H{
+			"status": "success",
+			"data":   users,
+			"pagination": gin.H{
+				"page":      page,
+				"page_size": pageSize,
+				"total":     total,
+			},
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #337

Add pagination support to 5 List endpoints:
- ListUsers (users.go)
- ListApps (apps.go)
- ListDeployments (deployments.go)
- ListSSLCertificates (ssl.go)
- ListProviders (providers.go)

Query params: page (default 1), page_size (default 20, max 100)
Response includes pagination metadata: {page, page_size, total}