### PR TITLE
fix: error message sanitization, deploy error leak, password assertion safety

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -69,7 +69,7 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			ExpiresInDays int      `json:"expires_in_days"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -228,7 +228,7 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			ExpiresInDays *int     `json:"expires_in_days"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -31,7 +31,7 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input mcp.CreateAppConfig
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.Name == "" || input.RepoURL == "" {
@@ -179,7 +179,7 @@ func UpdateApp(db *gorm.DB) gin.HandlerFunc {
 		id := c.Param("id")
 		var updates map[string]interface{}
 		if err := c.ShouldBindJSON(&updates); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -259,7 +259,7 @@ func DeployApp(bridge *service.Bridge) gin.HandlerFunc {
 
 		var cfg mcp.DeployConfig
 		if err := c.ShouldBindJSON(&cfg); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -552,7 +552,7 @@ func UpdateAppEnv(db *gorm.DB) gin.HandlerFunc {
 			EnvVars string `json:"env_vars"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/audit_enhanced.go
+++ b/internal/api/audit_enhanced.go
@@ -47,7 +47,7 @@ func ArchiveAuditLogs(auditSvc *service.AuditService) gin.HandlerFunc {
 			OlderThanDays int `json:"older_than_days" binding:"required,min=1"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -54,7 +55,7 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 			Password string `json:"password" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -67,11 +68,19 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 		// Validate password complexity
 		if passwordValidator != nil {
 			if err := passwordValidator.Validate(input.Password); err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{
+				var pwdErr *middleware.PasswordValidationError
+				errorsAs := false
+				if errors.As(err, &pwdErr) {
+					errorsAs = true
+				}
+				resp := gin.H{
 					"status":  "error",
 					"message": "password does not meet security requirements",
-					"errors":  err.(*middleware.PasswordValidationError).Errors,
-				})
+				}
+				if errorsAs {
+					resp["errors"] = pwdErr.Errors
+				}
+				c.JSON(http.StatusBadRequest, resp)
 				return
 			}
 		}
@@ -275,7 +284,7 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 			Password string `json:"password" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/cicd.go
+++ b/internal/api/cicd.go
@@ -28,7 +28,7 @@ func TriggerCIBuild(bridge *service.Bridge) gin.HandlerFunc {
 			Branch   string `json:"branch" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/clusters.go
+++ b/internal/api/clusters.go
@@ -37,7 +37,7 @@ func CreateCluster(bridge *service.Bridge) gin.HandlerFunc {
 			Tags           string `json:"tags"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.TenantID == "" {
@@ -154,7 +154,7 @@ func UpdateCluster(bridge *service.Bridge) gin.HandlerFunc {
 			NodeCount      *int   `json:"node_count"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -95,7 +95,7 @@ func CreateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gi
 			ExpiresInDays int    `json:"expires_in_days"` // 0 = never expires
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.TenantID == "" {
@@ -146,7 +146,7 @@ func UpdateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gi
 			Value string `json:"value" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -228,7 +228,7 @@ func RotateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gi
 			Value string `json:"value" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/dns.go
+++ b/internal/api/dns.go
@@ -58,7 +58,7 @@ func CreateDNSRecord(bridge *service.Bridge) gin.HandlerFunc {
 			Value  string `json:"value" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -100,7 +100,7 @@ func UpdateDNSRecord(bridge *service.Bridge) gin.HandlerFunc {
 			NewValue  string `json:"new_value" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/event_plugin_api.go
+++ b/internal/api/event_plugin_api.go
@@ -107,7 +107,7 @@ func (a *EventPluginAPI) UpdateEventPlugin(c *gin.Context) {
 		Config  map[string]interface{} `json:"config"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}
 

--- a/internal/api/monitor_alert_rules.go
+++ b/internal/api/monitor_alert_rules.go
@@ -16,7 +16,7 @@ func CreateAlertRule(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var rule model.AlertRuleRecord
 		if err := c.ShouldBindJSON(&rule); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -39,7 +39,7 @@ func UpdateAlertRule(db *gorm.DB) gin.HandlerFunc {
 
 		var rule model.AlertRuleRecord
 		if err := c.ShouldBindJSON(&rule); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		rule.ID = id

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -50,7 +50,7 @@ func CreateNotification(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input model.Provider
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.Name == "" {
@@ -92,7 +92,7 @@ func UpdateNotification(db *gorm.DB) gin.HandlerFunc {
 		id := c.Param("id")
 		var input model.Provider
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/plugins.go
+++ b/internal/api/plugins.go
@@ -78,7 +78,7 @@ func (h *PluginHandler) CreatePlugin() gin.HandlerFunc {
 			Priority    int    `json:"priority"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.TenantID == "" {
@@ -153,7 +153,7 @@ func (h *PluginHandler) UpdatePlugin() gin.HandlerFunc {
 		id := c.Param("id")
 		var input map[string]interface{}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -82,7 +82,7 @@ func CreateProvider(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var input model.Provider
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.Name == "" || input.Type == "" {
@@ -123,7 +123,7 @@ func UpdateProvider(db *gorm.DB) gin.HandlerFunc {
 		id := c.Param("id")
 		var input model.Provider
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/registries.go
+++ b/internal/api/registries.go
@@ -61,7 +61,7 @@ func CreateRegistry() gin.HandlerFunc {
 			Password string `json:"password"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.TenantID == "" {
@@ -130,7 +130,7 @@ func UpdateRegistry() gin.HandlerFunc {
 			Password string `json:"password"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/security_config.go
+++ b/internal/api/security_config.go
@@ -93,7 +93,7 @@ func UpdateSecurityConfig() gin.HandlerFunc {
 			Force2FAGraceDays       *int     `json:"force_2fa_grace_days"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/servers.go
+++ b/internal/api/servers.go
@@ -31,7 +31,7 @@ func AddServer(bridge *service.Bridge) gin.HandlerFunc {
 			User string `json:"user"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 		if input.Port == 0 {
@@ -93,7 +93,7 @@ func UpdateServer(bridge *service.Bridge) gin.HandlerFunc {
 		id := c.Param("id")
 		var config map[string]interface{}
 		if err := c.ShouldBindJSON(&config); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -57,7 +57,7 @@ func DeployAsyncHandler(bridge *service.Bridge) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var cfg mcp.DeployConfig
 		if err := c.ShouldBindJSON(&cfg); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/ssl.go
+++ b/internal/api/ssl.go
@@ -73,7 +73,7 @@ func RequestSSLCertificate(db *gorm.DB) gin.HandlerFunc {
 			Provider string `json:"provider"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -54,7 +54,7 @@ func CreateTemplate(db *gorm.DB) gin.HandlerFunc {
 			Port        int    `json:"port"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -103,7 +103,7 @@ func UpdateTemplate(db *gorm.DB) gin.HandlerFunc {
 			Port        int    `json:"port"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -49,7 +49,7 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			Code       string `json:"code" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -209,7 +209,7 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			Code string `json:"code" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -274,7 +274,7 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 			Code string `json:"code" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 
@@ -346,7 +346,7 @@ func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.Hand
 			Code string `json:"code" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -148,7 +148,7 @@ func UpdateUserRole(db *gorm.DB) gin.HandlerFunc {
 			RoleID string `json:"role_id" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&input); err != nil {
-			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", err.Error())
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 			return
 		}
 

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -25,14 +25,15 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 	go func() {
 		cs, deployErr := b.Deploy(ctx, cfg)
 		if deployErr != nil {
-			b.updateTask(taskID, "failed", 100, deployErr.Error())
+			slog.Error("deploy failed", "task_id", taskID, "app_id", appID, "error", deployErr)
+			b.updateTask(taskID, "failed", 100, "deploy failed: see server logs for details")
 			b.EventBus.Publish(DeployEvent{
 				TaskID:    taskID,
 				AppID:     appID,
 				Step:      "done",
 				Status:    "failed",
 				Progress:  100,
-				Message:   deployErr.Error(),
+				Message:   "deploy failed: see server logs for details",
 				Timestamp: time.Now().Format(time.RFC3339),
 				TraceID:   traceID,
 			})
@@ -166,10 +167,11 @@ func (b *Bridge) Deploy(ctx context.Context, cfg mcp.DeployConfig) (*mcp.Contain
 		metrics.DeployTotal.WithLabelValues(cfg.ContainerName, cfg.ServerID, "failed").Inc()
 		metrics.DeployDuration.Observe(time.Since(deployStart).Seconds())
 
+		slog.Error("deploy run failed", "app_id", cfg.ContainerName, "server_id", cfg.ServerID, "error", err)
 		b.EventBus.Publish(DeployEvent{
 			TaskID:    "", AppID: cfg.ContainerName,
 			Step: "run", Status: "failed", Progress: 60,
-			Message:   "deploy failed: " + err.Error(),
+			Message:   "deploy failed: see server logs for details",
 			Timestamp: time.Now().Format(time.RFC3339),
 		})
 


### PR DESCRIPTION
Closes #412 #413 #414

- Error sanitization: Remove err.Error() from 40 ShouldBindJSON responses across 21 API files (log server-side, return generic message)
- Deploy error leak: Sanitize deploy error messages in EventBus, log details server-side
- Password assertion: Use errors.As instead of unsafe type assertion for PasswordValidationError