### PR TITLE
fix: Swagger duplicate, formatter comments, HTTP 201 for create, UTC timestamps

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -75,7 +75,10 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
-		respondSuccess(c, app)
+		c.JSON(http.StatusCreated, gin.H{
+			"status": "success",
+			"data":   app,
+		})
 	}
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -135,15 +135,18 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 			}
 		}
 
-		respondSuccess(c, gin.H{
-			"user": model.User{
-				ID:       user.ID,
-				TenantID: user.TenantID,
-				RoleID:   user.RoleID,
-				Username: user.Username,
-				Email:    user.Email,
+		c.JSON(http.StatusCreated, gin.H{
+			"status": "success",
+			"data": gin.H{
+				"user": model.User{
+					ID:       user.ID,
+					TenantID: user.TenantID,
+					RoleID:   user.RoleID,
+					Username: user.Username,
+					Email:    user.Email,
+				},
+				"token": token,
 			},
-			"token": token,
 		})
 	}
 }

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -593,7 +593,6 @@ var TwoFARL = newTwoFARateLimiter(10, 5*time.Minute)
 // @Tags         2FA
 // @Produce      json
 // @Failure      429 {object} map[string]interface{} "too many 2FA attempts"
-// @Router       /auth/2fa/verify [post]
 func Check2FARateLimit() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ip := c.ClientIP()

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -475,7 +475,7 @@ func streamContainerLogs(ctx context.Context, bridge *service.Bridge, containerN
 			if err != nil {
 				hub.Broadcast(appID, WSMessage{
 					Type:      "error",
-					Timestamp: time.Now().Format(time.RFC3339),
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
 					Data:      err.Error(),
 					AppID:     appID,
 				})
@@ -483,7 +483,7 @@ func streamContainerLogs(ctx context.Context, bridge *service.Bridge, containerN
 			}
 			hub.Broadcast(appID, WSMessage{
 				Type:      "log",
-				Timestamp: time.Now().Format(time.RFC3339),
+				Timestamp: time.Now().UTC().Format(time.RFC3339),
 				Data:      logs,
 				AppID:     appID,
 			})

--- a/internal/service/webhook_formatter.go
+++ b/internal/service/webhook_formatter.go
@@ -77,7 +77,7 @@ func statusColorInt(status string) int {
 
 // ===================== JSON Formatter =====================
 
-// JSONFormatter produces a standard JSON representation of the webhook payload.
+// JSONFormatter implements FormatAdapter as a stateless strategy.
 type JSONFormatter struct{}
 
 // Format marshals the WebhookPayload to indented JSON.
@@ -94,7 +94,7 @@ func (f *JSONFormatter) Name() string { return "json" }
 
 // ===================== Slack Formatter =====================
 
-// SlackFormatter formats payloads for Slack Incoming Webhooks.
+// SlackFormatter implements FormatAdapter for Slack webhook payloads.
 type SlackFormatter struct{}
 
 // slackAttachment represents a Slack message attachment.
@@ -170,7 +170,7 @@ func (f *SlackFormatter) Name() string { return "slack" }
 
 // ===================== Discord Formatter =====================
 
-// DiscordFormatter formats payloads for Discord Webhooks.
+// DiscordFormatter implements FormatAdapter for Discord webhook payloads.
 type DiscordFormatter struct{}
 
 // discordEmbed represents a Discord embed object.
@@ -246,7 +246,7 @@ func (f *DiscordFormatter) Name() string { return "discord" }
 
 // ===================== Teams Formatter =====================
 
-// TeamsFormatter formats payloads as Microsoft Adaptive Cards for Teams.
+// TeamsFormatter implements FormatAdapter for Microsoft Teams webhook payloads.
 type TeamsFormatter struct{}
 
 // teamsAttachment is the top-level Teams webhook payload.


### PR DESCRIPTION
Closes #374

- L-1: Remove duplicate 2FA Swagger Router annotation
- L-2: Add design intent comments to webhook formatters
- L-3: Create endpoints return 201 Created
- L-4: Use time.Now().UTC() consistently in WebSocket logs