### PR TITLE
fix: grafana panic recovery, input length limits, HTTP 201, file permissions

### DIFF
--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -38,6 +38,10 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "error.app.name_and_repo_required")
 			return
 		}
+		if len(input.Name) > 255 || len(input.RepoURL) > 2048 {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.input_too_long")
+			return
+		}
 
 		id := uuid.New().String()
 		tenantID := c.GetString(string(auth.UserIDKey))
@@ -75,7 +79,7 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
-		respondSuccess(c, app)
+		c.JSON(http.StatusCreated, gin.H{"status": "success", "data": app})
 	}
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -58,6 +58,12 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		// Input length limits
+		if len(input.Username) > 255 || len(input.Email) > 255 || len(input.Password) > 128 {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.input_too_long")
+			return
+		}
+
 		// Validate password complexity
 		if passwordValidator != nil {
 			if err := passwordValidator.Validate(input.Password); err != nil {

--- a/internal/api/registries.go
+++ b/internal/api/registries.go
@@ -67,6 +67,10 @@ func CreateRegistry() gin.HandlerFunc {
 		if input.TenantID == "" {
 			input.TenantID = "tenant-default"
 		}
+		if len(input.Name) > 255 || len(input.URL) > 2048 || len(input.Username) > 255 || len(input.Password) > 255 {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.input_too_long")
+			return
+		}
 
 		registry, err := model.CreateRegistry(input.TenantID, input.Name, input.Provider, input.URL, input.Username, input.Password)
 		if err != nil {

--- a/internal/service/grafana_service.go
+++ b/internal/service/grafana_service.go
@@ -359,6 +359,11 @@ func (s *GrafanaService) StartAnnotationListener(ctx context.Context) {
 	eventTypes := []EventType{EventDeploy, EventAlert, EventServer, EventSystem}
 	for _, et := range eventTypes {
 		go func(eventType EventType) {
+			defer func() {
+				if rv := recover(); rv != nil {
+					slog.Error("panic recovered in grafana annotation listener", "event_type", eventType, "panic", rv)
+				}
+			}()
 			ch := s.bus.SubscribeType(ctx, eventType)
 			for {
 				select {

--- a/internal/signing/verify.go
+++ b/internal/signing/verify.go
@@ -67,7 +67,7 @@ func SignBinary(binaryPath, signaturePath string, signer *Signer) error {
 		return fmt.Errorf("failed to sign binary: %w", err)
 	}
 
-	if err := os.WriteFile(signaturePath, signature, 0644); err != nil {
+	if err := os.WriteFile(signaturePath, signature, 0640); err != nil {
 		return fmt.Errorf("failed to write signature file: %w", err)
 	}
 


### PR DESCRIPTION
Closes #407 #408 #409

- Grafana: Add panic recovery to annotation listener goroutine
- Input: Add max length validation for apps (name/repo), registries (name/url/username/password), auth register (username/email/password)
- HTTP 201: CreateApp returns 201 Created
- File permissions: Signature file uses 0640 instead of 0644