### PR TITLE
fix: resolve api-server startup failure, Redis log noise, enhance status (#740)

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -191,7 +191,9 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string, migrateOnly, migrate
 		})
 		if err := rdb.Ping(context.Background()).Err(); err != nil {
 			slog.Warn("Redis unavailable, falling back to in-memory implementations", "error", err)
-			rdb.Close() // close to prevent background reconnection noise
+			if closeErr := rdb.Close(); closeErr != nil {
+				slog.Debug("failed to close Redis client", "error", closeErr)
+			}
 			rdb = nil
 			eventBus = service.NewInMemoryEventBus()
 			typedBus = service.NewInMemoryTypedEventBus()

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -191,6 +191,8 @@ func run(configFilePath, cliDriver, cliDSN, cliAddr string, migrateOnly, migrate
 		})
 		if err := rdb.Ping(context.Background()).Err(); err != nil {
 			slog.Warn("Redis unavailable, falling back to in-memory implementations", "error", err)
+			rdb.Close() // close to prevent background reconnection noise
+			rdb = nil
 			eventBus = service.NewInMemoryEventBus()
 			typedBus = service.NewInMemoryTypedEventBus()
 			tokenBlacklist = auth.NewMemoryTokenBlacklist()

--- a/cmd/deploypilot/service.go
+++ b/cmd/deploypilot/service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -79,13 +80,22 @@ func checkAPIHealth() {
 
 	// Check health endpoint
 	client := &http.Client{Timeout: healthCheckTimeout}
-	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, defaultHealthPath)
-	resp, err := client.Get(url)
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d%s", port, defaultHealthPath)
+	ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 	if err != nil {
 		fmt.Printf("    API: unreachable (%v)\n", err)
 		return
 	}
-	defer resp.Body.Close()
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("    API: unreachable (%v)\n", err)
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode == http.StatusOK {
 		var result map[string]interface{}
@@ -127,7 +137,9 @@ func isPortListening(port int) bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	if cerr := conn.Close(); cerr != nil {
+		return false
+	}
 	return true
 }
 

--- a/cmd/deploypilot/service.go
+++ b/cmd/deploypilot/service.go
@@ -1,23 +1,30 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 const (
-	defaultInstallDir = "/opt/deploypilot"
-	apiServiceName    = "deploypilot"
-	mcpServiceName    = "deploypilot-mcp"
+	defaultInstallDir  = "/opt/deploypilot"
+	apiServiceName     = "deploypilot"
+	mcpServiceName     = "deploypilot-mcp"
+	defaultAPIPort     = 8080
+	defaultHealthPath  = "/api/v1/system/health"
+	healthCheckTimeout = 3 * time.Second
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status [service]",
 	Short: "Check DeployPilot service status",
-	Long:  "Check the status of DeployPilot services (api-server and mcp-server).",
+	Long:  "Check the status of DeployPilot services (api-server and mcp-server), including health checks.",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		services := []string{apiServiceName, mcpServiceName}
@@ -34,19 +41,94 @@ var statusCmd = &cobra.Command{
 				continue
 			}
 			if running {
-				fmt.Printf("  %s: running ✓\n", svc)
+				fmt.Printf("  %s: running\n", svc)
 			} else {
-				fmt.Printf("  %s: stopped ✗\n", svc)
+				fmt.Printf("  %s: stopped\n", svc)
 				allRunning = false
 			}
 		}
 
-		if !allRunning {
-			return nil
+		// Run health check if api-server is running
+		if allRunning || len(services) == 1 && services[0] == apiServiceName {
+			running, _ := isServiceRunning(apiServiceName)
+			if running {
+				fmt.Println()
+				checkAPIHealth()
+			}
 		}
-		fmt.Println("\nAll services are running.")
+
+		if allRunning {
+			fmt.Println("\nAll services are running.")
+		}
 		return nil
 	},
+}
+
+// checkAPIHealth checks the API server health endpoint and port listening.
+func checkAPIHealth() {
+	fmt.Println("  Health Check:")
+
+	// Check if port is listening
+	port := getAPIPort()
+	listening := isPortListening(port)
+	if listening {
+		fmt.Printf("    Port %d: listening\n", port)
+	} else {
+		fmt.Printf("    Port %d: not listening\n", port)
+	}
+
+	// Check health endpoint
+	client := &http.Client{Timeout: healthCheckTimeout}
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", port, defaultHealthPath)
+	resp, err := client.Get(url)
+	if err != nil {
+		fmt.Printf("    API: unreachable (%v)\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		var result map[string]interface{}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err == nil {
+			if status, ok := result["status"].(string); ok {
+				fmt.Printf("    API: healthy (status: %s)\n", status)
+			} else {
+				fmt.Printf("    API: healthy\n")
+			}
+			if db, ok := result["database"].(map[string]interface{}); ok {
+				if dbStatus, ok := db["status"].(string); ok {
+					fmt.Printf("    Database: %s\n", dbStatus)
+				}
+			}
+		} else {
+			fmt.Printf("    API: healthy (HTTP %d)\n", resp.StatusCode)
+		}
+	} else {
+		fmt.Printf("    API: unhealthy (HTTP %d)\n", resp.StatusCode)
+	}
+}
+
+// getAPIPort reads the configured port from config.yaml.
+func getAPIPort() int {
+	// Try to read port from config file
+	configPath := defaultInstallDir + "/config/config.yaml"
+	if data, err := exec.Command("grep", "-oP", `port:\s*\K\d+`, configPath).Output(); err == nil && len(data) > 0 {
+		var port int
+		if _, err := fmt.Sscanf(string(data), "%d", &port); err == nil && port > 0 {
+			return port
+		}
+	}
+	return defaultAPIPort
+}
+
+// isPortListening checks if a TCP port is accepting connections.
+func isPortListening(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 1*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }
 
 var startCmd = &cobra.Command{
@@ -65,7 +147,7 @@ var startCmd = &cobra.Command{
 			if err := systemctl("start", svc); err != nil {
 				return fmt.Errorf("failed to start %s: %w", svc, err)
 			}
-			fmt.Printf("  %s started ✓\n", svc)
+			fmt.Printf("  %s started\n", svc)
 		}
 		return nil
 	},
@@ -87,7 +169,7 @@ var stopCmd = &cobra.Command{
 			if err := systemctl("stop", svc); err != nil {
 				return fmt.Errorf("failed to stop %s: %w", svc, err)
 			}
-			fmt.Printf("  %s stopped ✓\n", svc)
+			fmt.Printf("  %s stopped\n", svc)
 		}
 		return nil
 	},
@@ -109,7 +191,7 @@ var restartCmd = &cobra.Command{
 			if err := systemctl("restart", svc); err != nil {
 				return fmt.Errorf("failed to restart %s: %w", svc, err)
 			}
-			fmt.Printf("  %s restarted ✓\n", svc)
+			fmt.Printf("  %s restarted\n", svc)
 		}
 		return nil
 	},
@@ -124,7 +206,7 @@ var reloadCmd = &cobra.Command{
 		if err := systemctl("reload", apiServiceName); err != nil {
 			return fmt.Errorf("failed to reload: %w", err)
 		}
-		fmt.Println("Configuration reloaded ✓")
+		fmt.Println("Configuration reloaded")
 		return nil
 	},
 }

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-gormigrate/gormigrate/v2"
@@ -15,12 +17,41 @@ import (
 	"gorm.io/gorm"
 )
 
+// migrationsPath resolves the absolute path to the migrations/ directory.
+// It checks multiple locations in order:
+//  1. CWD/migrations (for development)
+//  2. Executable directory/migrations (for installed binaries)
+//  3. /opt/deploypilot/migrations (default install path)
+func migrationsPath() string {
+	candidates := []string{
+		filepath.Join("migrations"),                              // CWD
+		filepath.Join(filepath.Dir(os.Args[0]), "migrations"),  // next to binary
+		filepath.Join("/opt/deploypilot", "migrations"),         // default install
+	}
+	for _, p := range candidates {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			continue
+		}
+		if info, err := os.Stat(abs); err == nil && info.IsDir() {
+			return abs
+		}
+	}
+	// Fallback: return CWD-relative path (will produce a clear error if missing)
+	return filepath.Join("migrations")
+}
+
+// migrationsURL returns the file:// URL for the migrations directory.
+func migrationsURL() string {
+	return "file://" + migrationsPath()
+}
+
 // RunMigrations runs golang-migrate SQL migrations from the migrations/ directory.
 // This is the primary migration system for new installations.
 func RunMigrations(dsn, driver string) error {
 	dsnURL := buildMigrateURL(dsn, driver)
 
-	m, err := migrate.New("file://migrations", dsnURL)
+	m, err := migrate.New(migrationsURL(), dsnURL)
 	if err != nil {
 		return fmt.Errorf("failed to create migrate instance: %w", err)
 	}
@@ -76,7 +107,7 @@ func RunMigrationsDown(dsn, driver string) error {
 func MigrationStatus(dsn, driver string) (uint, bool, error) {
 	dsnURL := buildMigrateURL(dsn, driver)
 
-	m, err := migrate.New("file://migrations", dsnURL)
+	m, err := migrate.New(migrationsURL(), dsnURL)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to create migrate instance: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #740

### 1. Fix api-server startup failure (critical)
`file://migrations` relative path fails when systemd CWD != project root. Added `migrationsPath()` that searches CWD, binary directory, and `/opt/deploypilot/` for the migrations folder.

### 2. Fix Redis reconnection log noise
When Redis Ping fails and code falls back to in-memory, the Redis client was kept alive causing continuous reconnection attempts. Now calls `rdb.Close()` and sets `rdb = nil`.

### 3. Enhance `deploypilot status` command
Added health check section when api-server is running:
- Port listening check (reads configured port from config.yaml)
- API health endpoint check (`/api/v1/system/health`)
- Database status from health response