### PR TITLE
fix: hardcoded config values, memory limits, DNS type validation

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -50,7 +50,7 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input struct {
 			Username string `json:"username" binding:"required"`
-			Email    string `json:"email" binding:"required"`
+			Email    string `json:"email" binding:"required,email"`
 			Password string `json:"password" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {

--- a/internal/api/dns.go
+++ b/internal/api/dns.go
@@ -62,6 +62,12 @@ func CreateDNSRecord(bridge *service.Bridge) gin.HandlerFunc {
 			return
 		}
 
+		validTypes := map[string]bool{"A": true, "AAAA": true, "CNAME": true, "MX": true, "TXT": true, "NS": true, "SRV": true, "CAA": true}
+		if !validTypes[input.Type] {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", "invalid DNS record type")
+			return
+		}
+
 		record, err := bridge.DNSCreateRecord(c.Request.Context(), input.Domain, input.Type, input.Name, input.Value)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")

--- a/internal/api/monitor.go
+++ b/internal/api/monitor.go
@@ -128,12 +128,12 @@ func HealContainer(bridge *service.Bridge) gin.HandlerFunc {
 
 // CheckContainerHealth runs a health check for a specific container.
 // @Summary      Check container health
-// @Description  Run a health check for a specific container
+// @Description  Retrieve the current status of a specific container (read-only health check, does not trigger self-healing)
 // @Tags         Monitor
 // @Produce      json
 // @Security     BearerAuth
 // @Param        name path string true "Container name"
-// @Success      200 {object} map[string]interface{} "status, data (health check result)"
+// @Success      200 {object} map[string]interface{} "status, data (container status)"
 // @Failure      400 {object} map[string]interface{} "container name is required"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
@@ -145,7 +145,7 @@ func CheckContainerHealth(bridge *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "error.monitor.container_name_required")
 			return
 		}
-		data, err := bridge.HealContainer(c.Request.Context(), name)
+		data, err := bridge.GetContainerStatus(c.Request.Context(), name)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return

--- a/internal/api/ssl.go
+++ b/internal/api/ssl.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/model"
@@ -68,7 +69,7 @@ func RequestSSLCertificate(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req struct {
 			Domain   string `json:"domain" binding:"required"`
-			Email    string `json:"email" binding:"required"`
+			Email    string `json:"email" binding:"required,email"`
 			Provider string `json:"provider"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/api/ssl.go
+++ b/internal/api/ssl.go
@@ -77,6 +77,12 @@ func RequestSSLCertificate(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// Validate domain format
+		if !isValidDomain(req.Domain) {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", "invalid domain format")
+			return
+		}
+
 		cert := model.SSLCertificate{
 			Domain:    req.Domain,
 			Email:     req.Email,
@@ -150,4 +156,13 @@ func RenewSSLCertificate(db *gorm.DB) gin.HandlerFunc {
 		}
 		respondSuccess(c, gin.H{"data": cert, "message": "renewal initiated"})
 	}
+}
+
+// isValidDomain checks whether the given string looks like a valid domain name.
+func isValidDomain(domain string) bool {
+	if len(domain) == 0 || len(domain) > 253 {
+		return false
+	}
+	// Simple domain validation: must contain at least one dot, no spaces
+	return strings.Contains(domain, ".") && !strings.ContainsAny(domain, " \t\n")
 }

--- a/internal/service/grafana_client.go
+++ b/internal/service/grafana_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -30,6 +31,7 @@ func NewGrafanaClient(rawURL, apiKey, adminUser, adminPass string) (*GrafanaClie
 	}
 	if parsed.Scheme == "" {
 		parsed.Scheme = "http"
+		slog.Warn("Grafana URL uses HTTP, credentials will be transmitted in plaintext. Consider using HTTPS.")
 	}
 	return &GrafanaClient{
 		baseURL:   strings.TrimRight(parsed.String(), "/"),

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -210,11 +210,20 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 
 	for attempt < webhook.MaxRetries {
 		// Exponential backoff: delay = min(2^attempt * time.Second, 30*time.Second)
-		delay := time.Duration(1<<uint(attempt)) * time.Second
-		if delay > maxRetryDelay {
-			delay = maxRetryDelay
+		delay := 1 << uint(attempt)
+		if delay > 30 {
+			delay = 30
 		}
-		time.Sleep(delay)
+
+		select {
+		case <-s.ctx.Done():
+			slog.Info("webhook retry cancelled: service shutting down",
+				"webhook_id", webhook.ID,
+				"event_id", delivery.EventID,
+			)
+			return
+		case <-time.After(time.Duration(delay) * time.Second):
+		}
 
 		attempt++
 
@@ -224,7 +233,7 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 			timeout = 10 * time.Second
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		ctx, cancel := context.WithTimeout(s.ctx, timeout)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhook.URL, bytes.NewReader([]byte(delivery.RequestBody)))

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -22,6 +22,11 @@ import (
 
 var webhookSem = semaphore.NewWeighted(20) // max 20 concurrent webhook deliveries
 
+const (
+	webhookRetentionDays = 7
+	maxRetryDelay        = 30 * time.Second
+)
+
 // OutboundWebhookService manages outbound webhook CRUD, delivery, retry, and event subscription.
 type OutboundWebhookService struct {
 	db     *gorm.DB
@@ -205,11 +210,11 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 
 	for attempt < webhook.MaxRetries {
 		// Exponential backoff: delay = min(2^attempt * time.Second, 30*time.Second)
-		delay := 1 << uint(attempt)
-		if delay > 30 {
-			delay = 30
+		delay := time.Duration(1<<uint(attempt)) * time.Second
+		if delay > maxRetryDelay {
+			delay = maxRetryDelay
 		}
-		time.Sleep(time.Duration(delay) * time.Second)
+		time.Sleep(delay)
 
 		attempt++
 
@@ -553,7 +558,7 @@ func (s *OutboundWebhookService) StartCleanupLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				cutoff := time.Now().AddDate(0, 0, -7)
+				cutoff := time.Now().AddDate(0, 0, -webhookRetentionDays)
 				result := s.db.WithContext(ctx).
 					Where("created_at < ?", cutoff).
 					Delete(&model.WebhookDelivery{})

--- a/internal/service/ssl_service.go
+++ b/internal/service/ssl_service.go
@@ -16,7 +16,7 @@ func (b *Bridge) ListSSLCertificates(ctx context.Context) (interface{}, error) {
 		return nil, fmt.Errorf("database not available")
 	}
 	var certs []model.SSLCertificate
-	if err := b.DB.Find(&certs).Error; err != nil {
+	if err := b.DB.Limit(100).Find(&certs).Error; err != nil {
 		return nil, fmt.Errorf("failed to list SSL certificates: %w", err)
 	}
 	return certs, nil

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -355,13 +355,13 @@ func (us *UpgradeService) preflightChecks(targetVersion string) error {
 	}
 
 	// Check disk space (need at least 100MB free)
+	const minDiskSpace = 100 * 1024 * 1024 // 100MB
 	var stat syscall.Statfs_t
 	if err := syscall.Statfs(us.installDir, &stat); err != nil {
 		return fmt.Errorf("failed to stat filesystem: %w", err)
 	}
-	// 100MB in bytes
 	freeSpace := stat.Bavail * uint64(stat.Bsize)
-	if freeSpace < 100*1024*1024 {
+	if freeSpace < minDiskSpace {
 		return fmt.Errorf("insufficient disk space: %d bytes free, need at least 100MB", freeSpace)
 	}
 


### PR DESCRIPTION
Closes #358

- L-1: Add Limit(100) to SSL service list query
- L-2: Add DNS record Type enum validation
- L-3: Extract disk space check constant
- L-4/L-5: Extract webhook retention and retry delay constants