### PR TITLE
fix: WS/SSE rate limiting, audit log sanitization, UpdateApp field whitelist

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -179,7 +179,21 @@ func UpdateApp(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
-		if err := db.Model(&model.App{}).Where("id = ?", id).Updates(updates).Error; err != nil {
+		allowedFields := map[string]bool{
+			"name": true, "description": true, "git_repo": true,
+			"git_branch": true, "build_cmd": true, "deploy_path": true,
+			"env_vars": true, "auto_deploy": true, "dockerfile_path": true,
+			"docker_image": true, "compose_path": true, "health_check_path": true,
+			"health_check_interval": true, "notification_id": true,
+		}
+		filtered := make(map[string]interface{})
+		for k, v := range updates {
+			if allowedFields[k] {
+				filtered[k] = v
+			}
+		}
+
+		if err := db.Model(&model.App{}).Where("id = ?", id).Updates(filtered).Error; err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,7 +27,7 @@ var globalMonitorAPI *MonitorAPI
 func GetGlobalMonitorAPI() *MonitorAPI { return globalMonitorAPI }
 
 // RegisterRoutes registers all API routes on the given Gin engine.
-func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, eventPluginMgr *plugin.EventPluginManager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig, apiPlatformCfg *config.APIPlatformConfig) {
+func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *WSHub, auditSvc *service.AuditService, pluginManager *plugin.Manager, eventPluginMgr *plugin.EventPluginManager, blacklist auth.TokenBlacklist, oauthSvc *service.OAuthService, backupSvc *backup.Service, keySvc *service.APIKeyService, metricsPublic bool, grafanaCfg *config.GrafanaConfig, apiPlatformCfg *config.APIPlatformConfig, rateLimiter *middleware.RateLimiter) {
 	// Swagger documentation — only accessible in development mode.
 	// In production, the endpoint is disabled to prevent information leakage.
 	if os.Getenv("DEPLOYPILOT_ENV") == "development" || os.Getenv("GIN_MODE") == "debug" {
@@ -69,6 +69,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 	}
 
 	wsGroup := r.Group("/ws")
+	if rateLimiter != nil {
+		wsGroup.Use(rateLimiter.Middleware())
+	}
 	{
 		wsGroup.GET("/logs/:app_id", LogStreamWS(bridge, wsHub, ticketStore))
 		wsGroup.GET("/terminal/:server_id", TerminalWS(bridge, wsHub, ticketStore))
@@ -79,6 +82,9 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 	// SSE routes (requires auth)
 	sseGroup := api.Group("/sse")
 	sseGroup.Use(auth.AuthMiddleware(blacklist))
+	if rateLimiter != nil {
+		sseGroup.Use(rateLimiter.Middleware())
+	}
 	{
 		sseGroup.GET("/deploy/:app_id", DeploySSE(bridge))
 		sseGroup.GET("/alerts", AlertSSE(bridge))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -153,7 +153,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 		api.SetRefreshTokenStore(memRefreshStore)
 	}
 
-	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, eventPluginMgr, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic, &cfg.Grafana, &cfg.APIPlatform)
+	api.RegisterRoutes(r, db, bridge, wsHub, auditSvc, nil, eventPluginMgr, blacklist, oauthSvc, backupSvc, keySvc, cfg.Monitor.MetricsPublic, &cfg.Grafana, &cfg.APIPlatform, rateLimiter)
 
 	// Serve embedded frontend static files
 	serveStaticFiles(r)

--- a/internal/service/audit_writer.go
+++ b/internal/service/audit_writer.go
@@ -47,7 +47,7 @@ func (w *FileAuditWriter) Write(entry AuditEntry) error {
 		"action":       entry.Action,
 		"resource_type": entry.ResourceType,
 		"resource_id":  entry.ResourceID,
-		"detail":       entry.Detail,
+		"detail":       sanitizeAuditData(entry.Detail),
 		"ip_address":   entry.IPAddress,
 		"user_agent":   entry.UserAgent,
 	}


### PR DESCRIPTION
Closes #372

- H-1: Add rate limiter to WebSocket and SSE route groups
- H-2: Sanitize sensitive fields in audit log entries
- H-3: Add field whitelist to UpdateApp to prevent unauthorized field updates