### PR TITLE
fix: input validation limits and log level corrections

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -416,7 +416,7 @@ func GetContainerLogs(bridge *service.Bridge) gin.HandlerFunc {
 		id := c.Param("id")
 		tail := 100
 		if t := c.Query("tail"); t != "" {
-			if parsed, err := strconv.Atoi(t); err == nil && parsed > 0 {
+			if parsed, err := strconv.Atoi(t); err == nil && parsed > 0 && parsed <= 10000 {
 				tail = parsed
 			}
 		}

--- a/internal/api/audit_enhanced.go
+++ b/internal/api/audit_enhanced.go
@@ -139,7 +139,7 @@ func buildAuditFilter(c *gin.Context) service.AuditFilter {
 		}
 	}
 	if v := c.Query("page_size"); v != "" {
-		if pageSize, err := strconv.Atoi(v); err == nil {
+		if pageSize, err := strconv.Atoi(v); err == nil && pageSize > 0 && pageSize <= 100 {
 			filter.PageSize = pageSize
 		}
 	}

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -283,7 +283,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 		us.emitProgress("download", fmt.Sprintf("download failed: %v", err), 40, "error")
 		// Auto-rollback
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after download error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("download: %w (auto-rollback attempted)", err)
 	}
@@ -294,7 +294,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.verifyBinaries(); err != nil {
 		us.emitProgress("verify", fmt.Sprintf("verification failed: %v", err), 70, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after verify error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("verify: %w (auto-rollback attempted)", err)
 	}
@@ -304,7 +304,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.replaceBinaries(); err != nil {
 		us.emitProgress("replace", fmt.Sprintf("replace failed: %v", err), 80, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after replace error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("replace: %w (auto-rollback attempted)", err)
 	}
@@ -314,7 +314,7 @@ func (us *UpgradeService) PerformUpgrade(ctx context.Context, targetVersion stri
 	if err := us.restartServices(); err != nil {
 		us.emitProgress("restart", fmt.Sprintf("restart failed: %v", err), 90, "error")
 		if err := us.restoreBinaries(backupDir); err != nil {
-			slog.Warn("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
+			slog.Error("auto-rollback failed after restart error", "backup_dir", backupDir, "error", err)
 		}
 		return nil, fmt.Errorf("restart: %w (auto-rollback attempted)", err)
 	}


### PR DESCRIPTION
Closes #390 #391

- Cap GetContainerLogs tail parameter at 10000
- Cap audit page_size at 100
- Upgrade auto-rollback failures use Error instead of Warn