### PR TITLE
fix: audit sanitization, 2FA swagger, io.ReadAll limits, SQL injection, UTC timestamps

### DIFF
--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -593,7 +593,6 @@ var TwoFARL = newTwoFARateLimiter(10, 5*time.Minute)
 // @Tags         2FA
 // @Produce      json
 // @Failure      429 {object} map[string]interface{} "too many 2FA attempts"
-// @Router       /auth/2fa/verify [post]
 func Check2FARateLimit() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ip := c.ClientIP()

--- a/internal/backup/backup_ops.go
+++ b/internal/backup/backup_ops.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -57,7 +58,7 @@ func (s *Service) CreateBackup(ctx context.Context, trigger string) (*Record, er
 	} else {
 		record.FilePath = backupPath
 		record.FileSize = fileSize
-		record.CreatedAt = time.Now()
+		record.CreatedAt = time.Now().UTC()
 	}
 
 	// Save record to database
@@ -90,7 +91,7 @@ func (s *Service) backupSQLite(ctx context.Context) (string, int64, error) {
 	}
 
 	// Generate backup filename with timestamp
-	timestamp := time.Now().Format("20060102-150405")
+	timestamp := time.Now().UTC().Format("20060102-150405")
 	backupPath := filepath.Join(s.config.BackupDir, fmt.Sprintf("db-%s.bak", timestamp))
 
 	// Use SQLite .backup command via a temporary connection
@@ -111,8 +112,10 @@ func (s *Service) backupSQLite(ctx context.Context) (string, int64, error) {
 		}
 	}()
 
-	// Validate backupPath doesn't contain single quotes (SQL injection prevention)
-	if strings.Contains(backupPath, "'") {
+	// Validate backupPath is a safe file path (SQL injection prevention)
+	// Only allow alphanumeric, underscore, hyphen, dot, and forward slash
+	validPathPattern := regexp.MustCompile(`^[a-zA-Z0-9_\-\./]+$`)
+	if !validPathPattern.MatchString(backupPath) {
 		return "", 0, fmt.Errorf("backup path contains invalid characters")
 	}
 	// Use BACKUP command for hot copy
@@ -155,7 +158,7 @@ func (s *Service) fileCopyBackup(srcPath, dstPath string) (string, int64, error)
 
 // backupGeneric creates a backup for non-SQLite databases using SQL dump.
 func (s *Service) backupGeneric(ctx context.Context) (string, int64, error) {
-	timestamp := time.Now().Format("20060102-150405")
+	timestamp := time.Now().UTC().Format("20060102-150405")
 
 	switch strings.ToLower(s.dbType) {
 	case "postgres":
@@ -178,7 +181,7 @@ func (s *Service) backupGeneric(ctx context.Context) (string, int64, error) {
 		// Fallback: write metadata-only backup file
 		backupPath := filepath.Join(s.config.BackupDir, fmt.Sprintf("db-%s.meta.json", timestamp))
 		meta := fmt.Sprintf(`{"type":"database","db_type":"%s","timestamp":"%s","note":"automated backup"}`,
-			s.dbType, time.Now().Format(time.RFC3339))
+			s.dbType, time.Now().UTC().Format(time.RFC3339))
 		if err := os.WriteFile(backupPath, []byte(meta), 0640); err != nil {
 			return "", 0, fmt.Errorf("failed to write backup metadata: %w", err)
 		}

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -32,6 +33,33 @@ type AuditService struct {
 	hmacKey        []byte
 	externalWriter AuditWriter
 	onRecord       []func(AuditEntry) // callbacks invoked after successful record
+}
+
+// sensitiveFieldPattern matches field names that may contain sensitive data.
+var sensitiveFieldPattern = regexp.MustCompile(`(?i)(password|secret|token|api_key|apikey|private_key|credit_card|ssn|authorization|auth)`)
+
+// sanitizeAuditData recursively sanitizes sensitive fields in audit data.
+func sanitizeAuditData(data interface{}) interface{} {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		sanitized := make(map[string]interface{}, len(v))
+		for key, val := range v {
+			if sensitiveFieldPattern.MatchString(key) {
+				sanitized[key] = "[REDACTED]"
+			} else {
+				sanitized[key] = sanitizeAuditData(val)
+			}
+		}
+		return sanitized
+	case []interface{}:
+		sanitized := make([]interface{}, len(v))
+		for i, val := range v {
+			sanitized[i] = sanitizeAuditData(val)
+		}
+		return sanitized
+	default:
+		return v
+	}
 }
 
 // OnRecord registers a callback to be invoked after each audit record is created.
@@ -136,7 +164,9 @@ func (s *AuditService) computeRecordHash(log *model.AuditLog) string {
 func (s *AuditService) Record(ctx context.Context, entry AuditEntry) error {
 	detail := ""
 	if entry.Detail != nil {
-		b, err := json.Marshal(entry.Detail)
+		// Sanitize sensitive fields before serialization
+		sanitized := sanitizeAuditData(entry.Detail)
+		b, err := json.Marshal(sanitized)
 		if err == nil {
 			detail = string(b)
 		}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -174,7 +174,7 @@ func (s *OAuthService) getUserInfo(ctx context.Context, provider, accessToken st
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB max
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #381 #382 #383

- Audit log: sanitize sensitive fields (password, token, secret, etc.)
- 2FA: remove duplicate Swagger Router annotation
- OAuth: add io.LimitReader (1MB max) to prevent OOM
- Backup: strengthen SQL injection validation with regex
- Backup: use UTC timestamps consistently