### PR TITLE
fix: frontend i18n, monitor API, CLI symlink, server auto-registration

### DIFF
--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -93,7 +93,7 @@
   "error.backup.not_found": "backup not found",
   "error.backup.delete_failed": "failed to delete backup",
 
-  "error.common.invalid_request": "invalid request: %s",
+  "error.common.invalid_request": "invalid request",
   "error.common.internal_error": "internal server error",
   "error.system.health_check_failed": "health check failed",
 

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -93,7 +93,7 @@
   "error.backup.not_found": "备份未找到",
   "error.backup.delete_failed": "删除备份失败",
 
-  "error.common.invalid_request": "无效请求: %s",
+  "error.common.invalid_request": "无效请求",
   "error.common.internal_error": "服务器内部错误",
   "error.system.health_check_failed": "健康检查失败",
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -677,6 +677,8 @@ EOF
     chown -R deploypilot:deploypilot "$INSTALL_DIR"
 
     print_step "10/10" "配置系统服务"
+    # Create CLI symlink
+    ln -sf ${INSTALL_DIR}/bin/deploypilot /usr/local/bin/deploypilot
     if [ "$HAS_SYSTEMD" = "true" ]; then
         print_info "正在创建 systemd 服务..."
 
@@ -763,6 +765,30 @@ EOF
     # Users should configure their AI IDE to run the MCP server directly
     print_info "MCP Server 配置: 请在 AI IDE 中配置 MCP server 路径"
 
+    # Register this server as a DeployPilot node
+    if systemctl is-active --quiet deploypilot; then
+        print_info "正在注册当前服务器..."
+        # Login to get JWT token
+        LOGIN_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/login" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${USERNAME}\", \"password\": \"${PASSWORD}\"}" 2>&1)
+        TOKEN=$(echo "$LOGIN_RESP" | grep -o '"token":"[^"]*"' | head -1 | cut -d'"' -f4)
+        if [ -n "$TOKEN" ]; then
+            SERVER_NAME=$(hostname -s 2>/dev/null || echo "deploy-server")
+            SERVER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/servers" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -d "{\"name\": \"${SERVER_NAME}\", \"host\": \"127.0.0.1\", \"port\": 22, \"user\": \"root\"}" 2>&1)
+            if echo "$SERVER_RESP" | grep -q '"id"'; then
+                print_success "当前服务器已注册为 DeployPilot 节点 (${SERVER_NAME})"
+            else
+                print_warning "服务器注册失败（可能已注册）"
+            fi
+        else
+            print_warning "无法登录以注册服务器（请使用已有账号登录面板添加）"
+        fi
+    fi
+
     echo ""
     echo -e "${GREEN}${BOLD}  🎉 安装成功完成！${RESET}"
     echo ""
@@ -773,23 +799,14 @@ EOF
     echo -e "  ${CYAN}版本:${RESET}      ${VERSION:-source}"
     echo ""
     echo -e "${BOLD}${WHITE}  MCP 配置 (AI IDE 集成):${RESET}"
-    echo -e "  ${CYAN}MCP Server 已作为 systemd 服务运行${RESET}"
-    echo ""
-    echo '  {'
-    echo '    "mcpServers": {'
-    echo '      "deploypilot": {'
-    echo "        \"command\": \"${INSTALL_DIR}/bin/mcp-server\","
-    echo "        \"args\": [\"--config\", \"${INSTALL_DIR}/config/config.yaml\"]"
-    echo '      }'
-    echo '    }'
-    echo '  }'
+    echo -e "  ${CYAN}MCP Server 通过 SSE 传输运行${RESET}"
+    echo -e "  ${CYAN}SSE 地址:${RESET}  http://${IP_ADDRESS}:${PORT}/api/v1/mcp/sse"
     echo ""
     echo -e "${BOLD}${WHITE}  管理命令:${RESET}"
-    echo -e "  ${CYAN}启动 API:${RESET}    systemctl start deploypilot"
-    echo -e "  ${CYAN}启动 MCP:${RESET}    systemctl start deploypilot-mcp"
-    echo -e "  ${CYAN}停止服务:${RESET}    systemctl stop deploypilot deploypilot-mcp"
-    echo -e "  ${CYAN}重启服务:${RESET}    systemctl restart deploypilot deploypilot-mcp"
-    echo -e "  ${CYAN}查看状态:${RESET}    systemctl status deploypilot"
+    echo -e "  ${CYAN}启动服务:${RESET}    systemctl start deploypilot"
+    echo -e "  ${CYAN}停止服务:${RESET}    systemctl stop deploypilot"
+    echo -e "  ${CYAN}重启服务:${RESET}    systemctl restart deploypilot"
+    echo -e "  ${CYAN}查看状态:${RESET}    deploypilot status"
     echo -e "  ${CYAN}查看日志:${RESET}    tail -f ${INSTALL_DIR}/logs/deploypilot.log"
     echo ""
     echo -e "${YELLOW}${BOLD}  ⚠️  安全提示:${RESET}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -742,7 +742,7 @@ EOF
         print_info "正在创建管理员账号..."
         REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
             -H "Content-Type: application/json" \
-            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@localhost\", \"password\": \"${PASSWORD}\"}" 2>&1)
+            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
         if echo "$REGISTER_RESP" | grep -q '"id"'; then
             print_success "管理员账号创建成功"
         elif echo "$REGISTER_RESP" | grep -q '"registration is disabled"'; then

--- a/web/src/api/modules/monitor.ts
+++ b/web/src/api/modules/monitor.ts
@@ -3,7 +3,7 @@ import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/a
 import type { SystemMetrics, ContainerMetrics, Alert, AlertRule } from '@/types/models'
 
 export function getSystemMetrics() {
-  return api.get<ApiResponse<SystemMetrics>>('/monitor/metrics')
+  return api.get<ApiResponse<SystemMetrics>>('/monitor/system')
 }
 
 export function getContainerMetrics(name: string) {

--- a/web/src/composables/useToast.ts
+++ b/web/src/composables/useToast.ts
@@ -1,0 +1,15 @@
+import { inject } from 'vue'
+
+/**
+ * Safely get the toast function from the Toast component's provide.
+ * Returns a no-op function if toast is not available (e.g., during testing
+ * or if Toast component hasn't mounted yet).
+ */
+export function useToast() {
+  const ctx = inject<{ toast: (message: string, variant?: 'default' | 'success' | 'destructive') => void }>('toast')
+  return {
+    toast: ctx?.toast ?? ((message: string) => {
+      console.warn('[useToast] Toast not available:', message)
+    }),
+  }
+}

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -189,6 +189,7 @@ export default {
     browseTemplates: 'Browse Templates',
     browseTemplatesDesc: 'Quickly create apps from templates',
     rule: 'Rule',
+    viewAll: 'View All',
   },
 
   apps: {
@@ -1072,6 +1073,9 @@ export default {
     oauth2_apps: 'OAuth2 Apps',
     grafana_settings: 'Grafana Settings',
     grafana_dashboards: 'Grafana Dashboards',
+    monitorSettings: 'Monitor Settings',
+    monitorExport: 'Monitor Export',
+    webhooks: 'Webhooks',
   },
 
   clusters: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -187,6 +187,7 @@ export default {
     browseTemplates: '浏览模板',
     browseTemplatesDesc: '从模板快速创建应用',
     rule: '规则',
+    viewAll: '查看全部',
   },
 
   apps: {
@@ -1068,6 +1069,9 @@ export default {
     oauth2_apps: 'OAuth2 应用',
     grafana_settings: 'Grafana 设置',
     grafana_dashboards: 'Grafana 仪表盘',
+    monitorSettings: '监控设置',
+    monitorExport: '监控导出',
+    webhooks: 'Webhooks',
   },
 
   clusters: {

--- a/web/src/views/ActivityFeed.vue
+++ b/web/src/views/ActivityFeed.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { Activity, Filter } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -9,7 +10,7 @@ import Button from '@/components/ui/Button.vue'
 import { listEvents, getEventStats } from '@/api/modules/events'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface EventItem {
   id: string

--- a/web/src/views/ApiKeys.vue
+++ b/web/src/views/ApiKeys.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, MoreHorizontal, Trash2, Copy, Key } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -16,7 +17,7 @@ import * as apikeysApi from '@/api/modules/apikeys'
 import type { ApiKey } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/AppBackups.vue
+++ b/web/src/views/AppBackups.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, Plus, RotateCcw, Trash2, Loader2 } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -14,7 +15,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const appName = ref('')
 const loading = ref(true)

--- a/web/src/views/AppEnv.vue
+++ b/web/src/views/AppEnv.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, Plus, Trash2, Eye, EyeOff, Save } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -12,7 +13,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const appName = ref('')
 const loading = ref(true)

--- a/web/src/views/AppLogs.vue
+++ b/web/src/views/AppLogs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, Radio, History, Trash2 } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -14,7 +15,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const appName = ref('')
 const realtimeEnabled = ref(false)

--- a/web/src/views/Apps.vue
+++ b/web/src/views/Apps.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import {
@@ -24,7 +25,7 @@ import type { App } from '@/types/models'
 
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 // State
 const apps = ref<App[]>([])

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Search, FileText, Calendar } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -14,7 +15,7 @@ import * as auditApi from '@/api/modules/audit'
 import type { AuditLog } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/BatchOperations.vue
+++ b/web/src/views/BatchOperations.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { Layers, Play, CheckCircle, XCircle } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -9,7 +10,7 @@ import Button from '@/components/ui/Button.vue'
 import { batchDeploy } from '@/api/modules/batchDeploy'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface AppEntry {
   image: string

--- a/web/src/views/CICD.vue
+++ b/web/src/views/CICD.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject } from 'vue'
+import { ref } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Rocket, Search, CheckCircle, XCircle, Loader2, Clock } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Badge from '@/components/ui/Badge.vue'
@@ -11,7 +12,7 @@ import * as cicdApi from '@/api/modules/cicd'
 import type { CICDBuild } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // 触发构建表单

--- a/web/src/views/Clusters.vue
+++ b/web/src/views/Clusters.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { Server, Plus, Globe, Trash2, RefreshCw, Settings } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -11,7 +12,7 @@ import Badge from '@/components/ui/Badge.vue'
 import { listClusters, createCluster, updateCluster, deleteCluster, testClusterConnection } from '@/api/modules/clusters'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface Cluster {
   id: string

--- a/web/src/views/DNS.vue
+++ b/web/src/views/DNS.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, MoreHorizontal, Pencil, Trash2, Search, Globe } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -18,7 +19,7 @@ import * as dnsApi from '@/api/modules/dns'
 import type { DNSRecord } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/Degradation.vue
+++ b/web/src/views/Degradation.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { getDegradationStatus, getDegradationAudits, getExportSummary } from '@/api/modules/degradation'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface DegradationStatus {
   level: string

--- a/web/src/views/Deployments.vue
+++ b/web/src/views/Deployments.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import {
   Search, Rocket,
 } from 'lucide-vue-next'
@@ -16,7 +17,7 @@ import * as deploymentsApi from '@/api/modules/deployments'
 import type { DeploymentRecord } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/FeatureFlags.vue
+++ b/web/src/views/FeatureFlags.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import type { Ref } from 'vue'
 import { getFeatureFlags, updateFeatureFlag, setFeatureFlagOverride, deleteFeatureFlagOverride, getFeatureFlagOverrides } from '@/api/modules/featureFlags'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface FeatureFlag {
   id: string

--- a/web/src/views/GrafanaDashboards.vue
+++ b/web/src/views/GrafanaDashboards.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import {
   LayoutDashboard,
   Plus,
@@ -25,7 +26,7 @@ import {
 } from '@/api/modules/grafana'
 import type { GrafanaDashboard } from '@/api/modules/grafana'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const dashboards = ref<GrafanaDashboard[]>([])
 const loading = ref(false)

--- a/web/src/views/GrafanaSettings.vue
+++ b/web/src/views/GrafanaSettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import PageHeader from '@/components/common/PageHeader.vue'
 import RelativeTime from '@/components/common/RelativeTime.vue'
 import Button from '@/components/ui/Button.vue'
@@ -24,7 +25,7 @@ import {
 } from '@/api/modules/grafana'
 import type { GrafanaStatus } from '@/api/modules/grafana'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const status = ref<GrafanaStatus | null>(null)
 const loading = ref(false)

--- a/web/src/views/Monitor.vue
+++ b/web/src/views/Monitor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, inject } from 'vue'
+import { computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { RefreshCw, Cpu, MemoryStick, HardDrive, ArrowUp, ArrowDown, Clock } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Button from '@/components/ui/Button.vue'
@@ -11,7 +12,7 @@ import * as monitorApi from '@/api/modules/monitor'
 import type { SystemMetrics } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // 轮询系统指标，每 30 秒刷新

--- a/web/src/views/MonitorAlertRules.vue
+++ b/web/src/views/MonitorAlertRules.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { RefreshCw } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Badge from '@/components/ui/Badge.vue'
@@ -11,7 +12,7 @@ import * as monitorApi from '@/api/modules/monitor'
 import type { AlertRule } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // 轮询告警规则列表

--- a/web/src/views/MonitorAlerts.vue
+++ b/web/src/views/MonitorAlerts.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { RefreshCw } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import RelativeTime from '@/components/common/RelativeTime.vue'
@@ -13,7 +14,7 @@ import * as monitorApi from '@/api/modules/monitor'
 import type { Alert } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // 轮询告警列表，每 30 秒刷新

--- a/web/src/views/MonitorContainers.vue
+++ b/web/src/views/MonitorContainers.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { RefreshCw, HeartPulse, Wrench } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
@@ -14,7 +15,7 @@ import * as monitorApi from '@/api/modules/monitor'
 import type { App, ContainerMetrics } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 const loading = ref(true)

--- a/web/src/views/Notifications.vue
+++ b/web/src/views/Notifications.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, MoreHorizontal, Pencil, Trash2, Bell } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -19,7 +20,7 @@ import * as notificationsApi from '@/api/modules/notifications'
 import type { Notification } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/PluginList.vue
+++ b/web/src/views/PluginList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import {
   Puzzle,
   Play,
@@ -17,7 +18,7 @@ import Switch from '@/components/ui/Switch.vue'
 import * as pluginApi from '@/api/modules/plugin'
 import type { PluginInfo } from '@/api/modules/plugin'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const plugins = ref<PluginInfo[]>([])
 const loading = ref(false)

--- a/web/src/views/Plugins.vue
+++ b/web/src/views/Plugins.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { Puzzle, Plus, Trash2, Power, PowerOff, RefreshCw } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -10,7 +11,7 @@ import Card from '@/components/ui/Card.vue'
 import { listPlugins, createPlugin, updatePlugin, deletePlugin, enablePlugin, disablePlugin, reloadPlugin } from '@/api/modules/plugins'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface Plugin {
   id: string

--- a/web/src/views/Providers.vue
+++ b/web/src/views/Providers.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, MoreHorizontal, Pencil, Trash2, Server } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -20,7 +21,7 @@ import * as providersApi from '@/api/modules/providers'
 import type { Provider } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/Registries.vue
+++ b/web/src/views/Registries.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { Database, Plus, Trash2, ExternalLink } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -10,7 +11,7 @@ import Card from '@/components/ui/Card.vue'
 import { listRegistries, createRegistry, updateRegistry, deleteRegistry } from '@/api/modules/registries'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface Registry {
   id: string

--- a/web/src/views/SSL.vue
+++ b/web/src/views/SSL.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted, computed } from 'vue'
+import { ref, onMounted, computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, RefreshCw, RotateCcw, Trash2 } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Badge from '@/components/ui/Badge.vue'
@@ -16,7 +17,7 @@ import * as sslApi from '@/api/modules/ssl'
 import type { SSLCertificate } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 const loading = ref(true)

--- a/web/src/views/SecuritySettings.vue
+++ b/web/src/views/SecuritySettings.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { ShieldCheck, ShieldOff, Copy } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Button from '@/components/ui/Button.vue'
@@ -13,7 +14,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 const authStore = useAuthStore()
-const toast = inject<any>('toast')!
+const { toast } = useToast()
 const twoFAEnabled = ref(false)
 const loadingStatus = ref(true)
 const setupStep = ref<'idle' | 'qr'>('idle')

--- a/web/src/views/ServerDetail.vue
+++ b/web/src/views/ServerDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import {
   ArrowLeft, Zap, Cpu, Terminal, Server as ServerIcon, Globe, Hash,
@@ -20,7 +21,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 // State
 const server = ref<Server | null>(null)

--- a/web/src/views/ServerEnvironment.vue
+++ b/web/src/views/ServerEnvironment.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import {
   ArrowLeft, RefreshCw, Monitor, Cpu, HardDrive, Server as ServerIcon,
@@ -18,7 +19,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const serverName = ref('')
 const loading = ref(true)

--- a/web/src/views/ServerTerminal.vue
+++ b/web/src/views/ServerTerminal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { ArrowLeft, Unplug, Plus, Maximize2, Minimize2, Trash2, Terminal as TerminalIcon } from 'lucide-vue-next'
 import Button from '@/components/ui/Button.vue'
@@ -11,7 +12,7 @@ import { useI18n } from 'vue-i18n'
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const serverName = ref('')
 const loading = ref(true)

--- a/web/src/views/Servers.vue
+++ b/web/src/views/Servers.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import {
   Search, Plus, MoreHorizontal, Eye, Zap, Terminal,
@@ -23,7 +24,7 @@ import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 // State
 const servers = ref<Server[]>([])

--- a/web/src/views/System.vue
+++ b/web/src/views/System.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Info, HeartPulse, RefreshCw, CheckCircle, XCircle, Download, ArrowUpCircle, AlertTriangle } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Card from '@/components/ui/Card.vue'
@@ -8,7 +9,7 @@ import Button from '@/components/ui/Button.vue'
 import * as systemApi from '@/api/modules/system'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/Templates.vue
+++ b/web/src/views/Templates.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { Plus, Pencil, Trash2, Rocket, FileCode } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -19,7 +20,7 @@ import { useI18n } from 'vue-i18n'
 
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 // State
 const templates = ref<Template[]>([])

--- a/web/src/views/Trial.vue
+++ b/web/src/views/Trial.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
-import { inject } from 'vue'
+
 import { getTrialStatus, extendTrial, listTrialPeriods } from '@/api/modules/trial'
 
 const { t } = useI18n()
-const toast: (msg: string, type?: string) => void = inject<any>('toast')
+const { toast } = useToast()
 
 interface TrialStatus {
   status: string

--- a/web/src/views/Users.vue
+++ b/web/src/views/Users.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { MoreHorizontal, Trash2, Users as UsersIcon, Shield } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -15,7 +16,7 @@ import * as usersApi from '@/api/modules/users'
 import type { User, Role } from '@/types/models'
 import { useI18n } from 'vue-i18n'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/WebhookDeliveries.vue
+++ b/web/src/views/WebhookDeliveries.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter, useRoute } from 'vue-router'
 import {
   ArrowLeft,
@@ -17,7 +18,7 @@ import type { WebhookDelivery } from '@/api/modules/outbound_webhook'
 
 const router = useRouter()
 const route = useRoute()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const webhookId = route.params.webhookId as string
 

--- a/web/src/views/WebhookForm.vue
+++ b/web/src/views/WebhookForm.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, inject } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter, useRoute } from 'vue-router'
 import {
   ArrowLeft,
@@ -19,7 +20,7 @@ import type { OutboundWebhook } from '@/api/modules/outbound_webhook'
 
 const router = useRouter()
 const route = useRoute()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const isEdit = computed(() => !!route.params.id)
 const pageTitle = computed(() => (isEdit.value ? 'Edit Webhook' : 'Create Webhook'))

--- a/web/src/views/WebhookList.vue
+++ b/web/src/views/WebhookList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import {
   Webhook,
@@ -20,7 +21,7 @@ import * as webhookApi from '@/api/modules/outbound_webhook'
 import type { OutboundWebhook } from '@/api/modules/outbound_webhook'
 
 const router = useRouter()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const webhooks = ref<OutboundWebhook[]>([])
 const loading = ref(false)

--- a/web/src/views/app-detail/index.vue
+++ b/web/src/views/app-detail/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import {
@@ -36,7 +37,7 @@ interface EnvItem {
 const props = defineProps<{ id: string }>()
 const router = useRouter()
 const { t } = useI18n()
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 // State
 const app = ref<App | null>(null)

--- a/web/src/views/credentials/index.vue
+++ b/web/src/views/credentials/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, inject, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { Plus, KeyRound, RefreshCw } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
@@ -20,7 +21,7 @@ import CredentialDialog from './CredentialDialog.vue'
 import RotateDialog from './RotateDialog.vue'
 import AuditLogTab from './AuditLogTab.vue'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 
 // State

--- a/web/src/views/license/index.vue
+++ b/web/src/views/license/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, inject, onMounted, computed } from 'vue'
+import { ref, onMounted, computed } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { RefreshCw, Key, ShieldCheck } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import Button from '@/components/ui/Button.vue'
@@ -18,7 +19,7 @@ import ActivateDialog from './ActivateDialog.vue'
 import IssueDialog from './IssueDialog.vue'
 import IssuedLicensesTable from './IssuedLicensesTable.vue'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 const { t } = useI18n()
 const authStore = useAuthStore()
 

--- a/web/src/views/oauth2/index.vue
+++ b/web/src/views/oauth2/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, inject } from 'vue'
+import { ref, onMounted } from 'vue'
+import { useToast } from '@/composables/useToast'
 import {
   KeyRound,
   Plus,
@@ -19,7 +20,7 @@ import type { OAuth2Client } from '@/api/modules/oauth2'
 import OAuth2ClientTable from './OAuth2ClientTable.vue'
 import OAuth2SecretDialog from './OAuth2SecretDialog.vue'
 
-const { toast } = inject<any>('toast')!
+const { toast } = useToast()
 
 const clients = ref<OAuth2Client[]>([])
 const loading = ref(false)


### PR DESCRIPTION
## Summary

- Add missing i18n keys: dashboard.viewAll, layout.monitorSettings, layout.monitorExport, layout.webhooks
- Fix monitor metrics API path: /monitor/metrics -> /monitor/system (was 404)
- Add CLI symlink to /usr/local/bin/deploypilot
- Auto-register current server during installation
- Update install output: show SSE URL instead of stdio config