### PR TITLE
fix: constant-time secret compare, Shamir crypto/rand, batch limit, path traversal

### DIFF
--- a/internal/api/batch_api.go
+++ b/internal/api/batch_api.go
@@ -26,6 +26,10 @@ func BatchDeployHandler(b *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "apps list cannot be empty")
 			return
 		}
+		if len(input.Apps) > 100 {
+			respondErrori18n(c, http.StatusBadRequest, "batch size cannot exceed 100")
+			return
+		}
 
 		config := mcp.BatchDeployConfig{
 			Apps:          input.Apps,

--- a/internal/api/file_manager_api.go
+++ b/internal/api/file_manager_api.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
 	"github.com/Yogdunana/deploypilot/internal/service"
@@ -73,6 +75,13 @@ func (f *FileManagerAPI) WriteFile(c *gin.Context) {
 		Content string `json:"content"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Reject path traversal attempts
+	cleanPath := filepath.Clean(req.Path)
+	if strings.Contains(cleanPath, "..") {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}

--- a/internal/service/key_rotation_service.go
+++ b/internal/service/key_rotation_service.go
@@ -198,7 +198,11 @@ func SplitSecret(secret []byte, n, m int) ([]ShamirShare, error) {
 	coefficients := make([]byte, m)
 	coefficients[0] = secret[0]
 	for i := 1; i < m; i++ {
-		coefficients[i] = byte(time.Now().UnixNano() >> (i * 8)) // deterministic for reproducibility
+		buf := make([]byte, 1)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, fmt.Errorf("failed to generate random coefficient: %w", err)
+		}
+		coefficients[i] = buf[0]
 	}
 
 	shares := make([]ShamirShare, n)

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -261,8 +262,8 @@ func (s *OAuth2Service) ClientCredentials(clientID, clientSecret string, scopes 
 		return nil, fmt.Errorf("failed to validate client: %w", err)
 	}
 
-	// Validate client secret
-	if client.ClientSecret != clientSecret {
+	// Validate client secret using constant-time comparison
+	if subtle.ConstantTimeCompare([]byte(client.ClientSecret), []byte(clientSecret)) != 1 {
 		return nil, fmt.Errorf("invalid client credentials")
 	}
 


### PR DESCRIPTION
Closes #416 #417 #418

- OAuth2: Use crypto/subtle.ConstantTimeCompare for client_secret validation (prevents timing attack)
- Shamir: Replace time.Now().UnixNano() with crypto/rand for polynomial coefficients
- BatchDeploy: Cap apps array at 100
- Path traversal: Reject paths containing ".." in WriteFile