### PR TITLE
feat: add HTTP MCP endpoint for cloud AI IDEs

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/Yogdunana/deploypilot/internal/mcp"
+	"github.com/Yogdunana/deploypilot/internal/service"
+)
+
+// MCPHTTPHandler handles MCP requests over HTTP/SSE.
+// It allows cloud-based AI IDEs (TRAE Solo, Coze, Cursor Cloud) to connect
+// to DeployPilot via the network instead of stdio.
+type MCPHTTPHandler struct {
+	mu          sync.RWMutex
+	sessions    map[string]*mcpSession
+	mcpServer   *server.MCPServer
+	bridge      *service.Bridge
+}
+
+type mcpSession struct {
+	id       string
+	role     string
+	userID   string
+	username string
+}
+
+// NewMCPHTTPHandler creates a new MCP HTTP handler.
+func NewMCPHTTPHandler(bridge *service.Bridge) *MCPHTTPHandler {
+	mcpServer := mcp.NewServer(bridge)
+	return &MCPHTTPHandler{
+		sessions:  make(map[string]*mcpSession),
+		mcpServer: mcpServer,
+		bridge:    bridge,
+	}
+}
+
+// HandleSSE handles SSE connections for MCP clients.
+// GET /api/v1/mcp/sse
+func (h *MCPHTTPHandler) HandleSSE(c *gin.Context) {
+	// Get user info from context (set by auth middleware)
+	userID, _ := c.Get("userID")
+	username, _ := c.Get("username")
+	role, _ := c.Get("role")
+
+	// Generate session ID
+	sessionID := uuid.New().String()
+
+	// Store session
+	h.mu.Lock()
+	h.sessions[sessionID] = &mcpSession{
+		id:       sessionID,
+		role:     role.(string),
+		userID:   userID.(string),
+		username: username.(string),
+	}
+	h.mu.Unlock()
+
+	// Cleanup on disconnect
+	defer func() {
+		h.mu.Lock()
+		delete(h.sessions, sessionID)
+		h.mu.Unlock()
+	}()
+
+	// Set SSE headers
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Header("Mcp-Session-Id", sessionID)
+
+	// Send endpoint event
+	c.SSEvent("endpoint", gin.H{
+		"message_endpoint": "/api/v1/mcp/message?session=" + sessionID,
+	})
+	c.Writer.Flush()
+
+	// Keep connection alive
+	ctx := c.Request.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Debug("MCP SSE connection closed", "session", sessionID)
+			return
+		case <-c.Done():
+			return
+		}
+	}
+}
+
+// HandleMessage handles MCP JSON-RPC messages from clients.
+// POST /api/v1/mcp/message
+func (h *MCPHTTPHandler) HandleMessage(c *gin.Context) {
+	sessionID := c.Query("session")
+	if sessionID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing session parameter"})
+		return
+	}
+
+	// Get session
+	h.mu.RLock()
+	session, ok := h.sessions[sessionID]
+	h.mu.RUnlock()
+
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+		return
+	}
+
+	// Read request body
+	var rawMessage json.RawMessage
+	if err := c.BindJSON(&rawMessage); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+		return
+	}
+
+	// Create context with role for permission checking
+	ctx := mcp.ContextWithRole(c.Request.Context(), session.role)
+
+	// Handle message through MCP server
+	response := h.mcpServer.HandleMessage(ctx, rawMessage)
+
+	// Return response
+	if response != nil {
+		c.Data(http.StatusOK, "application/json", mustMarshal(response))
+	} else {
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// HandleMessageDirect handles direct JSON-RPC messages (non-SSE mode).
+// POST /api/v1/mcp
+// This is for clients that prefer stateless HTTP instead of SSE.
+func (h *MCPHTTPHandler) HandleMessageDirect(c *gin.Context) {
+	// Get user info from context (set by auth middleware)
+	role, exists := c.Get("role")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	// Read request body
+	var rawMessage json.RawMessage
+	if err := c.BindJSON(&rawMessage); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+		return
+	}
+
+	// Create context with role for permission checking
+	ctx := mcp.ContextWithRole(c.Request.Context(), role.(string))
+
+	// Handle message through MCP server
+	response := h.mcpServer.HandleMessage(ctx, rawMessage)
+
+	// Return response
+	if response != nil {
+		c.Data(http.StatusOK, "application/json", mustMarshal(response))
+	} else {
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// HandleListTools returns the list of available MCP tools.
+// GET /api/v1/mcp/tools
+func (h *MCPHTTPHandler) HandleListTools(c *gin.Context) {
+	// Send a tools/list request to get available tools
+	listRequest := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	}
+	rawMessage, _ := json.Marshal(listRequest)
+
+	ctx := mcp.ContextWithRole(c.Request.Context(), "owner")
+	response := h.mcpServer.HandleMessage(ctx, rawMessage)
+
+	if response != nil {
+		c.Data(http.StatusOK, "application/json", mustMarshal(response))
+	} else {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list tools"})
+	}
+}
+
+func mustMarshal(v interface{}) []byte {
+	data, err := json.Marshal(v)
+	if err != nil {
+		slog.Error("failed to marshal MCP response", "error", err)
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal error"}}`)
+	}
+	return data
+}

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -9,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/Yogdunana/deploypilot/internal/mcp"
 	"github.com/Yogdunana/deploypilot/internal/service"

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -84,6 +84,18 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		sseGroup.GET("/alerts", AlertSSE(bridge))
 	}
 
+	// MCP routes (requires auth) - for cloud AI IDEs (TRAE Solo, Coze, Cursor Cloud)
+	mcpHandler := NewMCPHTTPHandler(bridge)
+	mcpGroup := api.Group("/mcp")
+	mcpGroup.Use(auth.APIKeyMiddleware(keySvc))
+	mcpGroup.Use(auth.AuthMiddleware(blacklist))
+	{
+		mcpGroup.GET("/sse", mcpHandler.HandleSSE)           // SSE endpoint for streaming
+		mcpGroup.POST("/message", mcpHandler.HandleMessage)  // Message endpoint for SSE clients
+		mcpGroup.POST("", mcpHandler.HandleMessageDirect)    // Direct JSON-RPC endpoint
+		mcpGroup.GET("/tools", mcpHandler.HandleListTools)   // List available tools
+	}
+
 	// Public routes
 	authGroup := api.Group("/auth")
 	authGroup.Use(middleware.CSRF())


### PR DESCRIPTION
## Summary

Implements the HTTP MCP endpoint that was documented but missing. Cloud-based AI IDEs can now connect to DeployPilot via the network.

## Problem

The documentation in `docs/ide-skills.md` describes how to configure cloud AI IDEs (TRAE Solo, Coze, Cursor Cloud) to connect via:

```json
{
  "mcpServers": {
    "deploypilot": {
      "url": "https://your-server:8080/api/v1/mcp",
      "headers": { "Authorization": "Bearer YOUR_API_TOKEN" }
    }
  }
}
```

But this endpoint was **not implemented**. The MCP server only supported stdio mode (local process communication).

## Solution

Added HTTP MCP endpoints:

| Endpoint | Method | Purpose |
|----------|--------|---------|
| `/api/v1/mcp` | POST | Direct JSON-RPC requests (stateless) |
| `/api/v1/mcp/sse` | GET | SSE streaming connection |
| `/api/v1/mcp/message` | POST | Message endpoint for SSE clients |
| `/api/v1/mcp/tools` | GET | List available MCP tools |

## Features

- **Dual authentication**: Supports both JWT and API Key
- **Role-based permissions**: Uses existing RBAC system
- **SSE support**: For streaming responses
- **Stateless mode**: Direct JSON-RPC for simple integrations

## Usage

### TRAE Solo / Coze / Cursor Cloud

```json
{
  "mcpServers": {
    "deploypilot": {
      "url": "https://your-server:8080/api/v1/mcp",
      "headers": {
        "Authorization": "Bearer YOUR_API_TOKEN"
      }
    }
  }
}
```

### Create API Token

1. Login to DeployPilot Web UI
2. Go to Settings → API Keys
3. Create a new API key with appropriate permissions
4. Use the key as `Bearer YOUR_API_TOKEN`

## Testing

```bash
# List available tools
curl -H "Authorization: Bearer YOUR_TOKEN" \
  https://your-server:8080/api/v1/mcp/tools

# Call a tool
curl -X POST -H "Authorization: Bearer YOUR_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_servers"}}' \
  https://your-server:8080/api/v1/mcp
```

## Fixes

This PR enables the documented functionality for cloud AI IDEs.