### PR TITLE
feat: auto-sync GitHub Release assets to Gitee (#726)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,3 +150,14 @@ jobs:
           files: dist/*
           draft: false
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') }}
+
+      - name: Sync Release to Gitee
+        uses: nicennnnnnnlee/action-gitee-release@master
+        with:
+          gitee_action: upload_asset
+          gitee_owner: Yogdunana
+          gitee_repo: deploypilot
+          gitee_token: ${{ secrets.GITEE_TOKEN }}
+          gitee_tag_name: ${{ github.ref_name }}
+          gitee_files: |
+            dist/*


### PR DESCRIPTION
## Summary

Fixes #726

- Add `nicennnnnnnlee/action-gitee-release` to release workflow
- Automatically upload release binaries to Gitee after GitHub Release creation
- Enables China users to download from Gitee as primary source

## Testing

This will be tested when the next tag is pushed and the release workflow runs.