### PR TITLE
fix: JWT time.Now atomicity, audit log errors, SystemHealth info leak

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -97,14 +98,16 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.create",
 				ResourceType: "apikey",
 				ResourceID:   apiKey.ID,
 				Detail:       map[string]string{"name": input.Name, "prefix": apiKey.KeyPrefix},
-			})
+			}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{
@@ -147,13 +150,15 @@ func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.delete",
 				ResourceType: "apikey",
 				ResourceID:   keyID,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"message": "API key revoked", "id": keyID})
@@ -267,13 +272,15 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     uid,
 				Action:       "apikey.update",
 				ResourceType: "apikey",
 				ResourceID:   keyID,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"message": "API key updated", "id": keyID})

--- a/internal/api/system.go
+++ b/internal/api/system.go
@@ -96,11 +96,13 @@ func SystemHealth(db *gorm.DB) gin.HandlerFunc {
 		// Check database
 		sqlDB, err := db.DB()
 		if err != nil {
+			slog.ErrorContext(c.Request.Context(), "database health check failed", "error", err)
 			health["status"] = "unhealthy"
-			health["database"] = gin.H{"status": "error", "message": err.Error()}
+			health["database"] = gin.H{"status": "error", "message": "connection failed"}
 		} else if err := sqlDB.Ping(); err != nil {
+			slog.ErrorContext(c.Request.Context(), "database health check failed", "error", err)
 			health["status"] = "unhealthy"
-			health["database"] = gin.H{"status": "error", "message": err.Error()}
+			health["database"] = gin.H{"status": "error", "message": "connection failed"}
 		} else {
 			health["database"] = gin.H{"status": "ok"}
 		}

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -83,13 +83,15 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(user.ID),
 				Username:     user.Username,
 				Action:       "auth.2fa_verify",
 				ResourceType: "user",
 				ResourceID:   user.ID,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{
@@ -160,13 +162,15 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     user.Username,
 				Action:       "auth.2fa_setup",
 				ResourceType: "user",
 				ResourceID:   uid,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		qrURL := auth.TOTPQRCodeURL(secret, user.Username)
@@ -228,13 +232,15 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     user.Username,
 				Action:       "auth.2fa_confirm",
 				ResourceType: "user",
 				ResourceID:   uid,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"enabled": true})
@@ -298,13 +304,15 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     user.Username,
 				Action:       "auth.2fa_disable",
 				ResourceType: "user",
 				ResourceID:   uid,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"enabled": false})
@@ -373,13 +381,15 @@ func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.Hand
 		}
 
 		if auditSvc != nil {
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(uid),
 				Username:     user.Username,
 				Action:       "auth.2fa_regenerate_codes",
 				ResourceType: "user",
 				ResourceID:   uid,
-			})
+			}}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		respondSuccess(c, gin.H{"backup_codes": plaintextCodes})
@@ -470,14 +480,16 @@ func ResetUser2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 		if auditSvc != nil {
 			adminID, _ := c.Get(string(auth.UserIDKey))
 			adminUID, _ := adminID.(string)
-			_ = auditSvc.Record(c.Request.Context(), service.AuditEntry{
+			if err := auditSvc.Record(c.Request.Context(), service.AuditEntry{
 				UserID:       parseUserID(adminUID),
 				Username:     "",
 				Action:       "auth.2fa_admin_reset",
 				ResourceType: "user",
 				ResourceID:   targetUserID,
 				Detail:       "admin reset 2FA for user " + user.Username,
-			})
+			}); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+			}
 		}
 
 		slog.Info("admin reset 2FA for user", "target_user", user.Username, "target_id", targetUserID)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -37,13 +37,14 @@ func GenerateToken(userID, role string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get JWT secret: %w", err)
 	}
+	now := time.Now()
 	claims := &Claims{
 		UserID: userID,
 		Role:   role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        uuid.New().String(),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(now.Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -52,13 +53,14 @@ func GenerateToken(userID, role string) (string, error) {
 
 // Generate2FAPendingToken creates a short-lived JWT (5 minutes) for 2FA verification.
 func Generate2FAPendingToken(userID, role string) (string, error) {
+	now := time.Now()
 	claims := &Claims{
 		UserID: userID,
 		Role:   role,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        uuid.New().String(),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
 		},
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)


### PR DESCRIPTION
Closes #351

- L-1: Use single now variable in GenerateToken/Generate2FAPendingToken
- L-2: Log audit record errors with slog.Warn
- L-3: Hide DB error details in SystemHealth