### PR TITLE
fix: GetDiskUsage path traversal, regex precompilation, token revocation errors

### DIFF
--- a/internal/api/refresh.go
+++ b/internal/api/refresh.go
@@ -112,7 +112,9 @@ func RefreshToken() gin.HandlerFunc {
 		}
 
 		// Rotate: revoke old refresh token, issue new pair
-		_ = refreshStore.Revoke(refreshToken)
+		if err := refreshStore.Revoke(refreshToken); err != nil {
+			slog.WarnContext(c.Request.Context(), "failed to revoke old refresh token", "error", err)
+		}
 
 		// Generate new access token
 		accessToken, err := auth.GenerateToken(entry.UserID, entry.Role)
@@ -168,7 +170,9 @@ func LogoutAllDevices() gin.HandlerFunc {
 		}
 
 		if refreshStore != nil {
-			_ = refreshStore.RevokeAllForUser(uid)
+			if err := refreshStore.RevokeAllForUser(uid); err != nil {
+				slog.WarnContext(c.Request.Context(), "failed to revoke all refresh tokens", "error", err)
+			}
 		}
 
 		clearAuthCookies(c)

--- a/internal/api/ssl.go
+++ b/internal/api/ssl.go
@@ -143,7 +143,10 @@ func RenewSSLCertificate(db *gorm.DB) gin.HandlerFunc {
 		cert.RetryCount++
 		newExpiresAt := time.Now().AddDate(0, 0, 90)
 		cert.ExpiresAt = &newExpiresAt
-		db.Save(&cert)
+		if result := db.Save(&cert); result.Error != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.ssl.failed_to_renew_certificate")
+			return
+		}
 		respondSuccess(c, gin.H{"data": cert, "message": "renewal initiated"})
 	}
 }

--- a/internal/detector/detector.go
+++ b/internal/detector/detector.go
@@ -12,6 +12,13 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
 )
 
+var (
+	versionFullRe    = regexp.MustCompile(`(\d+\.\d+\.\d+[a-z0-9]*)`)
+	versionPrefixedRe = regexp.MustCompile(`v(\d+\.\d+)`)
+	versionShortRe   = regexp.MustCompile(`(\d+\.\d+)`)
+	nginxVersionRe   = regexp.MustCompile(`(?:nginx|openresty)/([\d.]+)`)
+)
+
 // ComponentType represents the type of detected system component.
 type ComponentType string
 
@@ -472,15 +479,16 @@ func (d *Detector) detectOpenResty(ctx context.Context) (DetectedComponent, erro
 
 // extractVersion extracts a version string from command output using regex.
 func extractVersion(output string) string {
-	patterns := []string{
-		`(\d+\.\d+\.\d+[a-z0-9]*)`,  // e.g. 8.0.35, 15.2
-		`v(\d+\.\d+)`,                 // e.g. v7.2
-		`(\d+\.\d+)`,                  // e.g. 7.2
+	patterns := []struct {
+		re *regexp.Regexp
+	}{
+		{versionFullRe},
+		{versionPrefixedRe},
+		{versionShortRe},
 	}
 
-	for _, pattern := range patterns {
-		re := regexp.MustCompile(pattern)
-		matches := re.FindStringSubmatch(output)
+	for _, p := range patterns {
+		matches := p.re.FindStringSubmatch(output)
 		if len(matches) > 1 {
 			return matches[1]
 		}
@@ -495,7 +503,7 @@ func extractVersion(output string) string {
 // nginx -v output format: "nginx version: nginx/1.24.0" or "nginx version: openresty/1.25.3.1"
 func extractVersionFromNginxOutput(output string) string {
 	// Try to extract from "nginx/X.Y.Z" or "openresty/X.Y.Z"
-	re := regexp.MustCompile(`(?:nginx|openresty)/([\d.]+)`)
+	re := nginxVersionRe
 	matches := re.FindStringSubmatch(output)
 	if len(matches) > 1 {
 		return matches[1]

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/engine/deployer"
 )
 
+var mainDiskRe = regexp.MustCompile(`^(sd[a-z]|vd[a-z]|xvd[a-z]|nvme\d+n\d+|mmcblk\d+)$`)
+
 // MetricType defines the type of metric.
 type MetricType string
 
@@ -477,7 +479,6 @@ func collectDiskIOMetrics(ctx context.Context, executor deployer.CommandExecutor
 
 	// Pattern to match main disk devices, not partitions
 	// Matches: sda, vda, xvda, nvme0n1, etc. Skips: sda1, vda2, etc.
-	mainDiskRe := regexp.MustCompile(`^(sd[a-z]|vd[a-z]|xvd[a-z]|nvme\d+n\d+|mmcblk\d+)$`)
 
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {

--- a/internal/service/file_manager_service.go
+++ b/internal/service/file_manager_service.go
@@ -246,6 +246,9 @@ func (f *FileManagerService) MoveFile(ctx context.Context, serverID, srcPath, ds
 
 // GetDiskUsage returns disk usage information for a remote path.
 func (f *FileManagerService) GetDiskUsage(ctx context.Context, serverID, remotePath string) (*DiskUsage, error) {
+	if isPathBlocked(remotePath) {
+		return nil, fmt.Errorf("access to path %s is blocked", remotePath)
+	}
 	cmd := fmt.Sprintf("df -B1 --output=size,used,avail,pcent %s 2>/dev/null | tail -1", util.ShellQuote(remotePath))
 	if err := f.sb.Validate(cmd); err != nil {
 		return nil, fmt.Errorf("sandbox blocked: %w", err)

--- a/internal/service/firewall_service.go
+++ b/internal/service/firewall_service.go
@@ -17,6 +17,8 @@ import (
 // FirewallType represents the detected firewall backend.
 type FirewallType string
 
+var ufwLineRe = regexp.MustCompile(`\[(\d+)\]\s+(\S+)\s+(ALLOW|DENY|REJECT)\s+IN\s+(.*)`)
+
 const (
 	FirewallTypeUFW      FirewallType = "ufw"
 	FirewallTypeFirewalld FirewallType = "firewalld"
@@ -369,8 +371,7 @@ func parseUFWOutput(output string) []FirewallRule {
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		// Match lines like: "[ 1] 22/tcp                   ALLOW IN    Anywhere"
-		re := regexp.MustCompile(`\[(\d+)\]\s+(\S+)\s+(ALLOW|DENY|REJECT)\s+IN\s+(.*)`)
-		matches := re.FindStringSubmatch(line)
+		matches := ufwLineRe.FindStringSubmatch(line)
 		if len(matches) >= 5 {
 			rules = append(rules, FirewallRule{
 				ID:     matches[1],


### PR DESCRIPTION
Closes #350

- M-1: Add isPathBlocked check to GetDiskUsage
- M-2: Precompile regexps at package level
- M-3: Log token revocation errors
- M-4: Check db.Save error in RenewSSLCertificate