### PR TITLE
fix: increase Gitee upload retry times to 5 (#726)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,5 +162,6 @@ jobs:
           gitee_release_name: ${{ github.ref_name }}
           gitee_release_body: ${{ github.ref_name }}
           gitee_target_commitish: main
+          gitee_upload_retry_times: 5
           gitee_files: |
             dist/*


### PR DESCRIPTION
Gitee API resets connection on large file uploads (50-75MB). Increase retry times from 0 to 5.