### PR TITLE
fix: add arm64 cross-compiler for CGO builds (#724)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,24 @@ jobs:
       - name: Ensure go.sum is up to date
         run: go mod tidy
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install cross-compiler for arm64
+        if: matrix.goarch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build binaries
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 1
+          CC: ${{ matrix.goarch == 'arm64' && 'aarch64-linux-gnu-gcc' || 'gcc' }}
           VERSION: ${{ github.ref_name }}
           GIT_COMMIT: ${{ github.sha }}
           BUILD_TIME: ${{ needs.build-binaries.result != 'skipped' && steps.build.outputs.build_time || '' }}


### PR DESCRIPTION
## Summary

Fixes #724

- Add `gcc-aarch64-linux-gnu` cross-compiler for arm64 builds
- Set `CC=aarch64-linux-gnu-gcc` env var for arm64 matrix
- Add QEMU + Docker Buildx setup for arm64 emulation

## Problem

Release workflow fails for arm64 because the project uses `mattn/go-sqlite3` (CGO), and cross-compiling arm64 on ubuntu-latest (amd64) requires a C cross-compiler.

```
gcc_arm64.S:30: Error: no such instruction
```