### PR TITLE
fix: security hardening - API key salt, IDOR, context leak

### DIFF
--- a/internal/api/routes_servers.go
+++ b/internal/api/routes_servers.go
@@ -10,94 +10,94 @@ import (
 
 // registerServerRoutes registers all server-related routes.
 func registerServerRoutes(protected *gin.RouterGroup, db *gorm.DB, bridge *service.Bridge) {
-		servers := protected.Group("/servers")
-		{
-			servers.POST("", AddServer(bridge))
-			servers.GET("", ListServers(bridge))
-			servers.PUT("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), UpdateServer(bridge))
-			servers.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), DeleteServer(bridge))
-			servers.POST("/:id/detect", auth.RequireResourceAccessCached(bridge, "server", "id"), DetectEnvironment(bridge))
-			servers.GET("/:id/environment", auth.RequireResourceAccessCached(bridge, "server", "id"), GetServerEnvironment(bridge))
-			servers.POST("/:id/test", auth.RequireResourceAccessCached(bridge, "server", "id"), TestServer(bridge))
+	servers := protected.Group("/servers")
+	{
+		servers.POST("", AddServer(bridge))
+		servers.GET("", ListServers(bridge))
+		servers.PUT("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), UpdateServer(bridge))
+		servers.DELETE("/:id", auth.RequireResourceAccessCached(bridge, "server", "id"), DeleteServer(bridge))
+		servers.POST("/:id/detect", auth.RequireResourceAccessCached(bridge, "server", "id"), DetectEnvironment(bridge))
+		servers.GET("/:id/environment", auth.RequireResourceAccessCached(bridge, "server", "id"), GetServerEnvironment(bridge))
+		servers.POST("/:id/test", auth.RequireResourceAccessCached(bridge, "server", "id"), TestServer(bridge))
 
-			// File management
-			fileAPI := NewFileManagerAPI(db, sandbox.New(sandbox.DefaultConfig()))
-			servers.GET("/:id/files", fileAPI.ListFiles)
-			servers.GET("/:id/files/read", fileAPI.ReadFile)
-			servers.PUT("/:id/files/write", fileAPI.WriteFile)
-			servers.DELETE("/:id/files", fileAPI.DeleteFile)
-			servers.POST("/:id/files/mkdir", fileAPI.CreateDirectory)
-			servers.POST("/:id/files/move", fileAPI.MoveFile)
-			servers.GET("/:id/files/disk-usage", fileAPI.GetDiskUsage)
-			servers.GET("/:id/files/info", fileAPI.GetFileInfo)
-			servers.GET("/:id/files/search", fileAPI.SearchFiles)
+		// File management — requires server resource access
+		fileAPI := NewFileManagerAPI(db, sandbox.New(sandbox.DefaultConfig()))
+		servers.GET("/:id/files", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.ListFiles)
+		servers.GET("/:id/files/read", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.ReadFile)
+		servers.PUT("/:id/files/write", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.WriteFile)
+		servers.DELETE("/:id/files", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.DeleteFile)
+		servers.POST("/:id/files/mkdir", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.CreateDirectory)
+		servers.POST("/:id/files/move", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.MoveFile)
+		servers.GET("/:id/files/disk-usage", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.GetDiskUsage)
+		servers.GET("/:id/files/info", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.GetFileInfo)
+		servers.GET("/:id/files/search", auth.RequireResourceAccessCached(bridge, "server", "id"), fileAPI.SearchFiles)
 
-			// Firewall management
-			fwAPI := NewFirewallAPI(db, sandbox.New(sandbox.DefaultConfig()))
-			servers.GET("/:id/firewall", fwAPI.GetFirewallStatus)
-			servers.GET("/:id/firewall/detect", fwAPI.DetectFirewall)
-			servers.POST("/:id/firewall/ports/open", fwAPI.OpenPort)
-			servers.POST("/:id/firewall/ports/close", fwAPI.ClosePort)
-			servers.POST("/:id/firewall/blocks", fwAPI.BlockIP)
-			servers.DELETE("/:id/firewall/blocks/:ip", fwAPI.UnblockIP)
-			servers.POST("/:id/firewall/common-ports", fwAPI.AllowCommonPorts)
+		// Firewall management — requires server resource access
+		fwAPI := NewFirewallAPI(db, sandbox.New(sandbox.DefaultConfig()))
+		servers.GET("/:id/firewall", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.GetFirewallStatus)
+		servers.GET("/:id/firewall/detect", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.DetectFirewall)
+		servers.POST("/:id/firewall/ports/open", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.OpenPort)
+		servers.POST("/:id/firewall/ports/close", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.ClosePort)
+		servers.POST("/:id/firewall/blocks", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.BlockIP)
+		servers.DELETE("/:id/firewall/blocks/:ip", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.UnblockIP)
+		servers.POST("/:id/firewall/common-ports", auth.RequireResourceAccessCached(bridge, "server", "id"), fwAPI.AllowCommonPorts)
 
-			// SSH management
-			servers.GET("/:id/ssh/authorizations", NewSSHAPI(db).ListServerAuthorizations)
-		}
+		// SSH management — requires server resource access
+		servers.GET("/:id/ssh/authorizations", auth.RequireResourceAccessCached(bridge, "server", "id"), NewSSHAPI(db).ListServerAuthorizations)
+	}
 
-		// SSH key management (top-level)
-		sshAPI := NewSSHAPI(db)
-		sshGroup := protected.Group("/ssh")
-		{
-			sshGroup.POST("/keys/generate", sshAPI.GenerateKeyPair)
-			sshGroup.POST("/keys/import", sshAPI.ImportPublicKey)
-			sshGroup.GET("/keys", sshAPI.ListKeyPairs)
-			sshGroup.GET("/keys/:id", sshAPI.GetKeyPair)
-			sshGroup.DELETE("/keys/:id", sshAPI.DeleteKeyPair)
-			sshGroup.GET("/keys/:id/authorizations", sshAPI.ListKeyAuthorizations)
-			sshGroup.POST("/authorize", sshAPI.AuthorizeKey)
-			sshGroup.POST("/revoke", sshAPI.RevokeKey)
-		}
+	// SSH key management (top-level)
+	sshAPI := NewSSHAPI(db)
+	sshGroup := protected.Group("/ssh")
+	{
+		sshGroup.POST("/keys/generate", sshAPI.GenerateKeyPair)
+		sshGroup.POST("/keys/import", sshAPI.ImportPublicKey)
+		sshGroup.GET("/keys", sshAPI.ListKeyPairs)
+		sshGroup.GET("/keys/:id", sshAPI.GetKeyPair)
+		sshGroup.DELETE("/keys/:id", sshAPI.DeleteKeyPair)
+		sshGroup.GET("/keys/:id/authorizations", sshAPI.ListKeyAuthorizations)
+		sshGroup.POST("/authorize", sshAPI.AuthorizeKey)
+		sshGroup.POST("/revoke", sshAPI.RevokeKey)
+	}
 
-		// Process daemon management
-		procAPI := NewProcessAPI(db)
-		servers.GET("/:id/processes", procAPI.ListProcesses)
-		servers.GET("/:id/processes/tree", procAPI.GetProcessTree)
-		servers.GET("/:id/processes/search", procAPI.SearchProcesses)
-		servers.GET("/:id/processes/:pid", procAPI.GetProcess)
-		servers.POST("/:id/processes/:pid/kill", procAPI.KillProcess)
-		servers.GET("/:id/resources", procAPI.GetSystemResources)
+	// Process daemon management — requires server resource access
+	procAPI := NewProcessAPI(db)
+	servers.GET("/:id/processes", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.ListProcesses)
+	servers.GET("/:id/processes/tree", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.GetProcessTree)
+	servers.GET("/:id/processes/search", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.SearchProcesses)
+	servers.GET("/:id/processes/:pid", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.GetProcess)
+	servers.POST("/:id/processes/:pid/kill", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.KillProcess)
+	servers.GET("/:id/resources", auth.RequireResourceAccessCached(bridge, "server", "id"), procAPI.GetSystemResources)
 
-		procGroup := protected.Group("/processes")
-		{
-			procGroup.GET("/rules", procAPI.ListRules)
-			procGroup.GET("/rules/:id", procAPI.GetRule)
-			procGroup.POST("/rules", procAPI.CreateRule)
-			procGroup.PUT("/rules/:id", procAPI.UpdateRule)
-			procGroup.DELETE("/rules/:id", procAPI.DeleteRule)
-		}
+	procGroup := protected.Group("/processes")
+	{
+		procGroup.GET("/rules", procAPI.ListRules)
+		procGroup.GET("/rules/:id", procAPI.GetRule)
+		procGroup.POST("/rules", procAPI.CreateRule)
+		procGroup.PUT("/rules/:id", procAPI.UpdateRule)
+		procGroup.DELETE("/rules/:id", procAPI.DeleteRule)
+	}
 
-		// System snapshot management
-		snapAPI := NewSnapshotAPI(db)
-		servers.GET("/:id/snapshots", snapAPI.ListSnapshots)
-		servers.GET("/:id/snapshots/files", snapAPI.GetSnapshotFiles)
-		servers.GET("/:id/snapshots/diff", snapAPI.DiffSnapshots)
-		servers.GET("/:id/snapshots/:snap_id", snapAPI.GetSnapshot)
-		servers.POST("/:id/snapshots", snapAPI.CreateSnapshot)
-		servers.POST("/:id/snapshots/:snap_id/restore", snapAPI.RestoreSnapshot)
-		servers.DELETE("/:id/snapshots/:snap_id", snapAPI.DeleteSnapshot)
+	// System snapshot management — requires server resource access
+	snapAPI := NewSnapshotAPI(db)
+	servers.GET("/:id/snapshots", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.ListSnapshots)
+	servers.GET("/:id/snapshots/files", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.GetSnapshotFiles)
+	servers.GET("/:id/snapshots/diff", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.DiffSnapshots)
+	servers.GET("/:id/snapshots/:snap_id", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.GetSnapshot)
+	servers.POST("/:id/snapshots", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.CreateSnapshot)
+	servers.POST("/:id/snapshots/:snap_id/restore", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.RestoreSnapshot)
+	servers.DELETE("/:id/snapshots/:snap_id", auth.RequireResourceAccessCached(bridge, "server", "id"), snapAPI.DeleteSnapshot)
 
-		// Toolbox management
-		tbAPI := NewToolboxAPI(db)
-		servers.GET("/:id/toolbox/detect", tbAPI.DetectEnvironment)
-		servers.POST("/:id/toolbox/run", tbAPI.RunScript)
-		servers.POST("/:id/toolbox/builtin", tbAPI.RunBuiltInScript)
-		servers.GET("/:id/toolbox/builtin-scripts", tbAPI.ListBuiltInScripts)
-		servers.GET("/:id/toolbox/scripts", tbAPI.ListScripts)
-		servers.POST("/:id/toolbox/scripts", tbAPI.CreateScript)
-		servers.GET("/:id/toolbox/scripts/:script_id", tbAPI.GetScript)
-		servers.PUT("/:id/toolbox/scripts/:script_id", tbAPI.UpdateScript)
-		servers.DELETE("/:id/toolbox/scripts/:script_id", tbAPI.DeleteScript)
+	// Toolbox management — requires server resource access
+	tbAPI := NewToolboxAPI(db)
+	servers.GET("/:id/toolbox/detect", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.DetectEnvironment)
+	servers.POST("/:id/toolbox/run", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.RunScript)
+	servers.POST("/:id/toolbox/builtin", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.RunBuiltInScript)
+	servers.GET("/:id/toolbox/builtin-scripts", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.ListBuiltInScripts)
+	servers.GET("/:id/toolbox/scripts", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.ListScripts)
+	servers.POST("/:id/toolbox/scripts", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.CreateScript)
+	servers.GET("/:id/toolbox/scripts/:script_id", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.GetScript)
+	servers.PUT("/:id/toolbox/scripts/:script_id", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.UpdateScript)
+	servers.DELETE("/:id/toolbox/scripts/:script_id", auth.RequireResourceAccessCached(bridge, "server", "id"), tbAPI.DeleteScript)
 
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,7 @@ type AuthConfig struct {
 	JWTSecret      string `mapstructure:"jwt_secret"`
 	TokenExpire    string `mapstructure:"token_expire"`
 	WSTicketExpire string `mapstructure:"ws_ticket_expire"`
+	APIKeySalt     string `mapstructure:"api_key_salt"`
 	OAuthProviders []OAuthProviderConfig `mapstructure:"oauth_providers"`
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,7 +106,7 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	})
 
 	// API Key service
-	keySvc := service.NewAPIKeyService(db)
+	keySvc := service.NewAPIKeyService(db, cfg.Auth.APIKeySalt)
 
 	// Per-user IP whitelist service and middleware
 	ipWhitelistSvc := service.NewIPWhitelistService(db)

--- a/internal/service/apikey_service.go
+++ b/internal/service/apikey_service.go
@@ -18,16 +18,25 @@ import (
 
 // APIKeyService handles API key CRUD and validation.
 type APIKeyService struct {
-	DB *gorm.DB
+	DB   *gorm.DB
+	Salt string
 }
 
 // NewAPIKeyService creates a new APIKeyService.
-func NewAPIKeyService(db *gorm.DB) *APIKeyService {
-	return &APIKeyService{DB: db}
+// If salt is empty, a random salt is generated and logged as a warning.
+func NewAPIKeyService(db *gorm.DB, salt string) *APIKeyService {
+	if salt == "" {
+		b := make([]byte, 32)
+		if _, err := rand.Read(b); err != nil {
+			slog.Error("failed to generate random API key salt, using fallback")
+			salt = fmt.Sprintf("deploypilot-%s", time.Now().Format("20060102150405.999999999"))
+		} else {
+			salt = hex.EncodeToString(b)
+			slog.Warn("API_KEY_SALT not configured, generated a random salt. Set API_KEY_SALT in config for persistence across restarts", "salt_prefix", salt[:8]+"...")
+		}
+	}
+	return &APIKeyService{DB: db, Salt: salt}
 }
-
-// Create generates a new API key. Returns the APIKey model and the raw key (shown only once).
-const apiKeySalt = "deploypilot-apikey-salt-v1"
 
 func (s *APIKeyService) Create(ctx context.Context, userID, tenantID, name string, scopes []string, expiresInDays int) (*model.APIKey, string, error) {
 	// Generate random key: dp_ + 32 hex chars = 35 chars total
@@ -38,7 +47,7 @@ func (s *APIKeyService) Create(ctx context.Context, userID, tenantID, name strin
 	rawKey := "dp_" + hex.EncodeToString(rawBytes)
 
 	// Hash the key for storage
-	hash := sha256.Sum256([]byte(apiKeySalt + rawKey))
+	hash := sha256.Sum256([]byte(s.Salt + rawKey))
 	keyHash := hex.EncodeToString(hash[:])
 
 	// Prefix for identification (first 10 chars)
@@ -79,7 +88,7 @@ func (s *APIKeyService) Create(ctx context.Context, userID, tenantID, name strin
 // Validate checks if a raw API key is valid and not expired.
 // On success, it updates LastUsedAt and returns the APIKey.
 func (s *APIKeyService) Validate(ctx context.Context, rawKey string) (*model.APIKey, error) {
-	hash := sha256.Sum256([]byte(apiKeySalt + rawKey))
+	hash := sha256.Sum256([]byte(s.Salt + rawKey))
 	keyHash := hex.EncodeToString(hash[:])
 
 	var apiKey model.APIKey

--- a/internal/service/apikey_service_test.go
+++ b/internal/service/apikey_service_test.go
@@ -22,7 +22,7 @@ func setupAPIKeyTestDB(t *testing.T) *gorm.DB {
 
 func TestAPIKeyService_Create(t *testing.T) {
 	db := setupAPIKeyTestDB(t)
-	svc := NewAPIKeyService(db)
+	svc := NewAPIKeyService(db, "test-salt-for-unit-tests")
 
 	apiKey, rawKey, err := svc.Create(context.TODO(), "user-1", "tenant-default", "test-key", []string{"read", "write"}, 30)
 	if err != nil {
@@ -50,7 +50,7 @@ func TestAPIKeyService_Create(t *testing.T) {
 
 func TestAPIKeyService_CreateNoExpiry(t *testing.T) {
 	db := setupAPIKeyTestDB(t)
-	svc := NewAPIKeyService(db)
+	svc := NewAPIKeyService(db, "test-salt-for-unit-tests")
 
 	apiKey, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "permanent-key", []string{"read"}, 0)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestAPIKeyService_CreateNoExpiry(t *testing.T) {
 
 func TestAPIKeyService_Validate(t *testing.T) {
 	db := setupAPIKeyTestDB(t)
-	svc := NewAPIKeyService(db)
+	svc := NewAPIKeyService(db, "test-salt-for-unit-tests")
 
 	_, rawKey, err := svc.Create(context.TODO(), "user-1", "tenant-default", "test-key", []string{"read"}, 0)
 	if err != nil {
@@ -88,7 +88,7 @@ func TestAPIKeyService_Validate(t *testing.T) {
 
 func TestAPIKeyService_List(t *testing.T) {
 	db := setupAPIKeyTestDB(t)
-	svc := NewAPIKeyService(db)
+	svc := NewAPIKeyService(db, "test-salt-for-unit-tests")
 
 	for i := 0; i < 3; i++ {
 		_, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "key-"+string(rune('A'+i)), []string{"read"}, 0)
@@ -110,7 +110,7 @@ func TestAPIKeyService_List(t *testing.T) {
 
 func TestAPIKeyService_Delete(t *testing.T) {
 	db := setupAPIKeyTestDB(t)
-	svc := NewAPIKeyService(db)
+	svc := NewAPIKeyService(db, "test-salt-for-unit-tests")
 
 	apiKey, _, err := svc.Create(context.TODO(), "user-1", "tenant-default", "to-delete", []string{"read"}, 0)
 	if err != nil {

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -20,12 +20,18 @@ import (
 // ---------- 1. Deploy ----------
 
 // DeployAsync starts a deploy in a goroutine and returns a task ID immediately.
+// It uses a detached context so the deploy is not cancelled when the HTTP request ends.
 func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID string) (taskID string, err error) {
 	taskID = b.createTask("deploy")
 	traceID := tracing.TraceIDFromContext(ctx)
 	b.updateTask(taskID, "running", 0, "deploy started")
+
+	// Use a detached context so the deploy continues even if the original
+	// HTTP request context is cancelled (e.g. client disconnects).
+	detachedCtx := context.Background()
+
 	go func() {
-		cs, deployErr := b.Deploy(ctx, cfg)
+		cs, deployErr := b.Deploy(detachedCtx, cfg)
 		if deployErr != nil {
 			slog.Error("deploy failed", "task_id", taskID, "app_id", appID, "error", deployErr)
 			b.updateTask(taskID, "failed", 100, "deploy failed: see server logs for details")


### PR DESCRIPTION
## Summary

Security hardening batch addressing 3 high-priority issues.

## Changes

### #680 - Hardcoded API Key Salt (CVSS 9.1)
- **Before**: `const apiKeySalt = "deploypilot-apikey-salt-v1"` (same salt on all instances)
- **After**: Configurable via `auth.api_key_salt` in config.yaml
- Falls back to random salt with warning if not configured
- Added `APIKeySalt` field to `AuthConfig` struct
- Updated `NewAPIKeyService` signature to accept salt parameter
- Updated all test files

### #685 - Cross-Tenant IDOR on Server Sub-routes
- **Before**: 30+ server sub-routes (files, firewall, processes, snapshots, toolbox) had NO resource-level authorization
- **After**: All routes now protected with `RequireResourceAccessCached` middleware
- Affected routes:
  - File management (9 routes): list, read, write, delete, mkdir, move, disk-usage, info, search
  - Firewall (7 routes): status, detect, open/close port, block/unblock IP, common-ports
  - Process (6 routes): list, tree, search, get, kill, resources
  - Snapshot (7 routes): list, files, diff, get, create, restore, delete
  - Toolbox (9 routes): detect, run, builtin, scripts CRUD

### #686 - DeployAsync Context Cancellation
- **Before**: `go func() { b.Deploy(ctx, cfg) }` — deploy cancelled when HTTP request ends
- **After**: `go func() { b.Deploy(context.Background(), cfg) }` — deploy runs to completion

## Fixes

- Fixes #680
- Fixes #685
- Fixes #686

## Testing

- [x] Code compiles without errors
- [x] Unit tests updated
- [ ] API tests pass