### PR TITLE
fix: path traversal vulnerabilities in SSL and file manager (#690)

### DIFF
--- a/internal/api/file_manager_api.go
+++ b/internal/api/file_manager_api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -11,6 +12,28 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
+
+// validateFilePath checks if the path is safe (no path traversal)
+func validateFilePath(path string) error {
+	if path == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
+	// Check for null bytes
+	if strings.Contains(path, "\x00") {
+		return fmt.Errorf("path contains null bytes")
+	}
+	// Clean the path and check for traversal
+	cleanPath := filepath.Clean(path)
+	// Check for absolute paths that might escape intended directory
+	if strings.HasPrefix(cleanPath, "..") {
+		return fmt.Errorf("path traversal detected")
+	}
+	// Additional check for .. in the original path
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("path contains traversal sequence")
+	}
+	return nil
+}
 
 // FileManagerAPI provides HTTP handlers for remote file management.
 type FileManagerAPI struct {
@@ -30,6 +53,12 @@ func (f *FileManagerAPI) ListFiles(c *gin.Context) {
 	serverID := c.Param("server_id")
 	remotePath := c.DefaultQuery("path", "/home")
 
+	// Validate path to prevent traversal
+	if err := validateFilePath(remotePath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
 	entries, err := f.fileSvc.ListFiles(c.Request.Context(), serverID, remotePath)
 	if err != nil {
 		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
@@ -45,6 +74,12 @@ func (f *FileManagerAPI) ReadFile(c *gin.Context) {
 	serverID := c.Param("server_id")
 	remotePath := c.Query("path")
 	if remotePath == "" {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Validate path to prevent traversal
+	if err := validateFilePath(remotePath); err != nil {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}
@@ -77,8 +112,8 @@ func (f *FileManagerAPI) WriteFile(c *gin.Context) {
 		return
 	}
 
-	// Reject path traversal attempts
-	if strings.Contains(filepath.Clean(req.Path), "..") {
+	// Validate path to prevent traversal
+	if err := validateFilePath(req.Path); err != nil {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}
@@ -101,6 +136,12 @@ func (f *FileManagerAPI) DeleteFile(c *gin.Context) {
 		return
 	}
 
+	// Validate path to prevent traversal
+	if err := validateFilePath(remotePath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
 	if err := f.fileSvc.DeleteFile(c.Request.Context(), serverID, remotePath); err != nil {
 		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 		return
@@ -118,6 +159,12 @@ func (f *FileManagerAPI) CreateDirectory(c *gin.Context) {
 		Path string `json:"path" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Validate path to prevent traversal
+	if err := validateFilePath(req.Path); err != nil {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}
@@ -144,6 +191,16 @@ func (f *FileManagerAPI) MoveFile(c *gin.Context) {
 		return
 	}
 
+	// Validate paths to prevent traversal
+	if err := validateFilePath(req.SrcPath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+	if err := validateFilePath(req.DstPath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
 	if err := f.fileSvc.MoveFile(c.Request.Context(), serverID, req.SrcPath, req.DstPath); err != nil {
 		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 		return
@@ -157,6 +214,12 @@ func (f *FileManagerAPI) MoveFile(c *gin.Context) {
 func (f *FileManagerAPI) GetDiskUsage(c *gin.Context) {
 	serverID := c.Param("server_id")
 	remotePath := c.DefaultQuery("path", "/")
+
+	// Validate path to prevent traversal
+	if err := validateFilePath(remotePath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
 
 	usage, err := f.fileSvc.GetDiskUsage(c.Request.Context(), serverID, remotePath)
 	if err != nil {
@@ -177,6 +240,12 @@ func (f *FileManagerAPI) GetFileInfo(c *gin.Context) {
 		return
 	}
 
+	// Validate path to prevent traversal
+	if err := validateFilePath(remotePath); err != nil {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
 	info, err := f.fileSvc.GetFileInfo(c.Request.Context(), serverID, remotePath)
 	if err != nil {
 		respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
@@ -193,6 +262,12 @@ func (f *FileManagerAPI) SearchFiles(c *gin.Context) {
 	searchPath := c.DefaultQuery("path", "/home")
 	pattern := c.Query("pattern")
 	if pattern == "" {
+		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+		return
+	}
+
+	// Validate path to prevent traversal
+	if err := validateFilePath(searchPath); err != nil {
 		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
 		return
 	}

--- a/internal/provider/ssl/ssl.go
+++ b/internal/provider/ssl/ssl.go
@@ -14,6 +14,8 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -31,6 +33,49 @@ type CertificateProvider interface {
 type SSLProvider struct {
 	certDir    string
 	accountKey *ecdsa.PrivateKey
+}
+
+// validDomainRegex matches valid domain names (prevents path traversal)
+var validDomainRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}(\.[a-zA-Z0-9][a-zA-Z0-9-]{0,62})*$`)
+
+// validateDomain checks if the domain is valid and safe to use as a filename
+func validateDomain(domain string) error {
+	if domain == "" {
+		return fmt.Errorf("domain cannot be empty")
+	}
+	// Check for path traversal attempts
+	if strings.Contains(domain, "..") || strings.Contains(domain, "/") || strings.Contains(domain, "\\") {
+		return fmt.Errorf("invalid domain: contains path traversal characters")
+	}
+	// Check for valid domain format
+	if !validDomainRegex.MatchString(domain) {
+		return fmt.Errorf("invalid domain format: %s", domain)
+	}
+	return nil
+}
+
+// safeJoin safely joins a directory with a filename, preventing path traversal
+func safeJoin(dir, filename string) (string, error) {
+	// Clean the path to resolve any .. sequences
+	cleanPath := filepath.Clean(filename)
+	// Check for path traversal after cleaning
+	if strings.HasPrefix(cleanPath, "..") || strings.HasPrefix(cleanPath, "/") || strings.HasPrefix(cleanPath, "\\") {
+		return "", fmt.Errorf("path traversal detected: %s", filename)
+	}
+	// Join and verify the final path is within the directory
+	fullPath := filepath.Join(dir, cleanPath)
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path for directory: %w", err)
+	}
+	absPath, err := filepath.Abs(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get absolute path: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absDir+string(filepath.Separator)) && absPath != absDir {
+		return "", fmt.Errorf("path escapes directory: %s", filename)
+	}
+	return fullPath, nil
 }
 
 // NewSSLProvider creates a new SSL provider.
@@ -67,6 +112,11 @@ func (p *SSLProvider) RequestCertificate(ctx context.Context, domain, email stri
 	_ = email
 	slog.Info("requesting SSL certificate", "domain", domain, "email", email)
 
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		return nil, fmt.Errorf("invalid domain: %w", err)
+	}
+
 	// Generate self-signed certificate as placeholder
 	// In production, replace with ACME flow using go-acme/lego
 	cert, key, err := p.generateSelfSigned(domain)
@@ -74,9 +124,15 @@ func (p *SSLProvider) RequestCertificate(ctx context.Context, domain, email stri
 		return nil, fmt.Errorf("generate certificate: %w", err)
 	}
 
-	// Save to disk
-	certPath := filepath.Join(p.certDir, domain+".crt")
-	keyPath := filepath.Join(p.certDir, domain+".key")
+	// Save to disk using safe path joining
+	certPath, err := safeJoin(p.certDir, domain+".crt")
+	if err != nil {
+		return nil, fmt.Errorf("invalid cert path: %w", err)
+	}
+	keyPath, err := safeJoin(p.certDir, domain+".key")
+	if err != nil {
+		return nil, fmt.Errorf("invalid key path: %w", err)
+	}
 
 	if err := os.WriteFile(certPath, cert, 0600); err != nil {
 		return nil, fmt.Errorf("write cert: %w", err)
@@ -99,13 +155,28 @@ func (p *SSLProvider) RequestCertificate(ctx context.Context, domain, email stri
 // RenewCertificate renews an existing certificate.
 func (p *SSLProvider) RenewCertificate(ctx context.Context, domain string) (*Certificate, error) {
 	slog.Info("renewing SSL certificate", "domain", domain)
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		return nil, fmt.Errorf("invalid domain: %w", err)
+	}
 	return p.RequestCertificate(ctx, domain, "")
 }
 
 // GetCertificate loads a certificate from disk.
 func (p *SSLProvider) GetCertificate(domain string) (*Certificate, error) {
-	certPath := filepath.Join(p.certDir, domain+".crt")
-	keyPath := filepath.Join(p.certDir, domain+".key")
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		return nil, fmt.Errorf("invalid domain: %w", err)
+	}
+
+	certPath, err := safeJoin(p.certDir, domain+".crt")
+	if err != nil {
+		return nil, fmt.Errorf("invalid cert path: %w", err)
+	}
+	keyPath, err := safeJoin(p.certDir, domain+".key")
+	if err != nil {
+		return nil, fmt.Errorf("invalid key path: %w", err)
+	}
 
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
@@ -136,8 +207,20 @@ func (p *SSLProvider) GetCertificate(domain string) (*Certificate, error) {
 
 // DeleteCertificate removes certificate files from disk.
 func (p *SSLProvider) DeleteCertificate(domain string) error {
-	certPath := filepath.Join(p.certDir, domain+".crt")
-	keyPath := filepath.Join(p.certDir, domain+".key")
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		return fmt.Errorf("invalid domain: %w", err)
+	}
+
+	certPath, err := safeJoin(p.certDir, domain+".crt")
+	if err != nil {
+		return fmt.Errorf("invalid cert path: %w", err)
+	}
+	keyPath, err := safeJoin(p.certDir, domain+".key")
+	if err != nil {
+		return fmt.Errorf("invalid key path: %w", err)
+	}
+
 	_ = os.Remove(certPath)
 	_ = os.Remove(keyPath)
 	slog.Info("deleted SSL certificate", "domain", domain)
@@ -146,6 +229,11 @@ func (p *SSLProvider) DeleteCertificate(domain string) error {
 
 // CheckExpiry checks if a certificate is expiring soon.
 func (p *SSLProvider) CheckExpiry(domain string) (time.Duration, bool) {
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		slog.Warn("invalid domain in CheckExpiry", "domain", domain, "error", err)
+		return 0, true
+	}
 	cert, err := p.GetCertificate(domain)
 	if err != nil {
 		return 0, true
@@ -196,6 +284,10 @@ func (p *SSLProvider) generateSelfSigned(domain string) (certPEM, keyPEM []byte,
 
 // GetTLSConfig returns a tls.Config for the given domain.
 func (p *SSLProvider) GetTLSConfig(domain string) (*tls.Config, error) {
+	// Validate domain to prevent path traversal
+	if err := validateDomain(domain); err != nil {
+		return nil, fmt.Errorf("invalid domain: %w", err)
+	}
 	cert, err := p.GetCertificate(domain)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Fix path traversal vulnerabilities in SSL certificate management and file manager APIs.

## Changes

### SSL Provider (internal/provider/ssl/ssl.go)
- Add `validateDomain()` function to validate domain names against RFC-compliant regex
- Add `safeJoin()` function to safely join paths and verify they stay within intended directory
- Validate domain in all public methods:
  - `RequestCertificate`
  - `RenewCertificate`
  - `GetCertificate`
  - `DeleteCertificate`
  - `CheckExpiry`
  - `GetTLSConfig`

### File Manager API (internal/api/file_manager_api.go)
- Add `validateFilePath()` helper function
- Validate paths in all handlers:
  - `ListFiles`
  - `ReadFile`
  - `WriteFile`
  - `DeleteFile`
  - `CreateDirectory`
  - `MoveFile`
  - `GetDiskUsage`
  - `GetFileInfo`
  - `SearchFiles`

## Security Improvements

- Domain names are validated against regex: `^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}(\.[a-zA-Z0-9][a-zA-Z0-9-]{0,62})*$`
- Paths are checked for `..` sequences and null bytes
- `safeJoin()` verifies final path is within intended directory using absolute path comparison

## Example Attacks Prevented

```
# SSL Certificate path traversal (BEFORE: would write to /etc/passwd)
POST /api/v1/ssl/certificates
{"domain": "../../../etc/passwd"}  # -> Now rejected

# File manager path traversal (BEFORE: could escape sandbox)
GET /api/v1/servers/123/files?path=../../../etc/shadow  # -> Now rejected
```

## Fixes

- Fixes #690

## Testing

- [x] Code compiles without errors
- [ ] Unit tests added for validation functions