### PR TITLE
fix: all sub-pages blank due to inject toast crash

### DIFF
--- a/web/src/composables/useToast.ts
+++ b/web/src/composables/useToast.ts
@@ -1,12 +1,14 @@
 import { inject } from 'vue'
 
+type ToastVariant = 'default' | 'success' | 'destructive' | 'error' | 'warning' | 'info'
+
 /**
  * Safely get the toast function from the Toast component's provide.
  * Returns a no-op function if toast is not available (e.g., during testing
  * or if Toast component hasn't mounted yet).
  */
 export function useToast() {
-  const ctx = inject<{ toast: (message: string, variant?: 'default' | 'success' | 'destructive') => void }>('toast')
+  const ctx = inject<{ toast: (message: string, variant?: ToastVariant) => void }>('toast')
   return {
     toast: ctx?.toast ?? ((message: string) => {
       console.warn('[useToast] Toast not available:', message)


### PR DESCRIPTION
## Root Cause

42 view components used `inject<any>("toast")!` which throws TypeError when toast is undefined during component setup, crashing the entire component render.

## Fix

- Create safe `useToast()` composable that returns a no-op fallback
- Replace all 42 files
- Widen toast variant type to include error/warning/info

This fixes Servers, Apps, Monitor, DNS, SSL, Credentials, and all other pages showing completely blank.