### PR TITLE
fix: goroutine panic recovery for webhook, event, alert services

### DIFF
--- a/internal/service/alert_engine.go
+++ b/internal/service/alert_engine.go
@@ -210,6 +210,11 @@ func (e *AlertEngine) escalateAlert(ctx context.Context, group *model.AlertGroup
 	if e.notifySvc != nil && len(step.Channels) > 0 {
 		channels := strings.Join(step.Channels, ",")
 		go func() {
+			defer func() {
+				if rv := recover(); rv != nil {
+					e.logger.Error("panic recovered in escalation notification", "group_key", group.GroupKey, "panic", rv)
+				}
+			}()
 			_, err := e.notifySvc.SendToChannels(ctx, "alert", group.GroupKey, "", step.Severity, message, channels)
 			if err != nil {
 				e.logger.Error("failed to send escalation notification", "error", err)

--- a/internal/service/event_router.go
+++ b/internal/service/event_router.go
@@ -283,6 +283,11 @@ func (r *EventRouter) forwardToChannels(event BusEvent, channels []string) {
 
 	// Send via notification service
 	go func() {
+		defer func() {
+			if rv := recover(); rv != nil {
+				r.logger.Error("panic recovered in event notification", "event_id", event.ID, "panic", rv)
+			}
+		}()
 		_, err := r.notifySvc.SendToChannels(r.ctx, notifType, appName, "", status, message, channelsStr)
 		if err != nil {
 			r.logger.Error("failed to route event notification",

--- a/internal/service/outbound_webhook_service.go
+++ b/internal/service/outbound_webhook_service.go
@@ -522,6 +522,11 @@ func (s *OutboundWebhookService) handleEvent(event BusEvent) {
 		wh := &webhooks[i]
 		if s.matchesFilters(wh, event) {
 			go func() {
+				defer func() {
+					if rv := recover(); rv != nil {
+						slog.Error("panic recovered in webhook delivery", "webhook_id", wh.ID, "panic", rv)
+					}
+				}()
 				if err := webhookSem.Acquire(s.ctx, 1); err != nil {
 					slog.Warn("webhook delivery skipped: context cancelled", "webhook_id", wh.ID)
 					return


### PR DESCRIPTION
Closes #401

- outbound_webhook_service.go: Add defer recover() to webhook delivery goroutine
- event_router.go: Add defer recover() to event notification goroutine
- alert_engine.go: Add defer recover() to escalation notification goroutine