### PR TITLE
feat: server create page, reinstall password reset, smart install

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -491,6 +491,45 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 }
 
 
+// ResetPassword resets a user's password. Only allowed from localhost (for install script).
+func ResetPassword(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Only allow from localhost
+		if c.ClientIP() != "127.0.0.1" && c.ClientIP() != "::1" {
+			respondErrori18n(c, http.StatusForbidden, "error.common.forbidden")
+			return
+		}
+
+		var input struct {
+			Username string `json:"username" binding:"required"`
+			Password string `json:"password" binding:"required,min=8"`
+		}
+		if err := c.ShouldBindJSON(&input); err != nil {
+			respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request")
+			return
+		}
+
+		var user model.User
+		if err := db.Where("username = ?", input.Username).First(&user).Error; err != nil {
+			respondErrori18n(c, http.StatusNotFound, "error.auth.user_not_found")
+			return
+		}
+
+		hash, err := crypto.HashPassword(input.Password)
+		if err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")
+			return
+		}
+
+		if err := db.Model(&user).Update("password_hash", hash).Error; err != nil {
+			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
+			return
+		}
+
+		respondSuccess(c, gin.H{"message": "password_reset"})
+	}
+}
+
 // OAuthLogin initiates an OAuth2 login flow.
 // @Summary      OAuth login
 // @Description  Redirect to OAuth provider for authentication

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -102,6 +102,7 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB, bridge *service.Bridge, wsHub *W
 		// Registration endpoint - only allows creating the first admin user
 		// After that, users must be created by admins in the management panel
 		authGroup.POST("/register", Register(db))
+		authGroup.POST("/reset-password", ResetPassword(db))
 		authGroup.POST("/login", Login(db, func() *bruteforce.Protector {
 			if bridge != nil {
 				return bridge.BFProtector

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -741,22 +741,90 @@ EOF
     if systemctl is-active --quiet deploypilot; then
         print_success "DeployPilot API Server 启动成功"
 
-        print_info "正在创建管理员账号..."
-        REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
-        if echo "$REGISTER_RESP" | grep -q '"id"'; then
-            print_success "管理员账号创建成功"
-        elif echo "$REGISTER_RESP" | grep -q 'registration is disabled'; then
-            print_warning "检测到已有用户，跳过管理员创建"
-            print_info "请使用之前创建的管理员账号登录"
-            print_info "登录后可在「服务器」页面手动添加当前服务器"
-            # Keep USERNAME/PASSWORD for display, but skip server registration with these creds
-            SKIP_SERVER_REG=1
+        DB_FILE="${INSTALL_DIR}/data/deploypilot.db"
+        if [ -f "$DB_FILE" ]; then
+            # Reinstall detected
+            echo ""
+            print_warning "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            print_warning "  检测到已有 DeployPilot 数据"
+            print_warning "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+            echo ""
+            echo "  请选择操作："
+            echo "    1) 重置管理员密码（保留所有数据）"
+            echo "    2) 清空所有数据，重新开始"
+            echo "    3) 保留现有数据，不修改"
+            echo ""
+            REINSTALL_CHOICE=$(prompt_input "请输入选项 (1/2/3)" "1")
+
+            case "$REINSTALL_CHOICE" in
+                1)
+                    print_info "正在重置管理员密码..."
+                    RESET_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/reset-password" \
+                        -H "Content-Type: application/json" \
+                        -d "{\"username\": \"${USERNAME}\", \"password\": \"${PASSWORD}\"}" 2>&1)
+                    if echo "$RESET_RESP" | grep -q 'password_reset'; then
+                        print_success "管理员密码重置成功"
+                        SKIP_SERVER_REG=0
+                    elif echo "$RESET_RESP" | grep -q 'user_not_found\|not found'; then
+                        print_warning "用户 '${USERNAME}' 不存在，正在创建新管理员..."
+                        REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
+                            -H "Content-Type: application/json" \
+                            -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
+                        if echo "$REGISTER_RESP" | grep -q '"id"'; then
+                            print_success "管理员账号创建成功"
+                            SKIP_SERVER_REG=0
+                        else
+                            print_warning "管理员创建失败: $(echo "$REGISTER_RESP" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)"
+                            SKIP_SERVER_REG=1
+                        fi
+                    else
+                        print_warning "密码重置失败: $(echo "$RESET_RESP" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)"
+                        print_info "请手动登录面板修改密码"
+                        SKIP_SERVER_REG=1
+                    fi
+                    ;;
+                2)
+                    print_warning "正在清空所有数据..."
+                    systemctl stop deploypilot
+                    rm -f "$DB_FILE"
+                    rm -f "${DB_FILE}-wal" "${DB_FILE}-shm"
+                    systemctl start deploypilot
+                    sleep 2
+                    print_info "正在创建管理员账号..."
+                    REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
+                        -H "Content-Type: application/json" \
+                        -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
+                    if echo "$REGISTER_RESP" | grep -q '"id"'; then
+                        print_success "管理员账号创建成功"
+                        SKIP_SERVER_REG=0
+                    else
+                        print_warning "管理员创建失败: $(echo "$REGISTER_RESP" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)"
+                        SKIP_SERVER_REG=1
+                    fi
+                    ;;
+                3)
+                    print_info "保留现有数据，跳过管理员配置"
+                    print_info "请使用已有账号登录"
+                    SKIP_SERVER_REG=1
+                    ;;
+                *)
+                    print_warning "无效选项，保留现有数据"
+                    SKIP_SERVER_REG=1
+                    ;;
+            esac
         else
-            print_warning "管理员账号创建失败: $(echo "$REGISTER_RESP" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)"
-            print_info "请手动创建账号或使用已有账号: http://${IP_ADDRESS}:${PORT}"
-            SKIP_SERVER_REG=1
+            # Fresh install
+            print_info "正在创建管理员账号..."
+            REGISTER_RESP=$(curl -s -X POST "http://localhost:${PORT}/api/v1/auth/register" \
+                -H "Content-Type: application/json" \
+                -d "{\"username\": \"${USERNAME}\", \"email\": \"admin@example.com\", \"password\": \"${PASSWORD}\"}" 2>&1)
+            if echo "$REGISTER_RESP" | grep -q '"id"'; then
+                print_success "管理员账号创建成功"
+            else
+                print_warning "管理员账号创建失败: $(echo "$REGISTER_RESP" | grep -o '"message":"[^"]*"' | cut -d'"' -f4)"
+                print_info "请手动创建账号或使用已有账号: http://${IP_ADDRESS}:${PORT}"
+                SKIP_SERVER_REG=1
+            fi
         fi
     else
         print_warning "DeployPilot API Server 启动失败，请检查日志: ${INSTALL_DIR}/logs/deploypilot.err.log"

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -400,6 +400,12 @@ export default {
     detectFailed: 'Environment detection failed',
     hostPort: 'Host:Port',
     tags: 'Tags',
+    createServerName: 'Server Name',
+    createHost: 'Host Address',
+    createPort: 'SSH Port',
+    createSshUser: 'SSH User',
+    createSuccess: 'Server added successfully',
+    createFailed: 'Failed to add server',
   },
 
   serverDetail: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -398,6 +398,12 @@ export default {
     detectFailed: '环境检测失败',
     hostPort: '主机:端口',
     tags: '标签',
+    createServerName: '服务器名称',
+    createHost: '主机地址',
+    createPort: 'SSH 端口',
+    createSshUser: 'SSH 用户',
+    createSuccess: '服务器添加成功',
+    createFailed: '服务器添加失败',
   },
 
   serverDetail: {

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -79,6 +79,12 @@ const router = createRouter({
           meta: { titleKey: 'routes.appBackups' },
         },
         {
+          path: 'servers/create',
+          name: 'ServerCreate',
+          component: () => import('@/views/ServerCreate.vue'),
+          meta: { titleKey: 'routes.servers' },
+        },
+        {
           path: 'servers',
           name: 'Servers',
           component: () => import('@/views/Servers.vue'),

--- a/web/src/views/ServerCreate.vue
+++ b/web/src/views/ServerCreate.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { useToast } from '@/composables/useToast'
+import * as serversApi from '@/api/modules/servers'
+import PageHeader from '@/components/common/PageHeader.vue'
+import Button from '@/components/ui/Button.vue'
+import Input from '@/components/ui/Input.vue'
+
+const { t } = useI18n()
+const router = useRouter()
+const { toast } = useToast()
+
+const name = ref('')
+const host = ref('')
+const port = ref(22)
+const user = ref('root')
+const loading = ref(false)
+
+async function handleSubmit() {
+  if (!name.value || !host.value) {
+    toast(t('common.required') || '请填写必填项', 'destructive')
+    return
+  }
+  loading.value = true
+  try {
+    await serversApi.create({ name: name.value, host: host.value, port: port.value } as any)
+    toast(t('servers.createSuccess') || '服务器添加成功', 'success')
+    router.push('/servers')
+  } catch (err: any) {
+    toast(err.response?.data?.message || t('servers.createFailed') || '添加失败', 'destructive')
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageHeader :title="t('servers.addServer')">
+      <template #actions>
+        <Button variant="outline" @click="router.push('/servers')">
+          {{ t('common.back') || '返回' }}
+        </Button>
+      </template>
+    </PageHeader>
+
+    <div class="max-w-lg">
+      <form @submit.prevent="handleSubmit" class="space-y-4">
+        <!-- Name -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium">{{ t('servers.createServerName') }}</label>
+          <Input v-model="name" placeholder="例如: production-01" />
+        </div>
+        <!-- Host -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium">{{ t('servers.createHost') }}</label>
+          <Input v-model="host" placeholder="192.168.1.100" />
+        </div>
+        <!-- Port -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium">{{ t('servers.createPort') }}</label>
+          <Input v-model.number="port" type="number" placeholder="22" />
+        </div>
+        <!-- User -->
+        <div class="space-y-2">
+          <label class="text-sm font-medium">{{ t('servers.createSshUser') }}</label>
+          <Input v-model="user" placeholder="root" />
+        </div>
+        <!-- Submit -->
+        <Button type="submit" :disabled="loading">
+          {{ loading ? '...' : (t('servers.addServer') || '添加服务器') }}
+        </Button>
+      </form>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Changes

### Server Create Page (fixes crash)
- Added `ServerCreate.vue` with form for name/host/port/user
- Added route `/servers/create` (was missing, causing crash on click)
- Added i18n keys for server creation form

### Password Reset API
- Added `POST /api/v1/auth/reset-password` (localhost only)
- Allows install script to reset admin password during reinstall

### Smart Install Script
- Detects existing database on reinstall
- Offers 3 choices: reset password, wipe all data, or keep existing
- Reset password calls the new API; if user not found, creates new account
- Wipe data stops service, deletes DB, restarts, creates fresh admin