### PR TITLE
fix: cache stampede, DNS cache, terminal validation, WSMonitor lock, io.ReadAll limits

### DIFF
--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -567,6 +567,9 @@ func TerminalWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketSt
 					if m, ok := wsMsg.Data.(map[string]interface{}); ok {
 						rows := int(m["rows"].(float64))
 						cols := int(m["cols"].(float64))
+						if rows < 1 || rows > 500 || cols < 1 || cols > 500 {
+							continue
+						}
 						_ = session.SetWindowSize(rows, cols)
 					}
 				}

--- a/internal/api/ws_monitor.go
+++ b/internal/api/ws_monitor.go
@@ -52,10 +52,14 @@ func (h *WSMonitorHub) Run() {
 
 	case message := <-h.broadcast:
 		h.mu.RLock()
+		clients := make([]*websocket.Conn, 0, len(h.clients))
 		for conn := range h.clients {
-			_ = conn.WriteMessage(websocket.TextMessage, message)
+			clients = append(clients, conn)
 		}
 		h.mu.RUnlock()
+		for _, conn := range clients {
+			_ = conn.WriteMessage(websocket.TextMessage, message)
+		}
 
 	case <-h.done:
 		return

--- a/internal/service/dns_service.go
+++ b/internal/service/dns_service.go
@@ -117,10 +117,34 @@ func (b *Bridge) DNSListRecords(ctx context.Context, domain string) (interface{}
 
 	provider, err := b.getDNSProvider(ctx)
 	if err != nil {
+		// Cache empty result with short TTL to prevent repeated provider errors
+		if b.Cache != nil {
+			cacheKey := fmt.Sprintf("dns:%s:records", domain)
+			emptyResp := map[string]interface{}{
+				"status":  "error",
+				"domain":  domain,
+				"records": []map[string]interface{}{},
+			}
+			if cacheErr := b.Cache.SetJSON(ctx, cacheKey, emptyResp, 30*time.Second); cacheErr != nil {
+				slog.Warn("DNS cache set error (empty)", "error", cacheErr)
+			}
+		}
 		return nil, fmt.Errorf("DNS provider error: %w", err)
 	}
 	records, err := provider.ListRecords(ctx, domain)
 	if err != nil {
+		// Cache empty result with short TTL to prevent repeated query errors
+		if b.Cache != nil {
+			cacheKey := fmt.Sprintf("dns:%s:records", domain)
+			emptyResp := map[string]interface{}{
+				"status":  "error",
+				"domain":  domain,
+				"records": []map[string]interface{}{},
+			}
+			if cacheErr := b.Cache.SetJSON(ctx, cacheKey, emptyResp, 30*time.Second); cacheErr != nil {
+				slog.Warn("DNS cache set error (empty)", "error", cacheErr)
+			}
+		}
 		return nil, fmt.Errorf("DNS list records failed: %w", err)
 	}
 	// Convert to response format

--- a/internal/service/feature_flag_service.go
+++ b/internal/service/feature_flag_service.go
@@ -16,6 +16,7 @@ import (
 // FeatureFlagCache is an in-memory cache of feature flags with TTL.
 type FeatureFlagCache struct {
 	mu      sync.RWMutex
+	loadMu  sync.Mutex
 	flags   map[string]*model.FeatureFlag
 	overrides map[string]map[string]*model.FeatureFlagOverride // flagKey -> tenantID -> override
 	loadedAt time.Time
@@ -165,11 +166,17 @@ func (b *Bridge) EvaluateFeature(ctx context.Context, featureKey string, tenantI
 	if tenantID != "" {
 		override := b.featureFlagCache.GetOverride(featureKey, tenantID)
 		if override == nil {
-			// Cache miss: try loading from DB
-			var dbOverride model.FeatureFlagOverride
-			if err := b.DB.Where("flag_key = ? AND tenant_id = ?", featureKey, tenantID).First(&dbOverride).Error; err == nil {
-				override = &dbOverride
+			// Cache miss: acquire loadMu to prevent cache stampede
+			b.featureFlagCache.loadMu.Lock()
+			// double-check cache after acquiring lock
+			override = b.featureFlagCache.GetOverride(featureKey, tenantID)
+			if override == nil {
+				var dbOverride model.FeatureFlagOverride
+				if err := b.DB.Where("flag_key = ? AND tenant_id = ?", featureKey, tenantID).First(&dbOverride).Error; err == nil {
+					override = &dbOverride
+				}
 			}
+			b.featureFlagCache.loadMu.Unlock()
 		}
 		if override != nil {
 			return override.Enabled, nil
@@ -179,11 +186,17 @@ func (b *Bridge) EvaluateFeature(ctx context.Context, featureKey string, tenantI
 	// 2. Check dynamic feature flag from DB
 	flag := b.featureFlagCache.Get(featureKey)
 	if flag == nil {
-		// Cache miss: try loading from DB
-		var dbFlag model.FeatureFlag
-		if err := b.DB.Where("key = ?", featureKey).First(&dbFlag).Error; err == nil {
-			flag = &dbFlag
+		// Cache miss: acquire loadMu to prevent cache stampede
+		b.featureFlagCache.loadMu.Lock()
+		// double-check cache after acquiring lock
+		flag = b.featureFlagCache.Get(featureKey)
+		if flag == nil {
+			var dbFlag model.FeatureFlag
+			if err := b.DB.Where("key = ?", featureKey).First(&dbFlag).Error; err == nil {
+				flag = &dbFlag
+			}
 		}
+		b.featureFlagCache.loadMu.Unlock()
 	}
 	if flag != nil {
 		if flag.Status != model.FeatureFlagEnabled {

--- a/internal/service/grafana_client.go
+++ b/internal/service/grafana_client.go
@@ -77,7 +77,7 @@ func (c *GrafanaClient) doRequest(method, path string, body interface{}) ([]byte
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
 	if err != nil {
 		return nil, resp.StatusCode, fmt.Errorf("read response body: %w", err)
 	}

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -145,7 +145,7 @@ func (s *OutboundWebhookService) Deliver(ctx context.Context, webhook *model.Out
 	} else {
 		defer func() { _ = resp.Body.Close() }()
 		statusCode = resp.StatusCode
-		respBytes, _ := io.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
 		respBody = string(respBytes)
 	}
 
@@ -261,7 +261,7 @@ func (s *OutboundWebhookService) retryDelivery(webhook *model.OutboundWebhook, d
 		} else {
 			defer func() { _ = resp.Body.Close() }()
 			statusCode = resp.StatusCode
-			respBytes, _ := io.ReadAll(resp.Body)
+			respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
 			respBody = string(respBytes)
 		}
 
@@ -373,7 +373,7 @@ func (s *OutboundWebhookService) TestDelivery(ctx context.Context, webhookID str
 	} else {
 		defer func() { _ = resp.Body.Close() }()
 		statusCode = resp.StatusCode
-		respBytes, _ := io.ReadAll(resp.Body)
+		respBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
 		respBody = string(respBytes)
 	}
 


### PR DESCRIPTION
Closes #373

- M-1: FeatureFlagCache singleflight pattern for cache stampede
- M-2: DNS cache empty results to prevent penetration
- M-3: Terminal resize rows/cols range validation (1-500)
- M-4: WSMonitorHub broadcast lock optimization
- M-5: io.ReadAll wrapped with LimitReader (1MB max)