### PR TITLE
fix: use Go 1.24 compatible benchstat version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,8 +16,6 @@ jobs:
     name: Run Benchmarks
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Benchmarks are non-blocking: failures only produce warnings
-    if: always()
     steps:
       - uses: actions/checkout@v6
         with:
@@ -30,20 +28,23 @@ jobs:
       - name: Run benchmarks on PR branch
         run: |
           go mod tidy
-          go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee pr_bench.txt || true
+          go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee pr_bench.txt
 
       - name: Run benchmarks on base branch
         run: |
           git checkout ${{ github.event.pull_request.base.sha }}
           go mod tidy
-          go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee base_bench.txt || true
+          go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee base_bench.txt
 
-      - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+      - name: Install benchstat (Go 1.24 compatible version)
+        run: |
+          # Install benchstat version compatible with Go 1.24
+          # Latest benchstat requires Go 1.25+, so we use an older version
+          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20250305200910-02a15fd477ba
 
       - name: Compare benchmarks
         run: |
-          benchstat base_bench.txt pr_bench.txt > benchstat_results.txt || true
+          benchstat base_bench.txt pr_bench.txt > benchstat_results.txt
           cat benchstat_results.txt
 
       - name: Check for regression (>5%)


### PR DESCRIPTION
## Summary

Fix Benchmark CI by using a benchstat version compatible with Go 1.24.

## Problem

Latest benchstat requires Go 1.25+:
```
go install golang.org/x/perf/cmd/benchstat@latest
# golang.org/x/perf@v0.0.0-... requires go >= 1.25.0 (running go 1.24)
```

## Solution

Pin benchstat to a Go 1.24 compatible version:
```
go install golang.org/x/perf/cmd/benchstat@v0.0.0-20250305200910-02a15fd477ba
```

## Changes

- Remove `|| true` fallbacks (benchmarks should fail on error)
- Remove `if: always()` (job should respect step failures)
- Pin benchstat to Go 1.24 compatible version
- Add comment explaining version pin

## Testing

- [ ] Benchmark CI passes