### PR TITLE
fix: add registry SSRF protection, input validation, OAuth client reuse, HTTP 201, log levels

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -110,7 +110,7 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			}
 		}
 
-		respondSuccess(c, gin.H{
+		c.JSON(http.StatusCreated, gin.H{"status": "success", "data": gin.H{
 			"id":         apiKey.ID,
 			"name":       apiKey.Name,
 			"key":        rawKey,
@@ -118,7 +118,7 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			"scopes":     input.Scopes,
 			"expires_at": apiKey.ExpiresAt,
 			"created_at": apiKey.CreatedAt,
-		})
+		}})
 	}
 }
 

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -416,7 +416,7 @@ func GetContainerLogs(bridge *service.Bridge) gin.HandlerFunc {
 		id := c.Param("id")
 		tail := 100
 		if t := c.Query("tail"); t != "" {
-			if parsed, err := strconv.Atoi(t); err == nil && parsed > 0 {
+			if parsed, err := strconv.Atoi(t); err == nil && parsed > 0 && parsed <= 10000 {
 				tail = parsed
 			}
 		}

--- a/internal/api/audit_enhanced.go
+++ b/internal/api/audit_enhanced.go
@@ -139,7 +139,7 @@ func buildAuditFilter(c *gin.Context) service.AuditFilter {
 		}
 	}
 	if v := c.Query("page_size"); v != "" {
-		if pageSize, err := strconv.Atoi(v); err == nil {
+		if pageSize, err := strconv.Atoi(v); err == nil && pageSize > 0 && pageSize <= 100 {
 			filter.PageSize = pageSize
 		}
 	}

--- a/internal/api/registries.go
+++ b/internal/api/registries.go
@@ -73,7 +73,7 @@ func CreateRegistry() gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
-		respondSuccess(c, registry)
+		c.JSON(http.StatusCreated, gin.H{"status": "success", "data": registry})
 	}
 }
 

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -165,7 +165,10 @@ func (s *APIKeyService) Update(ctx context.Context, keyID, userID string, update
 // generateAPIKeyID generates a random hex ID for API keys.
 func generateAPIKeyID() string {
 	b := make([]byte, 12)
-	if _, err := rand.Read(b); err != nil { panic("failed to generate ID: " + err.Error()) }
+	if _, err := rand.Read(b); err != nil {
+		slog.Error("failed to generate random API key ID", "error", err)
+		return hex.EncodeToString([]byte(time.Now().Format("20060102150405")))
+	}
 	return hex.EncodeToString(b)
 }
 

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/crypto"
 	"github.com/Yogdunana/deploypilot/internal/model"
+	"github.com/Yogdunana/deploypilot/internal/util"
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 	"gorm.io/gorm"
@@ -160,7 +161,7 @@ func (s *OAuthService) getUserInfo(ctx context.Context, provider, accessToken st
 		return nil, fmt.Errorf("unsupported OAuth provider: %s", provider)
 	}
 
-	client := &http.Client{}
+	client := util.DefaultClient
 	req, err := http.NewRequestWithContext(ctx, "GET", p.UserInfoURL(), nil)
 	if err != nil {
 		return nil, err

--- a/internal/service/registry_service.go
+++ b/internal/service/registry_service.go
@@ -54,6 +54,11 @@ func (b *Bridge) RegistryOps(registryID string, operation string, args map[strin
 		}
 	}
 
+	// SSRF protection: validate registry URL
+	if err := validateWebhookURL(regURL); err != nil {
+		return nil, fmt.Errorf("invalid registry URL: %w", err)
+	}
+
 	// Create registry provider via plugin registry
 	config := map[string]interface{}{
 		"url":      regURL,

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -283,7 +283,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 		us.emitProgress("download", fmt.Sprintf("download failed: %v", err), 40, "error")
 		// Auto-rollback
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
 	}
@@ -294,7 +294,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.verifyBinaries(); err != nil {
 		us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
 	}
@@ -304,7 +304,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.replaceBinaries(); err != nil {
 		us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
 	}
@@ -314,7 +314,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.restartServices(); err != nil {
 		us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
 	}


### PR DESCRIPTION
Closes #389 #390 #391

- SSRF: Add URL validation to Registry operations
- Input: Cap GetContainerLogs tail at 10000, audit page_size at 100
- OAuth: Use util.DefaultClient instead of creating new client per call
- API Key: Replace panic with fallback in generateAPIKeyID
- HTTP: CreateRegistry and CreateAPIKey return 201 Created
- Log: Upgrade auto-rollback failures use Error instead of Warn