### PR TITLE
fix: goroutine panic recovery, config validation, HTTP 201

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -75,7 +75,7 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
-		respondSuccess(c, app)
+		c.JSON(http.StatusCreated, gin.H{"status": "success", "data": app})
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -259,6 +259,11 @@ func Load(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
+	// Validate required fields
+	if cfg.JWTSecret == "" {
+		return nil, fmt.Errorf("JWT_SECRET is required but not set")
+	}
+
 	return &cfg, nil
 }
 

--- a/internal/service/alert_engine.go
+++ b/internal/service/alert_engine.go
@@ -210,6 +210,11 @@ func (e *AlertEngine) escalateAlert(ctx context.Context, group *model.AlertGroup
 	if e.notifySvc != nil && len(step.Channels) > 0 {
 		channels := strings.Join(step.Channels, ",")
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					e.logger.Error("panic recovered in escalation notification", "group_key", group.GroupKey, "panic", r)
+				}
+			}()
 			_, err := e.notifySvc.SendToChannels(ctx, "alert", group.GroupKey, "", step.Severity, message, channels)
 			if err != nil {
 				e.logger.Error("failed to send escalation notification", "error", err)

--- a/internal/service/event_router.go
+++ b/internal/service/event_router.go
@@ -283,6 +283,11 @@ func (r *EventRouter) forwardToChannels(event BusEvent, channels []string) {
 
 	// Send via notification service
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				r.logger.Error("panic recovered in event notification", "event_id", event.ID, "panic", r)
+			}
+		}()
 		_, err := r.notifySvc.SendToChannels(r.ctx, notifType, appName, "", status, message, channelsStr)
 		if err != nil {
 			r.logger.Error("failed to route event notification",

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -359,6 +359,11 @@ func (s *GrafanaService) StartAnnotationListener(ctx context.Context) {
 	eventTypes := []EventType{EventDeploy, EventAlert, EventServer, EventSystem}
 	for _, et := range eventTypes {
 		go func(eventType EventType) {
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("panic recovered in grafana annotation listener", "event_type", eventType, "panic", r)
+				}
+			}()
 			ch := s.bus.SubscribeType(ctx, eventType)
 			for {
 				select {

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -522,6 +522,11 @@ func (s *OutboundWebhookService) handleEvent(event BusEvent) {
 		wh := &webhooks[i]
 		if s.matchesFilters(wh, event) {
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						slog.Error("panic recovered in webhook delivery", "webhook_id", wh.ID, "panic", r)
+					}
+				}()
 				if err := webhookSem.Acquire(s.ctx, 1); err != nil {
 					slog.Warn("webhook delivery skipped: context cancelled", "webhook_id", wh.ID)
 					return


### PR DESCRIPTION
Closes #401 #402 #403

- Panic recovery: Add defer recover() to goroutines in outbound_webhook_service.go, event_router.go, alert_engine.go, grafana_service.go
- Config validation: Validate JWT_SECRET is set at startup
- HTTP 201: CreateApp returns 201 Created