### PR TITLE
fix: audit RBAC, constant-time secret compare, Shamir crypto/rand, batch limit, path traversal

### DIFF
--- a/internal/api/batch_api.go
+++ b/internal/api/batch_api.go
@@ -26,6 +26,10 @@ func BatchDeployHandler(b *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "apps list cannot be empty")
 			return
 		}
+		if len(input.Apps) > 100 {
+			respondErrori18n(c, http.StatusBadRequest, "batch size cannot exceed 100")
+			return
+		}
 
 		config := mcp.BatchDeployConfig{
 			Apps:          input.Apps,

--- a/internal/api/file_manager_api.go
+++ b/internal/api/file_manager_api.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
 	"github.com/Yogdunana/deploypilot/internal/service"
@@ -73,6 +75,13 @@ func (f *FileManagerAPI) WriteFile(c *gin.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Reject path traversal attempts
+	cleanPath := filepath.Clean(req.Path)
+	if strings.Contains(cleanPath, "..") {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}

--- a/internal/api/oauth2_api.go
+++ b/internal/api/oauth2_api.go
@@ -118,7 +118,7 @@ func (a *OAuth2API) CreateClient(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	client, secret, err := svc.CreateClient(userID, req.Name, req.RedirectURIs, req.Scopes, req.GrantTypes)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -290,7 +290,7 @@ func (a *OAuth2API) Authorize(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	authz, err := svc.CreateAuthorization(req.ClientID, userID, req.Scopes)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -348,7 +348,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_grant",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -370,7 +370,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_client",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -388,7 +388,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_grant",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -416,7 +416,7 @@ func (a *OAuth2API) RefreshToken(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	token, err := svc.RefreshToken(req.RefreshToken)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -436,7 +436,7 @@ func (a *OAuth2API) RevokeToken(c *gin.Context) {
 
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	if err := svc.RevokeToken(req.AccessToken); err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -209,21 +209,26 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 			roles.GET("", ListRoles(db))
 		}
 
-		// Audit logs
-		protected.GET("/audit-logs", ListAuditLogs(auditSvc))
-		protected.GET("/audit-logs/stats", GetAuditStats(auditSvc))
-		protected.GET("/audit-logs/export", ExportAuditLogs(auditSvc))
-		protected.POST("/audit-logs/archive", ArchiveAuditLogs(auditSvc))
-		protected.POST("/audit-logs/verify", VerifyAuditLogs(auditSvc))
-		protected.GET("/audit-logs/trace/:trace_id", GetAuditLogsByTraceID(auditSvc))
+		// Audit logs (restricted to owner/admin)
+		auditGroup := protected.Group("")
+		auditGroup.Use(auth.RoleRequired("owner", "admin"))
+		{
+			auditGroup.GET("/audit-logs", ListAuditLogs(auditSvc))
+			auditGroup.GET("/audit-logs/stats", GetAuditStats(auditSvc))
+			auditGroup.GET("/audit-logs/export", ExportAuditLogs(auditSvc))
+			auditGroup.POST("/audit-logs/archive", ArchiveAuditLogs(auditSvc))
+			auditGroup.POST("/audit-logs/verify", VerifyAuditLogs(auditSvc))
+			auditGroup.GET("/audit-logs/trace/:trace_id", GetAuditLogsByTraceID(auditSvc))
+		}
 
 		// Audit verification & compliance (Issue #155)
 		auditVerGroup := protected.Group("/audit")
+		auditVerGroup.Use(auth.RoleRequired("owner", "admin"))
 		{
 			auditVerGroup.GET("/verify", VerifyAuditChain)
 			auditVerGroup.GET("/export", ExportAuditLogsV2)
 			auditVerGroup.GET("/gdpr/export", GDPRExportUserData)
-			auditVerGroup.DELETE("/gdpr/delete", auth.RequireScope("delete"), auth.RoleRequired("owner", "admin"), GDPRDeleteUserData)
+			auditVerGroup.DELETE("/gdpr/delete", auth.RequireScope("delete"), GDPRDeleteUserData)
 			auditVerGroup.GET("/compliance", ComplianceReport)
 		}
 		protected.GET("/events", ListEventLogs(db))

--- a/internal/api/signing_api.go
+++ b/internal/api/signing_api.go
@@ -91,13 +91,13 @@ func VerifySignature(c *gin.Context) {
 
 	signer, err := globalSigningAPI.loadSignerFromModel(&activeKey)
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to load signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to load signing key")
 		return
 	}
 
 	verified, err := signing.VerifySelf("", ed25519.PublicKey(signer.PublicKeyBytes()))
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to verify binary: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to verify binary")
 		return
 	}
 
@@ -124,7 +124,7 @@ func GenerateKeys(c *gin.Context) {
 
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to generate key pair: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
 		return
 	}
 
@@ -150,12 +150,12 @@ func GenerateKeys(c *gin.Context) {
 
 	// Deactivate all existing keys
 	if err := globalSigningAPI.db.Model(&model.SigningKey{}).Where("is_active = ?", true).Update("is_active", false).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys")
 		return
 	}
 
 	if err := globalSigningAPI.db.Create(&keyRecord).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to save signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to save signing key")
 		return
 	}
 
@@ -184,7 +184,7 @@ func RotateKeys(c *gin.Context) {
 
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to generate key pair: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
 		return
 	}
 
@@ -210,12 +210,12 @@ func RotateKeys(c *gin.Context) {
 
 	// Deactivate all existing keys (keep them in DB for verification)
 	if err := globalSigningAPI.db.Model(&model.SigningKey{}).Where("is_active = ?", true).Update("is_active", false).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys")
 		return
 	}
 
 	if err := globalSigningAPI.db.Create(&keyRecord).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to save new signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to save new signing key")
 		return
 	}
 

--- a/internal/service/key_rotation_service.go
+++ b/internal/service/key_rotation_service.go
@@ -198,7 +198,11 @@ func SplitSecret(secret []byte, n, m int) ([]ShamirShare, error) {
 	coefficients := make([]byte, m)
 	coefficients[0] = secret[0]
 	for i := 1; i < m; i++ {
-		coefficients[i] = byte(time.Now().UnixNano() >> (i * 8)) // deterministic for reproducibility
+		buf := make([]byte, 1)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, fmt.Errorf("failed to generate random coefficient: %w", err)
+		}
+		coefficients[i] = buf[0]
 	}
 
 	shares := make([]ShamirShare, n)

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -261,8 +262,8 @@ func (s *OAuth2Service) ClientCredentials(clientID, clientSecret string, scopes 
 		return nil, fmt.Errorf("failed to validate client: %w", err)
 	}
 
-	// Validate client secret
-	if client.ClientSecret != clientSecret {
+	// Validate client secret using constant-time comparison
+	if subtle.ConstantTimeCompare([]byte(client.ClientSecret), []byte(clientSecret)) != 1 {
 		return nil, fmt.Errorf("invalid client credentials")
 	}
 


### PR DESCRIPTION
Closes #416 #417 #418

- Audit RBAC: Restrict audit log endpoints to owner/admin roles
- OAuth2: Use crypto/subtle.ConstantTimeCompare for client_secret validation
- Shamir: Replace time.Now().UnixNano() with crypto/rand for polynomial coefficients
- BatchDeploy: Cap apps array at 100
- Path traversal: Reject paths containing ".." in WriteFile
- Error sanitization: Remove err.Error() from signing_api.go (8 places) and oauth2_api.go (7 places)