### PR TITLE
fix: admin creation fails with invalid email and i18n placeholder

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -93,7 +93,7 @@
   "error.backup.not_found": "backup not found",
   "error.backup.delete_failed": "failed to delete backup",
 
-  "error.common.invalid_request": "invalid request: %s",
+  "error.common.invalid_request": "invalid request",
   "error.common.internal_error": "internal server error",
   "error.system.health_check_failed": "health check failed",
 

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -93,7 +93,7 @@
   "error.backup.not_found": "备份未找到",
   "error.backup.delete_failed": "删除备份失败",
 
-  "error.common.invalid_request": "无效请求: %s",
+  "error.common.invalid_request": "无效请求",
   "error.common.internal_error": "服务器内部错误",
   "error.system.health_check_failed": "健康检查失败",
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -742,7 +742,7 @@ EOF
         print_info "正在创建管理员账号..."
         REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
             -H "Content-Type: application/json" \
-            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@localhost\", \"password\": \"${PASSWORD}\"}" 2>&1)
+            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
         if echo "$REGISTER_RESP" | grep -q '"id"'; then
             print_success "管理员账号创建成功"
         elif echo "$REGISTER_RESP" | grep -q '"registration is disabled"'; then


### PR DESCRIPTION
## Summary

- Change default email from `admin@localhost` to `admin@example.com` (localhost fails Go email validation, causing admin creation to fail during install)
- Remove `%s` placeholder from `error.common.invalid_request` i18n template (most callers don't pass args, causing literal `%s` in error messages)