### PR TITLE
fix: security hardening batch - timeouts, context, JWT, rate limit

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
@@ -24,6 +25,55 @@ var passwordValidator *middleware.PasswordValidator
 
 // auditSvcForAuth is the global audit service for auth events.
 var auditSvcForAuth *service.AuditService
+
+// registerRateLimiter provides per-IP rate limiting for registration attempts.
+// Max 5 registrations per IP per 15 minutes.
+type registerRateLimiter struct {
+	mu       sync.Mutex
+	attempts map[string]*rateLimitEntry
+	max      int
+	window   time.Duration
+}
+
+type rateLimitEntry struct {
+	count    int
+	expireAt time.Time
+}
+
+var registerRL = &registerRateLimiter{
+	attempts: make(map[string]*rateLimitEntry),
+	max:      5,
+	window:   15 * time.Minute,
+}
+
+// Allow checks if the given IP is allowed to register.
+func (rl *registerRateLimiter) Allow(ip string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	entry, ok := rl.attempts[ip]
+	if !ok || now.After(entry.expireAt) {
+		rl.attempts[ip] = &rateLimitEntry{count: 1, expireAt: now.Add(rl.window)}
+		return true
+	}
+	if entry.count >= rl.max {
+		return false
+	}
+	entry.count++
+	return true
+}
+
+// Remaining returns the remaining registration attempts for the given IP.
+func (rl *registerRateLimiter) Remaining(ip string) int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	now := time.Now()
+	entry, ok := rl.attempts[ip]
+	if !ok || now.After(entry.expireAt) {
+		return rl.max
+	}
+	return rl.max - entry.count
+}
 
 // SetPasswordValidator sets the global password validator for registration and password changes.
 func SetPasswordValidator(v *middleware.PasswordValidator) {
@@ -49,6 +99,18 @@ func SetAuditServiceForAuth(svc *service.AuditService) {
 // @Router       /auth/register [post]
 func Register(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Rate limit: max 5 registrations per IP per 15 minutes
+		clientIP := c.ClientIP()
+		if !registerRL.Allow(clientIP) {
+			c.Header("X-RateLimit-Remaining", "0")
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error": "too many registration attempts, please try again later",
+			})
+			c.Abort()
+			return
+		}
+		c.Header("X-RateLimit-Remaining", fmt.Sprintf("%d", registerRL.Remaining(clientIP)))
+
 		var input struct {
 			Username string `json:"username" binding:"required"`
 			Email    string `json:"email" binding:"required,email"`

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -18,14 +18,15 @@ type Claims struct {
 }
 
 // getJWTSecret returns the JWT signing secret from the environment.
-// Returns an error if JWT_SECRET is not set or is shorter than 16 characters.
+// Returns an error if JWT_SECRET is not set or is shorter than 32 characters.
+// 32 bytes (256 bits) is the minimum recommended for HMAC-SHA256.
 func getJWTSecret() ([]byte, error) {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		return nil, errors.New("JWT_SECRET environment variable is required and must be at least 16 characters")
+		return nil, errors.New("JWT_SECRET environment variable is required and must be at least 32 characters")
 	}
-	if len(secret) < 16 {
-		return nil, fmt.Errorf("JWT_SECRET must be at least 16 characters, current length: %d", len(secret))
+	if len(secret) < 32 {
+		return nil, fmt.Errorf("JWT_SECRET must be at least 32 characters (256 bits for HMAC-SHA256), current length: %d", len(secret))
 	}
 	return []byte(secret), nil
 }

--- a/internal/plugin/builtin/slack_notify.go
+++ b/internal/plugin/builtin/slack_notify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/plugin"
 	"github.com/gin-gonic/gin"
@@ -22,7 +23,7 @@ type SlackNotifyPlugin struct {
 // NewSlackNotifyPlugin creates a new SlackNotifyPlugin.
 func NewSlackNotifyPlugin() plugin.EventPlugin {
 	return &SlackNotifyPlugin{
-		client: &http.Client{},
+		client: &http.Client{Timeout: 15 * time.Second},
 	}
 }
 

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -27,11 +27,30 @@ func (b *Bridge) DeployAsync(ctx context.Context, cfg mcp.DeployConfig, appID st
 	traceID := tracing.TraceIDFromContext(ctx)
 	b.updateTask(taskID, "running", 0, "deploy started")
 
-	// Use a detached context so the deploy continues even if the original
-	// HTTP request context is cancelled (e.g. client disconnects).
-	detachedCtx := context.Background()
+	// Use a detached context with timeout so the deploy continues even if
+	// the original HTTP request context is cancelled (e.g. client disconnects),
+	// but still has a reasonable upper bound to prevent runaway goroutines.
+	detachedCtx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 
 	go func() {
+		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("deploy panicked", "task_id", taskID, "app_id", appID, "panic", r)
+				b.updateTask(taskID, "failed", 100, "deploy panicked: see server logs for details")
+				b.EventBus.Publish(DeployEvent{
+					TaskID:    taskID,
+					AppID:     appID,
+					Step:      "done",
+					Status:    "failed",
+					Progress:  100,
+					Message:   "deploy panicked: see server logs for details",
+					Timestamp: timeutil.FormatRFC3339(),
+					TraceID:   traceID,
+				})
+			}
+		}()
+
 		cs, deployErr := b.Deploy(detachedCtx, cfg)
 		if deployErr != nil {
 			slog.Error("deploy failed", "task_id", taskID, "app_id", appID, "error", deployErr)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/config"
 	"github.com/Yogdunana/deploypilot/internal/crypto"
@@ -160,7 +161,7 @@ func (s *OAuthService) getUserInfo(ctx context.Context, provider, accessToken st
 		return nil, fmt.Errorf("unsupported OAuth provider: %s", provider)
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 15 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, "GET", p.UserInfoURL(), nil)
 	if err != nil {
 		return nil, err

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -550,7 +550,7 @@ func downloadFile(ctx context.Context, url, destPath string) error {
 		_ = f.Close()
 		if !success {
 			// Clean up partially written file on error
-			os.Remove(destPath)
+			_ = os.Remove(destPath)
 		}
 	}()
 

--- a/internal/service/upgrade.go
+++ b/internal/service/upgrade.go
@@ -543,12 +543,22 @@ func downloadFile(ctx context.Context, url, destPath string) error {
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
-	defer func() { _ = f.Close() }()
 
-	if _, err := io.Copy(f, resp.Body); err != nil {
+	// Write to file with size limit (500MB max) and cleanup on error.
+	success := false
+	defer func() {
+		_ = f.Close()
+		if !success {
+			// Clean up partially written file on error
+			os.Remove(destPath)
+		}
+	}()
+
+	if _, err := io.Copy(f, io.LimitReader(resp.Body, 500*1024*1024)); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 
+	success = true
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Security hardening batch fixing 6 issues across HTTP clients, async context, JWT, and rate limiting.

## Changes

### HTTP Client Timeouts
- **oauth.go** (#673): Add 15s timeout to `getUserInfo` HTTP Client
- **slack_notify.go** (#674): Add 15s timeout to Slack webhook HTTP Client

### Async Context Safety
- **deploy_service.go** (#675): Replace `context.Background()` with `context.WithTimeout(30min)` in `DeployAsync`
- Add `defer recover()` to prevent goroutine panic from crashing the server

### JWT Security
- **jwt.go** (#698): Increase minimum JWT secret from 16 to 32 characters (256 bits for HMAC-SHA256)

### Rate Limiting
- **auth.go** (#699): Add IP-based rate limiting to `/auth/register` endpoint
  - Max 5 registrations per IP per 15 minutes
  - Returns `X-RateLimit-Remaining` header
  - Returns 429 when limit exceeded

### Download Safety
- **upgrade.go** (#676): Add 500MB size limit via `io.LimitReader` in `downloadFile`
- Clean up partially written temp files on download error

## Fixes

- Fixes #673
- Fixes #674
- Fixes #675
- Fixes #698
- Fixes #699
- Fixes #676