### PR TITLE
fix: use create_release for Gitee sync instead of upload_asset (#726)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,10 +154,13 @@ jobs:
       - name: Sync Release to Gitee
         uses: nicennnnnnnlee/action-gitee-release@master
         with:
-          gitee_action: upload_asset
+          gitee_action: create_release
           gitee_owner: Yogdunana
           gitee_repo: deploypilot
           gitee_token: ${{ secrets.GITEE_TOKEN }}
           gitee_tag_name: ${{ github.ref_name }}
+          gitee_release_name: ${{ github.ref_name }}
+          gitee_release_body: ${{ github.ref_name }}
+          gitee_target_commitish: main
           gitee_files: |
             dist/*


### PR DESCRIPTION
## Summary

Fixes #726

`upload_asset` requires an existing Gitee release. Use `create_release` instead which creates the release and uploads assets in one step.