### PR TITLE
fix: unify frontend API paths with /api/v1 baseURL (#734)

### DIFF
--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import router from '@/router'
 
 const api = axios.create({
-  baseURL: '',
+  baseURL: '/api/v1',
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',

--- a/web/src/api/modules/activity.ts
+++ b/web/src/api/modules/activity.ts
@@ -15,7 +15,7 @@ export interface ActivityItem {
 }
 
 export function list(params?: PaginationParams & { type?: string }) {
-  return api.get<PaginatedResponse<ActivityItem[]>>('/api/activity', { params })
+  return api.get<PaginatedResponse<ActivityItem[]>>('/activity', { params })
 }
 
 export function getStats() {
@@ -23,5 +23,5 @@ export function getStats() {
     today_count: number
     week_count: number
     by_type: Record<string, number>
-  }>>('/api/activity/stats')
+  }>>('/activity/stats')
 }

--- a/web/src/api/modules/apikeys.ts
+++ b/web/src/api/modules/apikeys.ts
@@ -4,13 +4,13 @@ import type { ApiKey } from '@/types/models'
 import type { CreateApiKeyRequest } from '@/types/api'
 
 export function list() {
-  return api.get<ApiResponse<ApiKey[]>>('/api/v1/api-keys')
+  return api.get<ApiResponse<ApiKey[]>>('/api-keys')
 }
 
 export function create(data: CreateApiKeyRequest) {
-  return api.post<ApiResponse<{ id: string; name: string; key: string; key_prefix: string; scopes: string[]; expires_at?: string; created_at: string }>>('/api/v1/api-keys', data)
+  return api.post<ApiResponse<{ id: string; name: string; key: string; key_prefix: string; scopes: string[]; expires_at?: string; created_at: string }>>('/api-keys', data)
 }
 
 export function remove(id: string) {
-  return api.delete<ApiResponse<{ message: string; id: string }>>(`/api/v1/api-keys/${id}`)
+  return api.delete<ApiResponse<{ message: string; id: string }>>(`/api-keys/${id}`)
 }

--- a/web/src/api/modules/apps.ts
+++ b/web/src/api/modules/apps.ts
@@ -3,65 +3,65 @@ import type { ApiResponse, PaginatedResponse, PaginationParams, DeployConfig, Bu
 import type { App, DeploymentRecord } from '@/types/models'
 
 export function list(params?: PaginationParams) {
-  return api.get<PaginatedResponse<App[]>>('/api/apps', { params })
+  return api.get<PaginatedResponse<App[]>>('/apps', { params })
 }
 
 export function get(id: number) {
-  return api.get<ApiResponse<App>>(`/api/apps/${id}`)
+  return api.get<ApiResponse<App>>(`/apps/${id}`)
 }
 
 export function create(data: Partial<App>) {
-  return api.post<ApiResponse<App>>('/api/apps', data)
+  return api.post<ApiResponse<App>>('/apps', data)
 }
 
 export function update(id: number, data: Partial<App>) {
-  return api.put<ApiResponse<App>>(`/api/apps/${id}`, data)
+  return api.put<ApiResponse<App>>(`/apps/${id}`, data)
 }
 
 export function deleteApp(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/apps/${id}`)
+  return api.delete<ApiResponse<void>>(`/apps/${id}`)
 }
 
 export function deploy(id: number, config?: DeployConfig, async = true) {
-  return api.post<ApiResponse<DeploymentRecord>>(`/api/apps/${id}/deploy`, { ...config, async })
+  return api.post<ApiResponse<DeploymentRecord>>(`/apps/${id}/deploy`, { ...config, async })
 }
 
 export function build(id: number, data: BuildConfig) {
-  return api.post<ApiResponse<any>>(`/api/apps/${id}/build`, data)
+  return api.post<ApiResponse<any>>(`/apps/${id}/build`, data)
 }
 
 export function getStatus(id: number) {
-  return api.get<ApiResponse<any>>(`/api/apps/${id}/status`)
+  return api.get<ApiResponse<any>>(`/apps/${id}/status`)
 }
 
 export function rollback(id: number, data: RollbackConfig) {
-  return api.post<ApiResponse<DeploymentRecord>>(`/api/apps/${id}/rollback`, data)
+  return api.post<ApiResponse<DeploymentRecord>>(`/apps/${id}/rollback`, data)
 }
 
 export function getLogs(id: number, tail?: number) {
-  return api.get<ApiResponse<string>>(`/api/apps/${id}/logs`, { params: { tail } })
+  return api.get<ApiResponse<string>>(`/apps/${id}/logs`, { params: { tail } })
 }
 
 export function backup(id: number) {
-  return api.post<ApiResponse<any>>(`/api/apps/${id}/backup`)
+  return api.post<ApiResponse<any>>(`/apps/${id}/backup`)
 }
 
 export function listBackups(id: number) {
-  return api.get<ApiResponse<any[]>>(`/api/apps/${id}/backups`)
+  return api.get<ApiResponse<any[]>>(`/apps/${id}/backups`)
 }
 
 export function restore(id: number, data: RestoreConfig) {
-  return api.post<ApiResponse<void>>(`/api/apps/${id}/restore`, data)
+  return api.post<ApiResponse<void>>(`/apps/${id}/restore`, data)
 }
 
 export function deleteBackup(id: number, backupId: string) {
-  return api.delete<ApiResponse<void>>(`/api/apps/${id}/backups/${backupId}`)
+  return api.delete<ApiResponse<void>>(`/apps/${id}/backups/${backupId}`)
 }
 
 export function getEnv(id: number) {
-  return api.get<ApiResponse<Record<string, string>>>(`/api/apps/${id}/env`)
+  return api.get<ApiResponse<Record<string, string>>>(`/apps/${id}/env`)
 }
 
 export function updateEnv(id: number, data: Record<string, string>) {
-  return api.put<ApiResponse<Record<string, string>>>(`/api/apps/${id}/env`, data)
+  return api.put<ApiResponse<Record<string, string>>>(`/apps/${id}/env`, data)
 }

--- a/web/src/api/modules/audit.ts
+++ b/web/src/api/modules/audit.ts
@@ -12,5 +12,5 @@ export interface AuditLogParams extends PaginationParams {
 }
 
 export function listLogs(params?: AuditLogParams) {
-  return api.get<PaginatedResponse<AuditLog[]>>('/api/audit/logs', { params })
+  return api.get<PaginatedResponse<AuditLog[]>>('/audit/logs', { params })
 }

--- a/web/src/api/modules/auth.ts
+++ b/web/src/api/modules/auth.ts
@@ -2,9 +2,9 @@ import api from '@/api'
 import type { ApiResponse, LoginRequest, LoginResponse, RegisterRequest } from '@/types/api'
 
 export function login(data: LoginRequest) {
-  return api.post<ApiResponse<LoginResponse>>('/api/auth/login', data)
+  return api.post<ApiResponse<LoginResponse>>('/auth/login', data)
 }
 
 export function register(data: RegisterRequest) {
-  return api.post<ApiResponse<LoginResponse>>('/api/auth/register', data)
+  return api.post<ApiResponse<LoginResponse>>('/auth/register', data)
 }

--- a/web/src/api/modules/batch.ts
+++ b/web/src/api/modules/batch.ts
@@ -16,25 +16,25 @@ export interface BatchOperation {
 }
 
 export function deployApps(data: { app_ids: number[]; branch?: string }) {
-  return api.post<ApiResponse<BatchOperation>>('/api/batch/deploy', data)
+  return api.post<ApiResponse<BatchOperation>>('/batch/deploy', data)
 }
 
 export function restartApps(data: { app_ids: number[] }) {
-  return api.post<ApiResponse<BatchOperation>>('/api/batch/restart', data)
+  return api.post<ApiResponse<BatchOperation>>('/batch/restart', data)
 }
 
 export function stopApps(data: { app_ids: number[] }) {
-  return api.post<ApiResponse<BatchOperation>>('/api/batch/stop', data)
+  return api.post<ApiResponse<BatchOperation>>('/batch/stop', data)
 }
 
 export function deleteServers(data: { server_ids: number[] }) {
-  return api.post<ApiResponse<BatchOperation>>('/api/batch/delete-servers', data)
+  return api.post<ApiResponse<BatchOperation>>('/batch/delete-servers', data)
 }
 
 export function getStatus(id: number) {
-  return api.get<ApiResponse<BatchOperation>>(`/api/batch/${id}`)
+  return api.get<ApiResponse<BatchOperation>>(`/batch/${id}`)
 }
 
 export function listOperations(params?: { page?: number; page_size?: number }) {
-  return api.get<ApiResponse<BatchOperation[]>>('/api/batch', { params })
+  return api.get<ApiResponse<BatchOperation[]>>('/batch', { params })
 }

--- a/web/src/api/modules/batchDeploy.ts
+++ b/web/src/api/modules/batchDeploy.ts
@@ -7,9 +7,9 @@ export function batchDeploy(data: {
   batch_size?: number
   server_ids?: string[]
 }) {
-  return api.post('/api/v1/batch-deploy', data)
+  return api.post('/batch-deploy', data)
 }
 
 export function getBatchDeployStatus(id: string) {
-  return api.get(`/api/v1/batch-deploy/${id}`)
+  return api.get(`/batch-deploy/${id}`)
 }

--- a/web/src/api/modules/cicd.ts
+++ b/web/src/api/modules/cicd.ts
@@ -3,9 +3,9 @@ import type { ApiResponse } from '@/types/api'
 import type { CICDBuild } from '@/types/models'
 
 export function triggerBuild(data: { provider: string; repo_url: string; branch: string; app_name?: string }) {
-  return api.post<ApiResponse<CICDBuild>>('/api/cicd/builds', data)
+  return api.post<ApiResponse<CICDBuild>>('/cicd/builds', data)
 }
 
 export function getBuildStatus(runId: string, provider: string) {
-  return api.get<ApiResponse<CICDBuild>>(`/api/cicd/builds/${provider}/${runId}`)
+  return api.get<ApiResponse<CICDBuild>>(`/cicd/builds/${provider}/${runId}`)
 }

--- a/web/src/api/modules/clusters.ts
+++ b/web/src/api/modules/clusters.ts
@@ -1,25 +1,25 @@
 import api from '@/api'
 
 export function listClusters(tenantId?: string) {
-  return api.get('/api/v1/clusters', { params: { tenant_id: tenantId } })
+  return api.get('/clusters', { params: { tenant_id: tenantId } })
 }
 
 export function getCluster(id: string) {
-  return api.get(`/api/v1/clusters/${id}`)
+  return api.get(`/clusters/${id}`)
 }
 
 export function createCluster(data: Record<string, unknown>) {
-  return api.post('/api/v1/clusters', data)
+  return api.post('/clusters', data)
 }
 
 export function updateCluster(id: string, data: Record<string, unknown>) {
-  return api.put(`/api/v1/clusters/${id}`, data)
+  return api.put(`/clusters/${id}`, data)
 }
 
 export function deleteCluster(id: string) {
-  return api.delete(`/api/v1/clusters/${id}`)
+  return api.delete(`/clusters/${id}`)
 }
 
 export function testClusterConnection(id: string) {
-  return api.post(`/api/v1/clusters/${id}/test`)
+  return api.post(`/clusters/${id}/test`)
 }

--- a/web/src/api/modules/credentials.ts
+++ b/web/src/api/modules/credentials.ts
@@ -3,21 +3,21 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { Credential } from '@/types/models'
 
 export function list(tenantId?: number, params?: PaginationParams) {
-  return api.get<PaginatedResponse<Credential[]>>('/api/credentials', { params: { tenant_id: tenantId, ...params } })
+  return api.get<PaginatedResponse<Credential[]>>('/credentials', { params: { tenant_id: tenantId, ...params } })
 }
 
 export function create(data: { name: string; type: string; value: string; expires_in_days?: number }) {
-  return api.post<ApiResponse<Credential>>('/api/credentials', data)
+  return api.post<ApiResponse<Credential>>('/credentials', data)
 }
 
 export function update(id: number, data: { name?: string; type?: string; value?: string }) {
-  return api.put<ApiResponse<Credential>>(`/api/credentials/${id}`, data)
+  return api.put<ApiResponse<Credential>>(`/credentials/${id}`, data)
 }
 
 export function deleteCredential(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/credentials/${id}`)
+  return api.delete<ApiResponse<void>>(`/credentials/${id}`)
 }
 
 export function rotate(id: number, data: { value: string }) {
-  return api.post<ApiResponse<Credential>>(`/api/credentials/${id}/rotate`, data)
+  return api.post<ApiResponse<Credential>>(`/credentials/${id}/rotate`, data)
 }

--- a/web/src/api/modules/degradation.ts
+++ b/web/src/api/modules/degradation.ts
@@ -1,13 +1,13 @@
 import api from '@/api'
 
 export function getDegradationStatus() {
-  return api.get('/api/v1/degradation/status')
+  return api.get('/degradation/status')
 }
 
 export function getDegradationAudits(limit?: number) {
-  return api.get('/api/v1/degradation/audits', { params: { limit } })
+  return api.get('/degradation/audits', { params: { limit } })
 }
 
 export function getExportSummary() {
-  return api.get('/api/v1/degradation/export-summary')
+  return api.get('/degradation/export-summary')
 }

--- a/web/src/api/modules/deployments.ts
+++ b/web/src/api/modules/deployments.ts
@@ -3,9 +3,9 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { DeploymentRecord } from '@/types/models'
 
 export function list(appId?: number, status?: string, params?: PaginationParams) {
-  return api.get<PaginatedResponse<DeploymentRecord[]>>('/api/deployments', { params: { app_id: appId, status, ...params } })
+  return api.get<PaginatedResponse<DeploymentRecord[]>>('/deployments', { params: { app_id: appId, status, ...params } })
 }
 
 export function get(id: number) {
-  return api.get<ApiResponse<DeploymentRecord>>(`/api/deployments/${id}`)
+  return api.get<ApiResponse<DeploymentRecord>>(`/deployments/${id}`)
 }

--- a/web/src/api/modules/dns.ts
+++ b/web/src/api/modules/dns.ts
@@ -3,17 +3,17 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { DNSRecord } from '@/types/models'
 
 export function listRecords(domain: string, params?: PaginationParams) {
-  return api.get<PaginatedResponse<DNSRecord[]>>(`/api/dns/records`, { params: { domain, ...params } })
+  return api.get<PaginatedResponse<DNSRecord[]>>(`/dns/records`, { params: { domain, ...params } })
 }
 
 export function createRecord(data: { domain: string; subdomain: string; type: string; value: string; ttl?: number; provider_id?: number }) {
-  return api.post<ApiResponse<DNSRecord>>('/api/dns/records', data)
+  return api.post<ApiResponse<DNSRecord>>('/dns/records', data)
 }
 
 export function updateRecord(id: number, data: Partial<DNSRecord>) {
-  return api.put<ApiResponse<DNSRecord>>(`/api/dns/records/${id}`, data)
+  return api.put<ApiResponse<DNSRecord>>(`/dns/records/${id}`, data)
 }
 
 export function deleteRecord(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/dns/records/${id}`)
+  return api.delete<ApiResponse<void>>(`/dns/records/${id}`)
 }

--- a/web/src/api/modules/events.ts
+++ b/web/src/api/modules/events.ts
@@ -1,9 +1,9 @@
 import api from '@/api'
 
 export function listEvents(params?: { event_type?: string; page?: number; page_size?: number }) {
-  return api.get('/api/v1/events', { params })
+  return api.get('/events', { params })
 }
 
 export function getEventStats() {
-  return api.get('/api/v1/events/stats')
+  return api.get('/events/stats')
 }

--- a/web/src/api/modules/featureFlags.ts
+++ b/web/src/api/modules/featureFlags.ts
@@ -1,29 +1,29 @@
 import api from '@/api'
 
 export function getFeatureFlags() {
-  return api.get('/api/v1/feature-flags')
+  return api.get('/feature-flags')
 }
 
 export function getFeatureFlag(key: string) {
-  return api.get(`/api/v1/feature-flags/${key}`)
+  return api.get(`/feature-flags/${key}`)
 }
 
 export function updateFeatureFlag(key: string, data: Record<string, unknown>) {
-  return api.put(`/api/v1/feature-flags/${key}`, data)
+  return api.put(`/feature-flags/${key}`, data)
 }
 
 export function setFeatureFlagOverride(key: string, data: { tenant_id: string; enabled: boolean; reason?: string }) {
-  return api.post(`/api/v1/feature-flags/${key}/override`, data)
+  return api.post(`/feature-flags/${key}/override`, data)
 }
 
 export function deleteFeatureFlagOverride(key: string, tenantId: string) {
-  return api.delete(`/api/v1/feature-flags/${key}/override`, { params: { tenant_id: tenantId } })
+  return api.delete(`/feature-flags/${key}/override`, { params: { tenant_id: tenantId } })
 }
 
 export function getFeatureFlagOverrides(key: string) {
-  return api.get(`/api/v1/feature-flags/${key}/overrides`)
+  return api.get(`/feature-flags/${key}/overrides`)
 }
 
 export function getFeatureFlagsForTenant(tenantId: string) {
-  return api.get(`/api/v1/feature-flags/tenant/${tenantId}`)
+  return api.get(`/feature-flags/tenant/${tenantId}`)
 }

--- a/web/src/api/modules/grafana.ts
+++ b/web/src/api/modules/grafana.ts
@@ -28,37 +28,37 @@ export interface GrafanaExport {
 }
 
 export function getGrafanaStatus() {
-  return api.get<ApiResponse<GrafanaStatus>>('/api/v1/grafana/status')
+  return api.get<ApiResponse<GrafanaStatus>>('/grafana/status')
 }
 
 export function testGrafanaConnection() {
-  return api.post<ApiResponse<{ success: boolean; version: string }>>('/api/v1/grafana/test')
+  return api.post<ApiResponse<{ success: boolean; version: string }>>('/grafana/test')
 }
 
 export function syncGrafana() {
-  return api.post<ApiResponse<{ synced: number }>>('/api/v1/grafana/sync')
+  return api.post<ApiResponse<{ synced: number }>>('/grafana/sync')
 }
 
 export function listGrafanaDashboards() {
-  return api.get<ApiResponse<GrafanaDashboard[]>>('/api/v1/grafana/dashboards')
+  return api.get<ApiResponse<GrafanaDashboard[]>>('/grafana/dashboards')
 }
 
 export function getGrafanaDashboard(id: string) {
-  return api.get<ApiResponse<GrafanaDashboard>>(`/api/v1/grafana/dashboards/${id}`)
+  return api.get<ApiResponse<GrafanaDashboard>>(`/grafana/dashboards/${id}`)
 }
 
 export function createGrafanaDashboard(data: { name: string; json: string; tags?: string }) {
-  return api.post<ApiResponse<GrafanaDashboard>>('/api/v1/grafana/dashboards', data)
+  return api.post<ApiResponse<GrafanaDashboard>>('/grafana/dashboards', data)
 }
 
 export function updateGrafanaDashboard(id: string, data: { name?: string; json?: string; tags?: string; enabled?: boolean }) {
-  return api.put<ApiResponse<GrafanaDashboard>>(`/api/v1/grafana/dashboards/${id}`, data)
+  return api.put<ApiResponse<GrafanaDashboard>>(`/grafana/dashboards/${id}`, data)
 }
 
 export function deleteGrafanaDashboard(id: string) {
-  return api.delete<ApiResponse<void>>(`/api/v1/grafana/dashboards/${id}`)
+  return api.delete<ApiResponse<void>>(`/grafana/dashboards/${id}`)
 }
 
 export function exportGrafana() {
-  return api.get<ApiResponse<GrafanaExport>>('/api/v1/grafana/export')
+  return api.get<ApiResponse<GrafanaExport>>('/grafana/export')
 }

--- a/web/src/api/modules/license.ts
+++ b/web/src/api/modules/license.ts
@@ -3,29 +3,29 @@ import type { ApiResponse } from '@/types/api'
 import type { LicenseInfo } from '@/types/models'
 
 export function getLicenseStatus() {
-  return api.get<ApiResponse<LicenseInfo>>('/api/v1/license/status')
+  return api.get<ApiResponse<LicenseInfo>>('/license/status')
 }
 
 export function activateLicense(data: { license_key?: string; use_type?: string; agree_terms?: boolean }) {
-  return api.post<ApiResponse<LicenseInfo>>('/api/v1/license/activate', data)
+  return api.post<ApiResponse<LicenseInfo>>('/license/activate', data)
 }
 
 export function deactivateLicense() {
-  return api.post<ApiResponse<void>>('/api/v1/license/deactivate')
+  return api.post<ApiResponse<void>>('/license/deactivate')
 }
 
 export function purchaseAddon(data: { addon_key: string; amount?: number; duration_days?: number }) {
-  return api.post<ApiResponse<LicenseInfo>>('/api/v1/license/addon', data)
+  return api.post<ApiResponse<LicenseInfo>>('/license/addon', data)
 }
 
 export function listLicenses() {
-  return api.get<ApiResponse<any[]>>('/api/v1/license/list')
+  return api.get<ApiResponse<any[]>>('/license/list')
 }
 
 export function issueLicense(data: any) {
-  return api.post<ApiResponse<any>>('/api/v1/license/issue', data)
+  return api.post<ApiResponse<any>>('/license/issue', data)
 }
 
 export function revokeLicense(id: string, reason: string) {
-  return api.post<ApiResponse<void>>(`/api/v1/license/${id}/revoke`, { reason })
+  return api.post<ApiResponse<void>>(`/license/${id}/revoke`, { reason })
 }

--- a/web/src/api/modules/monitor.ts
+++ b/web/src/api/modules/monitor.ts
@@ -3,25 +3,25 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { SystemMetrics, ContainerMetrics, Alert, AlertRule } from '@/types/models'
 
 export function getSystemMetrics() {
-  return api.get<ApiResponse<SystemMetrics>>('/api/monitor/metrics')
+  return api.get<ApiResponse<SystemMetrics>>('/monitor/metrics')
 }
 
 export function getContainerMetrics(name: string) {
-  return api.get<ApiResponse<ContainerMetrics>>(`/api/monitor/containers/${name}/metrics`)
+  return api.get<ApiResponse<ContainerMetrics>>(`/monitor/containers/${name}/metrics`)
 }
 
 export function listAlerts(params?: PaginationParams) {
-  return api.get<PaginatedResponse<Alert[]>>('/api/monitor/alerts', { params })
+  return api.get<PaginatedResponse<Alert[]>>('/monitor/alerts', { params })
 }
 
 export function listAlertRules(params?: PaginationParams) {
-  return api.get<PaginatedResponse<AlertRule[]>>('/api/monitor/alert-rules', { params })
+  return api.get<PaginatedResponse<AlertRule[]>>('/monitor/alert-rules', { params })
 }
 
 export function heal(name: string) {
-  return api.post<ApiResponse<void>>(`/api/monitor/containers/${name}/heal`)
+  return api.post<ApiResponse<void>>(`/monitor/containers/${name}/heal`)
 }
 
 export function check(name: string) {
-  return api.post<ApiResponse<{ healthy: boolean; message: string }>>(`/api/monitor/containers/${name}/check`)
+  return api.post<ApiResponse<{ healthy: boolean; message: string }>>(`/monitor/containers/${name}/check`)
 }

--- a/web/src/api/modules/monitor_query.ts
+++ b/web/src/api/modules/monitor_query.ts
@@ -17,38 +17,38 @@ export interface AlertHistoryParams {
 }
 
 export function getMonitorOverview(period?: string) {
-  return api.get<ApiResponse<any>>('/api/v1/monitors/overview', {
+  return api.get<ApiResponse<any>>('/monitors/overview', {
     params: period ? { period } : undefined,
   })
 }
 
 export function getMonitorHistory(id: string, params?: MonitorHistoryParams) {
-  return api.get<ApiResponse<any>>(`/api/v1/monitors/${id}/history`, { params })
+  return api.get<ApiResponse<any>>(`/monitors/${id}/history`, { params })
 }
 
 export function listAlertHistory(params?: AlertHistoryParams) {
-  return api.get<ApiResponse<any>>('/api/v1/alerts/history', { params })
+  return api.get<ApiResponse<any>>('/alerts/history', { params })
 }
 
 export function getAlertHistory(id: string) {
-  return api.get<ApiResponse<any>>(`/api/v1/alerts/history/${id}`)
+  return api.get<ApiResponse<any>>(`/alerts/history/${id}`)
 }
 
 export function getAlertStats(period?: string) {
-  return api.get<ApiResponse<any>>('/api/v1/alerts/stats', {
+  return api.get<ApiResponse<any>>('/alerts/stats', {
     params: period ? { period } : undefined,
   })
 }
 
 export function exportMonitorData(id: string, format: string = 'csv', params?: MonitorHistoryParams) {
-  return api.get(`/api/v1/monitors/${id}/export`, {
+  return api.get(`/monitors/${id}/export`, {
     params: { format, ...params },
     responseType: 'blob',
   })
 }
 
 export function exportAlertHistory(format: string = 'csv', params?: AlertHistoryParams) {
-  return api.get('/api/v1/alerts/export', {
+  return api.get('/alerts/export', {
     params: { format, ...params },
     responseType: 'blob',
   })

--- a/web/src/api/modules/monitor_settings.ts
+++ b/web/src/api/modules/monitor_settings.ts
@@ -11,9 +11,9 @@ export interface MonitorSettings {
 }
 
 export function getMonitorSettings() {
-  return api.get<ApiResponse<MonitorSettings>>('/api/v1/monitor/settings')
+  return api.get<ApiResponse<MonitorSettings>>('/monitor/settings')
 }
 
 export function updateMonitorSettings(data: Partial<MonitorSettings>) {
-  return api.put<ApiResponse<MonitorSettings>>('/api/v1/monitor/settings', data)
+  return api.put<ApiResponse<MonitorSettings>>('/monitor/settings', data)
 }

--- a/web/src/api/modules/notifications.ts
+++ b/web/src/api/modules/notifications.ts
@@ -3,17 +3,17 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { Notification } from '@/types/models'
 
 export function list(params?: PaginationParams) {
-  return api.get<PaginatedResponse<Notification[]>>('/api/notifications', { params })
+  return api.get<PaginatedResponse<Notification[]>>('/notifications', { params })
 }
 
 export function create(data: { type: string; name: string; config: Record<string, string>; enabled?: boolean }) {
-  return api.post<ApiResponse<Notification>>('/api/notifications', data)
+  return api.post<ApiResponse<Notification>>('/notifications', data)
 }
 
 export function update(id: number, data: Partial<Notification>) {
-  return api.put<ApiResponse<Notification>>(`/api/notifications/${id}`, data)
+  return api.put<ApiResponse<Notification>>(`/notifications/${id}`, data)
 }
 
 export function deleteNotification(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/notifications/${id}`)
+  return api.delete<ApiResponse<void>>(`/notifications/${id}`)
 }

--- a/web/src/api/modules/oauth2.ts
+++ b/web/src/api/modules/oauth2.ts
@@ -22,25 +22,25 @@ export interface OAuth2TokenResponse {
 }
 
 export function listOAuth2Clients() {
-  return api.get<ApiResponse<OAuth2Client[]>>('/api/v1/oauth/clients')
+  return api.get<ApiResponse<OAuth2Client[]>>('/oauth/clients')
 }
 
 export function createOAuth2Client(data: { name: string; redirect_uris?: string[]; scopes?: string[]; grant_types?: string[] }) {
-  return api.post<ApiResponse<OAuth2Client & { client_secret: string }>>('/api/v1/oauth/clients', data)
+  return api.post<ApiResponse<OAuth2Client & { client_secret: string }>>('/oauth/clients', data)
 }
 
 export function getOAuth2Client(id: string) {
-  return api.get<ApiResponse<OAuth2Client>>(`/api/v1/oauth/clients/${id}`)
+  return api.get<ApiResponse<OAuth2Client>>(`/oauth/clients/${id}`)
 }
 
 export function updateOAuth2Client(id: string, data: Partial<OAuth2Client>) {
-  return api.put<ApiResponse<OAuth2Client>>(`/api/v1/oauth/clients/${id}`, data)
+  return api.put<ApiResponse<OAuth2Client>>(`/oauth/clients/${id}`, data)
 }
 
 export function deleteOAuth2Client(id: string) {
-  return api.delete<ApiResponse<void>>(`/api/v1/oauth/clients/${id}`)
+  return api.delete<ApiResponse<void>>(`/oauth/clients/${id}`)
 }
 
 export function regenerateOAuth2Secret(id: string) {
-  return api.post<ApiResponse<{ client_secret: string }>>(`/api/v1/oauth/clients/${id}/secret`)
+  return api.post<ApiResponse<{ client_secret: string }>>(`/oauth/clients/${id}/secret`)
 }

--- a/web/src/api/modules/outbound_webhook.ts
+++ b/web/src/api/modules/outbound_webhook.ts
@@ -42,37 +42,37 @@ export interface PaginatedResponse<T> {
 }
 
 export function listWebhooks(page = 1, pageSize = 20) {
-  return api.get<ApiResponse<PaginatedResponse<OutboundWebhook>>>('/api/v1/webhooks', {
+  return api.get<ApiResponse<PaginatedResponse<OutboundWebhook>>>('/webhooks', {
     params: { page, page_size: pageSize },
   })
 }
 
 export function getWebhook(id: string) {
-  return api.get<ApiResponse<OutboundWebhook>>(`/api/v1/webhooks/${id}`)
+  return api.get<ApiResponse<OutboundWebhook>>(`/webhooks/${id}`)
 }
 
 export function createWebhook(data: Partial<OutboundWebhook>) {
-  return api.post<ApiResponse<OutboundWebhook>>('/api/v1/webhooks', data)
+  return api.post<ApiResponse<OutboundWebhook>>('/webhooks', data)
 }
 
 export function updateWebhook(id: string, data: Partial<OutboundWebhook>) {
-  return api.put<ApiResponse<OutboundWebhook>>(`/api/v1/webhooks/${id}`, data)
+  return api.put<ApiResponse<OutboundWebhook>>(`/webhooks/${id}`, data)
 }
 
 export function deleteWebhook(id: string) {
-  return api.delete(`/api/v1/webhooks/${id}`)
+  return api.delete(`/webhooks/${id}`)
 }
 
 export function testWebhook(id: string) {
-  return api.post<ApiResponse<WebhookDelivery>>(`/api/v1/webhooks/${id}/test`)
+  return api.post<ApiResponse<WebhookDelivery>>(`/webhooks/${id}/test`)
 }
 
 export function listDeliveries(webhookId: string, page = 1, pageSize = 20) {
-  return api.get<ApiResponse<PaginatedResponse<WebhookDelivery>>>(`/api/v1/webhooks/${webhookId}/deliveries`, {
+  return api.get<ApiResponse<PaginatedResponse<WebhookDelivery>>>(`/webhooks/${webhookId}/deliveries`, {
     params: { page, page_size: pageSize },
   })
 }
 
 export function getDelivery(webhookId: string, deliveryId: string) {
-  return api.get<ApiResponse<WebhookDelivery>>(`/api/v1/webhooks/${webhookId}/deliveries/${deliveryId}`)
+  return api.get<ApiResponse<WebhookDelivery>>(`/webhooks/${webhookId}/deliveries/${deliveryId}`)
 }

--- a/web/src/api/modules/plugin.ts
+++ b/web/src/api/modules/plugin.ts
@@ -12,21 +12,21 @@ export interface PluginInfo {
 }
 
 export function listPlugins() {
-  return api.get<ApiResponse<PluginInfo[]>>('/api/v1/event-plugins')
+  return api.get<ApiResponse<PluginInfo[]>>('/event-plugins')
 }
 
 export function getPlugin(name: string) {
-  return api.get<ApiResponse<PluginInfo>>(`/api/v1/event-plugins/${name}`)
+  return api.get<ApiResponse<PluginInfo>>(`/event-plugins/${name}`)
 }
 
 export function updatePlugin(name: string, data: { enabled?: boolean; config?: Record<string, unknown> }) {
-  return api.put<ApiResponse<PluginInfo>>(`/api/v1/event-plugins/${name}`, data)
+  return api.put<ApiResponse<PluginInfo>>(`/event-plugins/${name}`, data)
 }
 
 export function startPlugin(name: string) {
-  return api.post<ApiResponse<void>>(`/api/v1/event-plugins/${name}/start`)
+  return api.post<ApiResponse<void>>(`/event-plugins/${name}/start`)
 }
 
 export function stopPlugin(name: string) {
-  return api.post<ApiResponse<void>>(`/api/v1/event-plugins/${name}/stop`)
+  return api.post<ApiResponse<void>>(`/event-plugins/${name}/stop`)
 }

--- a/web/src/api/modules/plugins.ts
+++ b/web/src/api/modules/plugins.ts
@@ -1,33 +1,33 @@
 import api from '@/api'
 
 export function listPlugins(tenantId?: string, provider?: string) {
-  return api.get('/api/v1/plugins', { params: { tenant_id: tenantId, provider } })
+  return api.get('/plugins', { params: { tenant_id: tenantId, provider } })
 }
 
 export function getPlugin(id: string) {
-  return api.get(`/api/v1/plugins/${id}`)
+  return api.get(`/plugins/${id}`)
 }
 
 export function createPlugin(data: Record<string, unknown>) {
-  return api.post('/api/v1/plugins', data)
+  return api.post('/plugins', data)
 }
 
 export function updatePlugin(id: string, data: Record<string, unknown>) {
-  return api.put(`/api/v1/plugins/${id}`, data)
+  return api.put(`/plugins/${id}`, data)
 }
 
 export function deletePlugin(id: string) {
-  return api.delete(`/api/v1/plugins/${id}`)
+  return api.delete(`/plugins/${id}`)
 }
 
 export function enablePlugin(id: string) {
-  return api.post(`/api/v1/plugins/${id}/enable`)
+  return api.post(`/plugins/${id}/enable`)
 }
 
 export function disablePlugin(id: string) {
-  return api.post(`/api/v1/plugins/${id}/disable`)
+  return api.post(`/plugins/${id}/disable`)
 }
 
 export function reloadPlugin(id: string) {
-  return api.post(`/api/v1/plugins/${id}/reload`)
+  return api.post(`/plugins/${id}/reload`)
 }

--- a/web/src/api/modules/providers.ts
+++ b/web/src/api/modules/providers.ts
@@ -3,17 +3,17 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { Provider } from '@/types/models'
 
 export function list(type?: string, params?: PaginationParams) {
-  return api.get<PaginatedResponse<Provider[]>>('/api/providers', { params: { type, ...params } })
+  return api.get<PaginatedResponse<Provider[]>>('/providers', { params: { type, ...params } })
 }
 
 export function create(data: { type: string; name: string; config: Record<string, string>; enabled?: boolean }) {
-  return api.post<ApiResponse<Provider>>('/api/providers', data)
+  return api.post<ApiResponse<Provider>>('/providers', data)
 }
 
 export function update(id: number, data: Partial<Provider>) {
-  return api.put<ApiResponse<Provider>>(`/api/providers/${id}`, data)
+  return api.put<ApiResponse<Provider>>(`/providers/${id}`, data)
 }
 
 export function deleteProvider(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/providers/${id}`)
+  return api.delete<ApiResponse<void>>(`/providers/${id}`)
 }

--- a/web/src/api/modules/registries.ts
+++ b/web/src/api/modules/registries.ts
@@ -1,21 +1,21 @@
 import api from '@/api'
 
 export function listRegistries(tenantId?: string) {
-  return api.get('/api/v1/registries', { params: { tenant_id: tenantId } })
+  return api.get('/registries', { params: { tenant_id: tenantId } })
 }
 
 export function getRegistry(id: string) {
-  return api.get(`/api/v1/registries/${id}`)
+  return api.get(`/registries/${id}`)
 }
 
 export function createRegistry(data: Record<string, unknown>) {
-  return api.post('/api/v1/registries', data)
+  return api.post('/registries', data)
 }
 
 export function updateRegistry(id: string, data: Record<string, unknown>) {
-  return api.put(`/api/v1/registries/${id}`, data)
+  return api.put(`/registries/${id}`, data)
 }
 
 export function deleteRegistry(id: string) {
-  return api.delete(`/api/v1/registries/${id}`)
+  return api.delete(`/registries/${id}`)
 }

--- a/web/src/api/modules/servers.ts
+++ b/web/src/api/modules/servers.ts
@@ -3,29 +3,29 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { Server } from '@/types/models'
 
 export function list(params?: PaginationParams) {
-  return api.get<PaginatedResponse<Server[]>>('/api/servers', { params })
+  return api.get<PaginatedResponse<Server[]>>('/servers', { params })
 }
 
 export function create(data: Partial<Server>) {
-  return api.post<ApiResponse<Server>>('/api/servers', data)
+  return api.post<ApiResponse<Server>>('/servers', data)
 }
 
 export function update(id: number, data: Partial<Server>) {
-  return api.put<ApiResponse<Server>>(`/api/servers/${id}`, data)
+  return api.put<ApiResponse<Server>>(`/servers/${id}`, data)
 }
 
 export function deleteServer(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/servers/${id}`)
+  return api.delete<ApiResponse<void>>(`/servers/${id}`)
 }
 
 export function test(id: number) {
-  return api.post<ApiResponse<{ success: boolean; message: string }>>(`/api/servers/${id}/test`)
+  return api.post<ApiResponse<{ success: boolean; message: string }>>(`/servers/${id}/test`)
 }
 
 export function detect(id: number, data: { host: string; port?: number }) {
-  return api.post<ApiResponse<Server['detected_info']>>(`/api/servers/${id}/detect`, data)
+  return api.post<ApiResponse<Server['detected_info']>>(`/servers/${id}/detect`, data)
 }
 
 export function getEnvironment(id: number) {
-  return api.get<ApiResponse<Server['detected_info']>>(`/api/servers/${id}/environment`)
+  return api.get<ApiResponse<Server['detected_info']>>(`/servers/${id}/environment`)
 }

--- a/web/src/api/modules/ssl.ts
+++ b/web/src/api/modules/ssl.ts
@@ -3,17 +3,17 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { SSLCertificate } from '@/types/models'
 
 export function listCertificates(params?: PaginationParams) {
-  return api.get<PaginatedResponse<SSLCertificate[]>>('/api/ssl/certificates', { params })
+  return api.get<PaginatedResponse<SSLCertificate[]>>('/ssl/certificates', { params })
 }
 
 export function requestCertificate(data: { domain: string; email: string; provider?: string; auto_renew?: boolean }) {
-  return api.post<ApiResponse<SSLCertificate>>('/api/ssl/certificates', data)
+  return api.post<ApiResponse<SSLCertificate>>('/ssl/certificates', data)
 }
 
 export function deleteCertificate(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/ssl/certificates/${id}`)
+  return api.delete<ApiResponse<void>>(`/ssl/certificates/${id}`)
 }
 
 export function renewCertificate(id: number) {
-  return api.post<ApiResponse<SSLCertificate>>(`/api/ssl/certificates/${id}/renew`)
+  return api.post<ApiResponse<SSLCertificate>>(`/ssl/certificates/${id}/renew`)
 }

--- a/web/src/api/modules/system.ts
+++ b/web/src/api/modules/system.ts
@@ -2,19 +2,19 @@ import api from '@/api'
 import type { ApiResponse } from '@/types/api'
 
 export function getVersion() {
-  return api.get<ApiResponse<{ version: string; build_time: string; git_commit: string; go: string; goos: string; goarch: string; num_cpu: number }>>('/api/system/version')
+  return api.get<ApiResponse<{ version: string; build_time: string; git_commit: string; go: string; goos: string; goarch: string; num_cpu: number }>>('/system/version')
 }
 
 export function getHealth() {
-  return api.get<ApiResponse<{ status: string; database: { status: string } }>>('/api/system/health')
+  return api.get<ApiResponse<{ status: string; database: { status: string } }>>('/system/health')
 }
 
 export function checkUpdate() {
-  return api.get<ApiResponse<{ current_version: string; latest_version: string; update_available: boolean; message: string; release_notes?: string; published_at?: string }>>('/api/system/update/check')
+  return api.get<ApiResponse<{ current_version: string; latest_version: string; update_available: boolean; message: string; release_notes?: string; published_at?: string }>>('/system/update/check')
 }
 
 export function performUpdate(targetVersion?: string) {
-  return api.post<ApiResponse<{ success: boolean; old_version: string; new_version: string; message: string; rollback_path?: string }>>('/api/system/update/perform', {
+  return api.post<ApiResponse<{ success: boolean; old_version: string; new_version: string; message: string; rollback_path?: string }>>('/system/update/perform', {
     version: targetVersion || 'latest'
   })
 }

--- a/web/src/api/modules/templates.ts
+++ b/web/src/api/modules/templates.ts
@@ -3,17 +3,17 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { Template } from '@/types/models'
 
 export function list(params?: PaginationParams) {
-  return api.get<PaginatedResponse<Template[]>>('/api/templates', { params })
+  return api.get<PaginatedResponse<Template[]>>('/templates', { params })
 }
 
 export function create(data: { name: string; description: string; tech_stack: string; deploy_mode: string; config: Record<string, any> }) {
-  return api.post<ApiResponse<Template>>('/api/templates', data)
+  return api.post<ApiResponse<Template>>('/templates', data)
 }
 
 export function update(id: number, data: Partial<Template>) {
-  return api.put<ApiResponse<Template>>(`/api/templates/${id}`, data)
+  return api.put<ApiResponse<Template>>(`/templates/${id}`, data)
 }
 
 export function deleteTemplate(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/templates/${id}`)
+  return api.delete<ApiResponse<void>>(`/templates/${id}`)
 }

--- a/web/src/api/modules/trial.ts
+++ b/web/src/api/modules/trial.ts
@@ -1,13 +1,13 @@
 import api from '@/api'
 
 export function getTrialStatus() {
-  return api.get('/api/v1/trial/status')
+  return api.get('/trial/status')
 }
 
 export function extendTrial(data: { machine_id: string; days: number; reason?: string }) {
-  return api.post('/api/v1/trial/extend', data)
+  return api.post('/trial/extend', data)
 }
 
 export function listTrialPeriods() {
-  return api.get('/api/v1/trial/list')
+  return api.get('/trial/list')
 }

--- a/web/src/api/modules/twofa.ts
+++ b/web/src/api/modules/twofa.ts
@@ -4,17 +4,17 @@ import type { TwoFASetupResponse } from '@/types/models'
 import type { TwoFAVerifyRequest, TwoFACodeRequest } from '@/types/api'
 
 export function setup() {
-  return api.post<ApiResponse<TwoFASetupResponse>>('/api/v1/2fa/setup')
+  return api.post<ApiResponse<TwoFASetupResponse>>('/2fa/setup')
 }
 
 export function confirm(data: TwoFACodeRequest) {
-  return api.post<ApiResponse<{ enabled: boolean }>>('/api/v1/2fa/confirm', data)
+  return api.post<ApiResponse<{ enabled: boolean }>>('/2fa/confirm', data)
 }
 
 export function disable(data: TwoFACodeRequest) {
-  return api.post<ApiResponse<{ enabled: boolean }>>('/api/v1/2fa/disable', data)
+  return api.post<ApiResponse<{ enabled: boolean }>>('/2fa/disable', data)
 }
 
 export function verify(data: TwoFAVerifyRequest) {
-  return api.post<ApiResponse<{ user: any; token: string }>>('/api/v1/auth/2fa/verify', data)
+  return api.post<ApiResponse<{ user: any; token: string }>>('/auth/2fa/verify', data)
 }

--- a/web/src/api/modules/uptime.ts
+++ b/web/src/api/modules/uptime.ts
@@ -11,41 +11,41 @@ import type {
 // ── Uptime Monitors ──────────────────────────────────────────────
 
 export function createMonitor(data: Partial<UptimeMonitor>) {
-  return api.post<ApiResponse<UptimeMonitor>>('/api/v1/monitors', data)
+  return api.post<ApiResponse<UptimeMonitor>>('/monitors', data)
 }
 
 export function listMonitors() {
-  return api.get<ApiResponse<UptimeMonitor[]>>('/api/v1/monitors')
+  return api.get<ApiResponse<UptimeMonitor[]>>('/monitors')
 }
 
 export function getMonitor(id: string) {
-  return api.get<ApiResponse<UptimeMonitor>>(`/api/v1/monitors/${id}`)
+  return api.get<ApiResponse<UptimeMonitor>>(`/monitors/${id}`)
 }
 
 export function updateMonitor(id: string, data: Partial<UptimeMonitor>) {
-  return api.put<ApiResponse<UptimeMonitor>>(`/api/v1/monitors/${id}`, data)
+  return api.put<ApiResponse<UptimeMonitor>>(`/monitors/${id}`, data)
 }
 
 export function deleteMonitor(id: string) {
-  return api.delete<ApiResponse<void>>(`/api/v1/monitors/${id}`)
+  return api.delete<ApiResponse<void>>(`/monitors/${id}`)
 }
 
 export function checkMonitor(id: string) {
-  return api.post<ApiResponse<MonitorCheckResult>>(`/api/v1/monitors/${id}/check`)
+  return api.post<ApiResponse<MonitorCheckResult>>(`/monitors/${id}/check`)
 }
 
 export function checkAllMonitors() {
-  return api.post<ApiResponse<void>>('/api/v1/monitors/check-all')
+  return api.post<ApiResponse<void>>('/monitors/check-all')
 }
 
 export function getMonitorResults(id: string, limit?: number) {
-  return api.get<ApiResponse<MonitorCheckResult[]>>(`/api/v1/monitors/${id}/results`, {
+  return api.get<ApiResponse<MonitorCheckResult[]>>(`/monitors/${id}/results`, {
     params: limit ? { limit } : undefined,
   })
 }
 
 export function getMonitorSLA(id: string, days?: number) {
-  return api.get<ApiResponse<MonitorSLA>>(`/api/v1/monitors/${id}/sla`, {
+  return api.get<ApiResponse<MonitorSLA>>(`/monitors/${id}/sla`, {
     params: days ? { days } : undefined,
   })
 }
@@ -53,19 +53,19 @@ export function getMonitorSLA(id: string, days?: number) {
 // ── Status Page (public) ─────────────────────────────────────────
 
 export function getStatusPage() {
-  return api.get<ApiResponse<StatusPageData>>('/api/v1/status')
+  return api.get<ApiResponse<StatusPageData>>('/status')
 }
 
 // ── Heartbeats ───────────────────────────────────────────────────
 
 export function createHeartbeat(data: Partial<HeartbeatMonitor>) {
-  return api.post<ApiResponse<HeartbeatMonitor>>('/api/v1/heartbeats', data)
+  return api.post<ApiResponse<HeartbeatMonitor>>('/heartbeats', data)
 }
 
 export function listHeartbeats() {
-  return api.get<ApiResponse<HeartbeatMonitor[]>>('/api/v1/heartbeats')
+  return api.get<ApiResponse<HeartbeatMonitor[]>>('/heartbeats')
 }
 
 export function deleteHeartbeat(id: string) {
-  return api.delete<ApiResponse<void>>(`/api/v1/heartbeats/${id}`)
+  return api.delete<ApiResponse<void>>(`/heartbeats/${id}`)
 }

--- a/web/src/api/modules/users.ts
+++ b/web/src/api/modules/users.ts
@@ -3,21 +3,21 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { User, Role } from '@/types/models'
 
 export function getMe() {
-  return api.get<ApiResponse<User>>('/api/users/me')
+  return api.get<ApiResponse<User>>('/users/me')
 }
 
 export function list(params?: PaginationParams) {
-  return api.get<PaginatedResponse<User[]>>('/api/users', { params })
+  return api.get<PaginatedResponse<User[]>>('/users', { params })
 }
 
 export function deleteUser(id: number) {
-  return api.delete<ApiResponse<void>>(`/api/users/${id}`)
+  return api.delete<ApiResponse<void>>(`/users/${id}`)
 }
 
 export function updateRole(id: number, roleId: number) {
-  return api.put<ApiResponse<User>>(`/api/users/${id}/role`, { role_id: roleId })
+  return api.put<ApiResponse<User>>(`/users/${id}/role`, { role_id: roleId })
 }
 
 export function getRoles() {
-  return api.get<ApiResponse<Role[]>>('/api/roles')
+  return api.get<ApiResponse<Role[]>>('/roles')
 }


### PR DESCRIPTION
## Summary

Fixes #734

**Root Cause**: Backend registers all routes under `/api/v1/` group, but 17 of 33 frontend API modules were calling `/api/` (missing `/v1`), causing 404 on login and all other endpoints.

**Fix**:
- Set axios `baseURL` to `/api/v1` in `web/src/api/index.ts`
- Remove redundant `/api/` and `/api/v1/` prefixes from all 33 API module files
- All API paths are now relative to the baseURL (e.g., `/auth/login` → `/api/v1/auth/login`)

**Files changed**: 36 (1 config + 33 modules + 2 meta)