### PR TITLE
fix: type assertions and panic removal

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -25,8 +25,8 @@ import (
 func ListAPIKeys(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -56,8 +56,8 @@ func ListAPIKeys(keySvc *service.APIKeyService) gin.HandlerFunc {
 func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -137,8 +137,8 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -180,8 +180,8 @@ func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 func GetAPIKey(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -214,8 +214,8 @@ func GetAPIKey(keySvc *service.APIKeyService) gin.HandlerFunc {
 func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -302,8 +302,8 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 func GetAPIKeyStats(keySvc *service.APIKeyService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -122,8 +122,8 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -199,8 +199,8 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -264,8 +264,8 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -336,8 +336,8 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}
@@ -410,8 +410,8 @@ func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.Hand
 func Get2FAStatus(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, _ := c.Get(string(auth.UserIDKey))
-		uid, _ := userID.(string)
-		if uid == "" {
+		uid, ok := userID.(string)
+		if !ok || uid == "" {
 			respondErrori18n(c, http.StatusUnauthorized, "error.common.unauthorized")
 			return
 		}

--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -565,8 +565,13 @@ func TerminalWS(bridge *service.Bridge, hub *WSHub, ticketStore *auth.WSTicketSt
 					}
 				case "resize":
 					if m, ok := wsMsg.Data.(map[string]interface{}); ok {
-						rows := int(m["rows"].(float64))
-						cols := int(m["cols"].(float64))
+						rowsVal, ok1 := m["rows"].(float64)
+						colsVal, ok2 := m["cols"].(float64)
+						if !ok1 || !ok2 {
+							continue
+						}
+						rows := int(rowsVal)
+						cols := int(colsVal)
 						if rows < 1 || rows > 500 || cols < 1 || cols > 500 {
 							continue
 						}

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -165,7 +165,10 @@ func (s *APIKeyService) Update(ctx context.Context, keyID, userID string, update
 // generateAPIKeyID generates a random hex ID for API keys.
 func generateAPIKeyID() string {
 	b := make([]byte, 12)
-	if _, err := rand.Read(b); err != nil { panic("failed to generate ID: " + err.Error()) }
+	if _, err := rand.Read(b); err != nil {
+		slog.Error("failed to generate random API key ID", "error", err)
+		return hex.EncodeToString([]byte(time.Now().Format("20060102150405")))
+	}
 	return hex.EncodeToString(b)
 }
 


### PR DESCRIPTION
Closes #396

- WebSocket terminal resize: Add comma-ok pattern for rows/cols type assertion
- apikeys.go: Check ok value for userID type assertion (6 places)
- twofa.go: Check ok value for userID type assertion (6 places)
- generateAPIKeyID: Replace panic with fallback to timestamp-based ID