### PR TITLE
fix: replace panic calls with proper error handling

### DIFF
--- a/internal/api/device_api.go
+++ b/internal/api/device_api.go
@@ -32,6 +32,16 @@ func GetGlobalDeviceAPI() *DeviceAPI {
 	return globalDeviceAPI
 }
 
+// getUserIDStrFromCtx safely extracts user ID string from context
+func getUserIDStrFromCtx(c *gin.Context) (string, bool) {
+	userID, exists := c.Get(string(auth.UserIDKey))
+	if !exists {
+		return "", false
+	}
+	userIDStr, ok := userID.(string)
+	return userIDStr, ok
+}
+
 // ListDevices godoc
 // @Summary      List devices
 // @Description  Get all devices for the authenticated user
@@ -49,13 +59,13 @@ func ListDevices(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStrFromCtx(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
 
-	devices, err := globalDeviceAPI.svc.ListDevices(userID.(string))
+	devices, err := globalDeviceAPI.svc.ListDevices(userIDStr)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to list devices")
 		return
@@ -83,8 +93,8 @@ func RevokeDevice(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStrFromCtx(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
@@ -95,7 +105,7 @@ func RevokeDevice(c *gin.Context) {
 		return
 	}
 
-	if err := globalDeviceAPI.svc.RevokeDevice(id, userID.(string)); err != nil {
+	if err := globalDeviceAPI.svc.RevokeDevice(id, userIDStr); err != nil {
 		respondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -123,8 +133,8 @@ func TrustDevice(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStrFromCtx(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
@@ -146,7 +156,7 @@ func TrustDevice(c *gin.Context) {
 		input.Days = 30
 	}
 
-	if err := globalDeviceAPI.svc.TrustDevice(id, userID.(string), input.Days); err != nil {
+	if err := globalDeviceAPI.svc.TrustDevice(id, userIDStr, input.Days); err != nil {
 		respondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -171,8 +181,8 @@ func CurrentDevice(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStrFromCtx(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
@@ -181,7 +191,7 @@ func CurrentDevice(c *gin.Context) {
 	clientIP := c.ClientIP()
 	deviceID := model.GenerateDeviceID(userAgent, clientIP)
 
-	isNew, device, err := globalDeviceAPI.svc.IsNewDevice(userID.(string), deviceID)
+	isNew, device, err := globalDeviceAPI.svc.IsNewDevice(userIDStr, deviceID)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to check device")
 		return

--- a/internal/api/ip_whitelist_api.go
+++ b/internal/api/ip_whitelist_api.go
@@ -26,6 +26,16 @@ func SetIPWhitelistAPI(api *IPWhitelistAPI) {
 	globalIPWhitelistAPI = api
 }
 
+// getUserIDStr safely extracts user ID string from context
+func getUserIDStr(c *gin.Context) (string, bool) {
+	userID, exists := c.Get(string(auth.UserIDKey))
+	if !exists {
+		return "", false
+	}
+	userIDStr, ok := userID.(string)
+	return userIDStr, ok
+}
+
 // ListIPWhitelist godoc
 // @Summary      List IP whitelist
 // @Description  Get all whitelist entries for the current user
@@ -43,13 +53,13 @@ func ListIPWhitelist(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStr(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
 
-	entries, err := globalIPWhitelistAPI.svc.List(userID.(string))
+	entries, err := globalIPWhitelistAPI.svc.List(userIDStr)
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to list IP whitelist entries")
 		return
@@ -77,8 +87,8 @@ func AddIPWhitelist(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStr(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
@@ -93,11 +103,11 @@ func AddIPWhitelist(c *gin.Context) {
 	}
 
 	entry, err := globalIPWhitelistAPI.svc.Create(
-		userID.(string),
+		userIDStr,
 		input.Description,
 		input.CIDR,
 		"tenant-default",
-		userID.(string),
+		userIDStr,
 	)
 	if err != nil {
 		respondError(c, http.StatusBadRequest, err.Error())
@@ -126,8 +136,8 @@ func DeleteIPWhitelist(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStr(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
@@ -138,7 +148,7 @@ func DeleteIPWhitelist(c *gin.Context) {
 		return
 	}
 
-	if err := globalIPWhitelistAPI.svc.Delete(id, userID.(string)); err != nil {
+	if err := globalIPWhitelistAPI.svc.Delete(id, userIDStr); err != nil {
 		respondError(c, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -163,15 +173,15 @@ func CheckIPAccess(c *gin.Context) {
 		return
 	}
 
-	userID, exists := c.Get(string(auth.UserIDKey))
-	if !exists {
+	userIDStr, ok := getUserIDStr(c)
+	if !ok {
 		respondErrori18n(c, http.StatusUnauthorized, "error.auth.authentication_required")
 		return
 	}
 
 	clientIP := c.ClientIP()
-	enforced := globalIPWhitelistAPI.svc.IsEnforced(userID.(string))
-	allowed := globalIPWhitelistAPI.svc.Check(clientIP, userID.(string))
+	enforced := globalIPWhitelistAPI.svc.IsEnforced(userIDStr)
+	allowed := globalIPWhitelistAPI.svc.Check(clientIP, userIDStr)
 
 	respondSuccess(c, gin.H{
 		"ip":              clientIP,
@@ -181,7 +191,7 @@ func CheckIPAccess(c *gin.Context) {
 	})
 
 	// Re-respond with full data including count
-	entries, err := globalIPWhitelistAPI.svc.List(userID.(string))
+	entries, err := globalIPWhitelistAPI.svc.List(userIDStr)
 	if err == nil {
 		respondSuccess(c, gin.H{
 			"ip":              clientIP,

--- a/internal/api/signing_api.go
+++ b/internal/api/signing_api.go
@@ -122,6 +122,12 @@ func GenerateKeys(c *gin.Context) {
 		return
 	}
 
+	userIDStr, ok := userID.(string)
+	if !ok {
+		respondErrori18n(c, http.StatusInternalServerError, "error.auth.invalid_user_id")
+		return
+	}
+
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
@@ -145,7 +151,7 @@ func GenerateKeys(c *gin.Context) {
 		PrivateKey:  base64.StdEncoding.EncodeToString(privateKey.Seed()),
 		Fingerprint: fingerprint,
 		IsActive:    true,
-		CreatedBy:   userID.(string),
+		CreatedBy:   userIDStr,
 	}
 
 	// Deactivate all existing keys
@@ -182,6 +188,12 @@ func RotateKeys(c *gin.Context) {
 		return
 	}
 
+	userIDStr, ok := userID.(string)
+	if !ok {
+		respondErrori18n(c, http.StatusInternalServerError, "error.auth.invalid_user_id")
+		return
+	}
+
 	publicKey, privateKey, err := signing.GenerateKeyPair()
 	if err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to generate key pair")
@@ -205,7 +217,7 @@ func RotateKeys(c *gin.Context) {
 		PrivateKey:  base64.StdEncoding.EncodeToString(privateKey.Seed()),
 		Fingerprint: fingerprint,
 		IsActive:    true,
-		CreatedBy:   userID.(string),
+		CreatedBy:   userIDStr,
 	}
 
 	// Deactivate all existing keys (keep them in DB for verification)

--- a/internal/service/oauth2_service.go
+++ b/internal/service/oauth2_service.go
@@ -70,8 +70,14 @@ func (s *OAuth2Service) CreateClient(userID, name string, redirectURIs, scopes, 
 	// Validate grant types
 	validGrantTypes := validateGrantTypes(grantTypes)
 
-	clientID := generateClientID()
-	clientSecret := generateClientSecret()
+	clientID, err := generateClientID()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate client ID: %w", err)
+	}
+	clientSecret, err := generateClientSecret()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate client secret: %w", err)
+	}
 
 	redirectURIsJSON, err := json.Marshal(redirectURIs)
 	if err != nil {
@@ -88,8 +94,13 @@ func (s *OAuth2Service) CreateClient(userID, name string, redirectURIs, scopes, 
 		return nil, "", fmt.Errorf("failed to marshal grant types: %w", err)
 	}
 
+	oauth2ID, err := generateOAuth2ID()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate OAuth2 ID: %w", err)
+	}
+
 	client := &model.OAuth2Client{
-		ID:           generateOAuth2ID(),
+		ID:           oauth2ID,
 		UserID:       userID,
 		Name:         name,
 		ClientID:     clientID,
@@ -168,7 +179,10 @@ func (s *OAuth2Service) RegenerateSecret(id, userID string) (string, error) {
 		return "", fmt.Errorf("failed to get OAuth2 client: %w", err)
 	}
 
-	newSecret := generateClientSecret()
+	newSecret, err := generateClientSecret()
+	if err != nil {
+		return "", fmt.Errorf("failed to regenerate client secret: %w", err)
+	}
 	if err := s.db.Model(&client).Update("client_secret", newSecret).Error; err != nil {
 		return "", fmt.Errorf("failed to regenerate client secret: %w", err)
 	}
@@ -201,11 +215,19 @@ func (s *OAuth2Service) CreateAuthorization(clientID, userID string, scopes []st
 		return nil, fmt.Errorf("failed to marshal scopes: %w", err)
 	}
 
-	code := generateToken()
+	code, err := generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate authorization code: %w", err)
+	}
 	expiresAt := time.Now().Add(time.Duration(s.cfg.CodeExpireMinutes) * time.Minute)
 
+	oauth2ID, err := generateOAuth2ID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OAuth2 ID: %w", err)
+	}
+
 	authz := &model.OAuth2Authorization{
-		ID:        generateOAuth2ID(),
+		ID:        oauth2ID,
 		ClientID:  clientID,
 		UserID:    userID,
 		Scopes:    string(scopesJSON),
@@ -347,8 +369,14 @@ func (s *OAuth2Service) ValidateAccessToken(token string) (*model.OAuth2Token, e
 
 // createToken creates a new access/refresh token pair.
 func (s *OAuth2Service) createToken(clientID, userID string, scopes []string) (*model.OAuth2Token, error) {
-	accessToken := generateToken()
-	refreshToken := generateToken()
+	accessToken, err := generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate access token: %w", err)
+	}
+	refreshToken, err := generateToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
 
 	scopesJSON, err := json.Marshal(scopes)
 	if err != nil {
@@ -357,8 +385,13 @@ func (s *OAuth2Service) createToken(clientID, userID string, scopes []string) (*
 
 	expiresAt := time.Now().Add(time.Duration(s.cfg.TokenExpireHours) * time.Hour)
 
+	oauth2ID, err := generateOAuth2ID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate OAuth2 ID: %w", err)
+	}
+
 	token := &model.OAuth2Token{
-		ID:           generateOAuth2ID(),
+		ID:           oauth2ID,
 		ClientID:     clientID,
 		UserID:       userID,
 		AccessToken:  accessToken,
@@ -377,37 +410,37 @@ func (s *OAuth2Service) createToken(clientID, userID string, scopes []string) (*
 }
 
 // generateToken generates a random 32-byte hex string.
-func generateToken() string {
+func generateToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		slog.Error("failed to generate token", "error", err)
-		panic("failed to generate token: " + err.Error())
+		return "", fmt.Errorf("failed to generate token: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }
 
 // generateClientID generates a random 16-byte hex string prefixed with "dp_".
-func generateClientID() string {
+func generateClientID() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		slog.Error("failed to generate client ID", "error", err)
-		panic("failed to generate client ID: " + err.Error())
+		return "", fmt.Errorf("failed to generate client ID: %w", err)
 	}
-	return "dp_" + hex.EncodeToString(b)
+	return "dp_" + hex.EncodeToString(b), nil
 }
 
 // generateClientSecret generates a random 32-byte hex string.
-func generateClientSecret() string {
+func generateClientSecret() (string, error) {
 	return generateToken()
 }
 
 // generateOAuth2ID generates a random hex ID for OAuth2 records.
-func generateOAuth2ID() string {
+func generateOAuth2ID() (string, error) {
 	b := make([]byte, 12)
 	if _, err := rand.Read(b); err != nil {
-		panic("failed to generate OAuth2 ID: " + err.Error())
+		return "", fmt.Errorf("failed to generate OAuth2 ID: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }
 
 // validateGrantTypes filters grant types to only allowed values.


### PR DESCRIPTION
## Summary

Replace panic calls with proper error handling to prevent service crashes.

## Changes

### OAuth2 Service (`internal/service/oauth2_service.go`)
- `generateToken()`: replaced `panic()` with error return
- `generateClientID()`: replaced `panic()` with error return  
- `generateOAuth2ID()`: replaced `panic()` with error return
- Updated all call sites to handle errors properly

### Signing API (`internal/api/signing_api.go`)
- Added `ok` check for userID type assertion

### IP Whitelist API (`internal/api/ip_whitelist_api.go`)
- Added `getUserIDStr()` helper function with `ok` check
- Updated all handlers

### Device API (`internal/api/device_api.go`)
- Added `getUserIDStrFromCtx()` helper function with `ok` check
- Updated all handlers

## Fixes

- Fixes #681
- Fixes #682
- Fixes #683

## Testing

- [x] Code compiles without errors