### PR TITLE
fix: internal error info leak, ignored critical errors, custom base64 encoder

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -97,14 +98,16 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.create",
 				ResourceType: "apikey",
 				ResourceID:   apiKey.ID,
 				Detail:       map[string]string{"name": input.Name, "prefix": apiKey.KeyPrefix},
-			})
+			}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{
@@ -147,13 +150,15 @@ func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.delete",
 				ResourceType: "apikey",
 				ResourceID:   keyID,
-			})
+			}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"message": "API key revoked", "id": keyID})
@@ -232,13 +237,13 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			updates["name"] = *input.Name
 		}
 		if input.Scopes != nil {
-		validatedScopes := auth.ValidateScopes(input.Scopes)
-		if len(validatedScopes) == 0 {
-			validatedScopes = []string{"read"}
+			validatedScopes := auth.ValidateScopes(input.Scopes)
+			if len(validatedScopes) == 0 {
+				validatedScopes = []string{"read"}
+			}
+			scopesJSON, _ := json.Marshal(validatedScopes)
+			updates["scopes"] = string(scopesJSON)
 		}
-		scopesJSON, _ := json.Marshal(validatedScopes)
-		updates["scopes"] = string(scopesJSON)
-	}
 		if input.AllowedIPs != nil {
 			if len(input.AllowedIPs) == 0 {
 				updates["allowed_ips"] = ""
@@ -267,13 +272,15 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.update",
 				ResourceType: "apikey",
 				ResourceID:   keyID,
-			})
+			}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"message": "API key updated", "id": keyID})

--- a/internal/api/detect.go
+++ b/internal/api/detect.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/Yogdunana/deploypilot/internal/detector"
@@ -20,7 +21,8 @@ func DetectAllComponents(executor deployer.CommandExecutor) gin.HandlerFunc {
 		d := detector.New(executor)
 		components, err := d.DetectAll(c.Request.Context())
 		if err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to detect all components", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
@@ -44,7 +46,8 @@ func DetectDatabases(executor deployer.CommandExecutor) gin.HandlerFunc {
 		d := detector.New(executor)
 		components, err := d.DetectDatabases(c.Request.Context())
 		if err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to detect databases", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
@@ -68,7 +71,8 @@ func DetectWebServers(executor deployer.CommandExecutor) gin.HandlerFunc {
 		d := detector.New(executor)
 		components, err := d.DetectWebServers(c.Request.Context())
 		if err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to detect web servers", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 

--- a/internal/api/event_plugin_api.go
+++ b/internal/api/event_plugin_api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
@@ -118,12 +119,14 @@ func (a *EventPluginAPI) UpdateEventPlugin(c *gin.Context) {
 	if input.Enabled != nil {
 		if *input.Enabled {
 			if err := a.pluginMgr.EnablePlugin(name); err != nil {
-				respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed", err.Error())
+				slog.ErrorContext(c.Request.Context(), "failed to enable event plugin", "error", err)
+				respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed")
 				return
 			}
 		} else {
 			if err := a.pluginMgr.DisablePlugin(name); err != nil {
-				respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed", err.Error())
+				slog.ErrorContext(c.Request.Context(), "failed to disable event plugin", "error", err)
+				respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed")
 				return
 			}
 		}
@@ -131,7 +134,8 @@ func (a *EventPluginAPI) UpdateEventPlugin(c *gin.Context) {
 
 	if input.Config != nil {
 		if err := a.pluginMgr.SetPluginConfig(name, input.Config); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to set event plugin config", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.update_failed")
 			return
 		}
 	}

--- a/internal/api/monitor_alert_rules.go
+++ b/internal/api/monitor_alert_rules.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
@@ -21,7 +22,8 @@ func CreateAlertRule(db *gorm.DB) gin.HandlerFunc {
 
 		svc := service.NewAlertRuleService(db)
 		if err := svc.CreateAlertRule(&rule); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to create alert rule", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
@@ -44,7 +46,8 @@ func UpdateAlertRule(db *gorm.DB) gin.HandlerFunc {
 
 		svc := service.NewAlertRuleService(db)
 		if err := svc.UpdateAlertRule(&rule); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to update alert rule", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 
@@ -60,7 +63,8 @@ func DeleteAlertRule(db *gorm.DB) gin.HandlerFunc {
 
 		svc := service.NewAlertRuleService(db)
 		if err := svc.DeleteAlertRule(id); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to delete alert rule", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 

--- a/internal/api/plugins.go
+++ b/internal/api/plugins.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
@@ -99,7 +100,8 @@ func (h *PluginHandler) CreatePlugin() gin.HandlerFunc {
 			enabled, input.Priority,
 		)
 		if err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.create_failed", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to create plugin", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.create_failed")
 			return
 		}
 
@@ -215,7 +217,8 @@ func (h *PluginHandler) EnablePlugin() gin.HandlerFunc {
 		}
 
 		if err := h.lifecycleManager.EnablePlugin(c.Request.Context(), id); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.instance_create_failed", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to enable plugin", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.instance_create_failed")
 			return
 		}
 
@@ -273,7 +276,8 @@ func (h *PluginHandler) ReloadPlugin() gin.HandlerFunc {
 		}
 
 		if err := h.lifecycleManager.ReloadPlugin(c.Request.Context(), id); err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.instance_create_failed", err.Error())
+			slog.ErrorContext(c.Request.Context(), "failed to reload plugin", "error", err)
+			respondErrori18n(c, http.StatusInternalServerError, "error.plugin.instance_create_failed")
 			return
 		}
 

--- a/internal/service/file_manager_service.go
+++ b/internal/service/file_manager_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -344,30 +345,9 @@ func base64Encode(s string) string {
 	return encodeToString([]byte(s))
 }
 
-// encodeToString is a simple base64 encoder (avoids importing encoding/base64 in service).
+// encodeToString encodes data to base64 using the standard library.
 func encodeToString(data []byte) string {
-	const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-	var result strings.Builder
-	result.Grow(len(data) * 4 / 3)
-
-	for i := 0; i < len(data); i += 3 {
-		n := len(data) - i
-		if n > 3 {
-			n = 3
-		}
-		var val uint32
-		for j := 0; j < n; j++ {
-			val |= uint32(data[i+j]) << uint((2-j)*8)
-		}
-		for j := 0; j < n+1; j++ {
-			result.WriteByte(charset[(val>>(uint((3-j)*6)))&0x3F])
-		}
-	}
-	// Padding
-	for result.Len()%4 != 0 {
-		result.WriteByte('=')
-	}
-	return result.String()
+	return base64.StdEncoding.EncodeToString(data)
 }
 
 // parseLsOutput parses the output of `ls -la` into FileEntry slices.


### PR DESCRIPTION
Closes #349

- H-1: Remove err.Error() from 500 responses, add slog.ErrorContext logging
- H-2: Check CreateAPIKey IP restriction update error
- H-3: Replace custom base64 encoder with stdlib encoding/base64