### PR TITLE
fix: constant-time secret compare, Shamir crypto/rand, batch size limit

### DIFF
--- a/internal/api/batch_api.go
+++ b/internal/api/batch_api.go
@@ -26,6 +26,10 @@ func BatchDeployHandler(b *service.Bridge) gin.HandlerFunc {
 			respondErrori18n(c, http.StatusBadRequest, "apps list cannot be empty")
 			return
 		}
+		if len(input.Apps) > 100 {
+			respondErrori18n(c, http.StatusBadRequest, "batch size cannot exceed 100")
+			return
+		}
 
 		config := mcp.BatchDeployConfig{
 			Apps:          input.Apps,

--- a/internal/service/key_rotation_service.go
+++ b/internal/service/key_rotation_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -194,11 +195,15 @@ func SplitSecret(secret []byte, n, m int) ([]ShamirShare, error) {
 		return nil, fmt.Errorf("total shares N cannot exceed 255")
 	}
 
-	// Generate random coefficients for polynomial
+	// Generate random coefficients for polynomial using cryptographic random
 	coefficients := make([]byte, m)
 	coefficients[0] = secret[0]
 	for i := 1; i < m; i++ {
-		coefficients[i] = byte(time.Now().UnixNano() >> (i * 8)) // deterministic for reproducibility
+		buf := make([]byte, 1)
+		if _, err := rand.Read(buf); err != nil {
+			return nil, fmt.Errorf("failed to generate random coefficient: %w", err)
+		}
+		coefficients[i] = buf[0]
 	}
 
 	shares := make([]ShamirShare, n)

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -261,8 +262,8 @@ func (s *OAuth2Service) ClientCredentials(clientID, clientSecret string, scopes 
 		return nil, fmt.Errorf("failed to validate client: %w", err)
 	}
 
-	// Validate client secret
-	if client.ClientSecret != clientSecret {
+	// Validate client secret using constant-time comparison
+	if subtle.ConstantTimeCompare([]byte(client.ClientSecret), []byte(clientSecret)) != 1 {
 		return nil, fmt.Errorf("invalid client credentials")
 	}
 


### PR DESCRIPTION
Closes #416 #417 #418

- OAuth2: Use crypto/subtle.ConstantTimeCompare for client_secret validation (prevents timing attack)
- Shamir: Replace time.Now().UnixNano() with crypto/rand for polynomial coefficients
- BatchDeploy: Cap apps array at 100