### PR TITLE
fix: CheckContainerHealth logic, blockedPaths, HTTP timeout, goroutine leak

### DIFF
--- a/internal/api/monitor.go
+++ b/internal/api/monitor.go
@@ -128,12 +128,12 @@ func HealContainer(bridge *service.Bridge) gin.HandlerFunc {
 
 // CheckContainerHealth runs a health check for a specific container.
 // @Summary      Check container health
-// @Description  Run a health check for a specific container
+// @Description  Retrieve the current status of a specific container (read-only health check, does not trigger self-healing)
 // @Tags         Monitor
 // @Produce      json
 // @Security     BearerAuth
 // @Param        name path string true "Container name"
-// @Success      200 {object} map[string]interface{} "status, data (health check result)"
+// @Success      200 {object} map[string]interface{} "status, data (container status)"
 // @Failure      400 {object} map[string]interface{} "container name is required"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
@@ -145,7 +145,7 @@ func CheckContainerHealth(bridge *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "error.monitor.container_name_required")
 			return
 		}
-		data, err := bridge.HealContainer(c.Request.Context(), name)
+		data, err := bridge.GetContainerStatus(c.Request.Context(), name)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -209,7 +209,15 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 		if delay > 30 {
 			delay = 30
 		}
-		time.Sleep(time.Duration(delay) * time.Second)
+		select {
+		case <-s.ctx.Done():
+			slog.Info("webhook retry cancelled: service shutting down",
+				"webhook_id", webhook.ID,
+				"event_id", delivery.EventID,
+			)
+			return
+		case <-time.After(time.Duration(delay) * time.Second):
+		}
 
 		attempt++
 
@@ -219,7 +227,7 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 			timeout = 10 * time.Second
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(s.ctx, timeout)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhook.URL, bytes.NewReader([]byte(delivery.RequestBody)))


### PR DESCRIPTION
Closes #356

- H-1: Fix CheckContainerHealth to call GetContainerStatus instead of HealContainer
- H-4: retryDelivery uses s.ctx for cancellation on shutdown