### PR TITLE
fix: reset register rate limiter in test setup

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -161,6 +161,8 @@ func setupTestRouter(db *gorm.DB) *gin.Engine {
 		c.Set("db", db)
 		c.Next()
 	})
+	// Reset rate limiter state between tests
+	resetRegisterRateLimiter()
 
 	api := r.Group("/api/v1")
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -46,6 +46,14 @@ var registerRL = &registerRateLimiter{
 	window:   15 * time.Minute,
 }
 
+// resetRegisterRateLimiter clears all rate limit state.
+// Must be called in test setup to prevent cross-test interference.
+func resetRegisterRateLimiter() {
+	registerRL.mu.Lock()
+	defer registerRL.mu.Unlock()
+	registerRL.attempts = make(map[string]*rateLimitEntry)
+}
+
 // Allow checks if the given IP is allowed to register.
 func (rl *registerRateLimiter) Allow(ip string) bool {
 	rl.mu.Lock()

--- a/internal/api/coverage_test.go
+++ b/internal/api/coverage_test.go
@@ -391,6 +391,7 @@ func TestDeleteDNSRecord_WithID_Cov(t *testing.T) {
 
 func TestRegister_WithAllFields_Cov(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db := setupTestDB(t)
 	defer db.Exec("VACUUM")
 
@@ -414,6 +415,7 @@ func TestRegister_WithAllFields_Cov(t *testing.T) {
 
 func TestRegister_DuplicateEmail_Cov(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db := setupTestDB(t)
 	defer db.Exec("VACUUM")
 
@@ -1255,6 +1257,7 @@ func TestUpdateDNSRecord_MissingFields(t *testing.T) {
 
 func TestRegister_DBCreateError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db, _ := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	_ = db.Exec("CREATE TABLE roles (id TEXT PRIMARY KEY, name TEXT)")
 	_ = db.Exec("CREATE TABLE users (id TEXT PRIMARY KEY, username TEXT UNIQUE, email TEXT UNIQUE, password_hash TEXT)")
@@ -1765,6 +1768,7 @@ func TestSplitAndTrim_Blanks(t *testing.T) {
 
 func TestRegister_MissingFields(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db := setupTestDB(t)
 	defer db.Exec("VACUUM")
 
@@ -2629,6 +2633,7 @@ func TestListAuditLogs_Success_Cov(t *testing.T) {
 
 func TestRegister_MissingEmail_Cov(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db := setupTestDB(t)
 	defer db.Exec("VACUUM")
 
@@ -2648,6 +2653,7 @@ func TestRegister_MissingEmail_Cov(t *testing.T) {
 
 func TestRegister_InvalidJSON_Cov(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	resetRegisterRateLimiter()
 	db := setupTestDB(t)
 	defer db.Exec("VACUUM")
 


### PR DESCRIPTION
## Summary

Fix main CI test failures caused by the register rate limiter persisting state across tests.

## Problem

The global `registerRateLimiter` retains state between test functions. After the first few register tests exhaust the rate limit (5 per IP), subsequent tests get 429 instead of their expected status codes.

## Solution

- Add `resetRegisterRateLimiter()` function to clear rate limit state
- Call it in `setupTestRouter()` (api_test.go)
- Call it at the start of each `TestRegister_*` function (coverage_test.go)

## Fixes

- Follow-up to #708 (security hardening batch)