### PR TITLE
fix: error sanitization, path traversal, error handling, integer overflow, parseUnix refactor

### DIFF
--- a/internal/api/batch_api.go
+++ b/internal/api/batch_api.go
@@ -52,7 +52,7 @@ func BatchDeployHandler(b *service.Bridge) gin.HandlerFunc {
 
 		result, err := b.BatchDeployWithConfig(c.Request.Context(), config)
 		if err != nil {
-			respondErrori18n(c, http.StatusInternalServerError, err.Error())
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return
 		}
 

--- a/internal/api/file_manager_api.go
+++ b/internal/api/file_manager_api.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/Yogdunana/deploypilot/internal/sandbox"
 	"github.com/Yogdunana/deploypilot/internal/service"
@@ -61,18 +63,22 @@ func (f *FileManagerAPI) ReadFile(c *gin.Context) {
 // WriteFile writes content to a remote file.
 // PUT /api/v1/servers/:server_id/files/write
 func (f *FileManagerAPI) WriteFile(c *gin.Context) {
+	// Limit request body to 10MB
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10*1024*1024)
 
 	serverID := c.Param("server_id")
-
-	// Limit request body to 10MB
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10*1024*1024)
 
 	var req struct {
 		Path    string `json:"path" binding:"required"`
 		Content string `json:"content"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Reject path traversal attempts
+	if strings.Contains(filepath.Clean(req.Path), "..") {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}

--- a/internal/api/oauth2_api.go
+++ b/internal/api/oauth2_api.go
@@ -118,7 +118,7 @@ func (a *OAuth2API) CreateClient(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	client, secret, err := svc.CreateClient(userID, req.Name, req.RedirectURIs, req.Scopes, req.GrantTypes)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -290,7 +290,7 @@ func (a *OAuth2API) Authorize(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	authz, err := svc.CreateAuthorization(req.ClientID, userID, req.Scopes)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -348,7 +348,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_grant",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -370,7 +370,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_client",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -388,7 +388,7 @@ func (a *OAuth2API) Token(c *gin.Context) {
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
 				"error":             "invalid_grant",
-				"error_description": err.Error(),
+				"error_description": "internal server error",
 			})
 			return
 		}
@@ -416,7 +416,7 @@ func (a *OAuth2API) RefreshToken(c *gin.Context) {
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	token, err := svc.RefreshToken(req.RefreshToken)
 	if err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 
@@ -436,7 +436,7 @@ func (a *OAuth2API) RevokeToken(c *gin.Context) {
 
 	svc := service.NewOAuth2Service(a.db, a.cfg)
 	if err := svc.RevokeToken(req.AccessToken); err != nil {
-		respondError(c, http.StatusBadRequest, err.Error())
+		respondError(c, http.StatusBadRequest, "invalid request")
 		return
 	}
 

--- a/internal/api/signing_api.go
+++ b/internal/api/signing_api.go
@@ -91,13 +91,13 @@ func VerifySignature(c *gin.Context) {
 
 	signer, err := globalSigningAPI.loadSignerFromModel(&activeKey)
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to load signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to load signing key")
 		return
 	}
 
 	verified, err := signing.VerifySelf("", ed25519.PublicKey(signer.PublicKeyBytes()))
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to verify binary: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to verify binary")
 		return
 	}
 
@@ -124,7 +124,7 @@ func GenerateKeys(c *gin.Context) {
 
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to generate key pair: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
 		return
 	}
 
@@ -150,12 +150,12 @@ func GenerateKeys(c *gin.Context) {
 
 	// Deactivate all existing keys
 	if err := globalSigningAPI.db.Model(&model.SigningKey{}).Where("is_active = ?", true).Update("is_active", false).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys")
 		return
 	}
 
 	if err := globalSigningAPI.db.Create(&keyRecord).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to save signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to save signing key")
 		return
 	}
 
@@ -184,7 +184,7 @@ func RotateKeys(c *gin.Context) {
 
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to generate key pair: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
 		return
 	}
 
@@ -210,12 +210,12 @@ func RotateKeys(c *gin.Context) {
 
 	// Deactivate all existing keys (keep them in DB for verification)
 	if err := globalSigningAPI.db.Model(&model.SigningKey{}).Where("is_active = ?", true).Update("is_active", false).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to deactivate old keys")
 		return
 	}
 
 	if err := globalSigningAPI.db.Create(&keyRecord).Error; err != nil {
-		respondError(c, http.StatusInternalServerError, "failed to save new signing key: "+err.Error())
+		respondError(c, http.StatusInternalServerError, "failed to save new signing key")
 		return
 	}
 

--- a/internal/auth/refresh_token.go
+++ b/internal/auth/refresh_token.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -342,13 +343,9 @@ func splitString(s string, sep rune, n int) []string {
 }
 
 func parseUnix(s string) int64 {
-	n := int64(0)
-	for _, c := range s {
-		if c >= '0' && c <= '9' {
-			n = n*10 + int64(c-'0')
-		} else {
-			break
-		}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0
 	}
 	return n
 }

--- a/internal/model/device.go
+++ b/internal/model/device.go
@@ -33,6 +33,10 @@ func GenerateDeviceID(userAgent, ip string) string {
 // hexEncode converts a byte slice to a lowercase hex string.
 func hexEncode(b []byte) string {
 	const hexChars = "0123456789abcdef"
+	// Guard against integer overflow on very large inputs
+	if len(b) > (1<<30) {
+		b = b[:1<<30]
+	}
 	result := make([]byte, len(b)*2)
 	for i, v := range b {
 		result[i*2] = hexChars[v>>4]

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/Yogdunana/deploypilot/internal/metrics"
 	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/tracing"
+	"gorm.io/gorm"
 )
 
 // ---------- 1. Deploy ----------
@@ -391,7 +393,10 @@ func (b *Bridge) findPreviousSuccessfulImage(ctx context.Context, containerName 
 		Limit(1).
 		First(&record).Error
 	if err != nil {
-		return "", fmt.Errorf("no successful deployment found for container %s", containerName)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", fmt.Errorf("no successful deployment found for container %s", containerName)
+		}
+		return "", fmt.Errorf("failed to query deployment record: %w", err)
 	}
 
 	return record.Image, nil


### PR DESCRIPTION
Closes #422 #423 #424

- signing_api.go: Remove err.Error() from 8 respondError calls
- oauth2_api.go: Remove err.Error() from 4 respondError and 3 error_description fields
- batch_api.go: Replace err.Error() with i18n key
- file_manager_api.go: Add path traversal check, remove duplicate MaxBytesReader
- deploy_service.go: Distinguish gorm.ErrRecordNotFound from DB errors
- device.go: Add integer overflow guard in hexEncode
- refresh_token.go: Replace manual parseUnix with strconv.ParseInt