### PR TITLE
fix: monitor pages ref auto-unwrap bug, computed optimization

### DIFF
--- a/web/src/views/FeatureFlags.vue
+++ b/web/src/views/FeatureFlags.vue
@@ -3,7 +3,6 @@ import { ref, onMounted, computed } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
 
-import type { Ref } from 'vue'
 import { getFeatureFlags, updateFeatureFlag, setFeatureFlagOverride, deleteFeatureFlagOverride, getFeatureFlagOverrides } from '@/api/modules/featureFlags'
 
 const { t } = useI18n()

--- a/web/src/views/MonitorAlertRules.vue
+++ b/web/src/views/MonitorAlertRules.vue
@@ -16,7 +16,7 @@ const { toast } = useToast()
 const { t } = useI18n()
 
 // 轮询告警规则列表
-const { data: rules, loading, refresh } = usePolling<AlertRule[]>({
+const { data: rulesRef, loading, refresh } = usePolling<AlertRule[]>({
   fetchFn: async () => {
     const res = await monitorApi.listAlertRules()
     if (res.data.status === 'success') {
@@ -27,6 +27,9 @@ const { data: rules, loading, refresh } = usePolling<AlertRule[]>({
   interval: 60000,
   autoStart: true,
 })
+
+// Unwrap ref for template
+const rules = computed(() => rulesRef.value)
 
 // 表格列
 const columns = computed(() => [
@@ -94,7 +97,7 @@ async function handleRefresh() {
     <!-- 规则表格 -->
     <Table
       :columns="columns"
-      :data="rules.value || []"
+      :data="rules || []"
       :loading="loading"
     >
       <template #cell-name="{ row }">

--- a/web/src/views/MonitorAlerts.vue
+++ b/web/src/views/MonitorAlerts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { RefreshCw } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -18,7 +18,7 @@ const { toast } = useToast()
 const { t } = useI18n()
 
 // 轮询告警列表，每 30 秒刷新
-const { data: alerts, loading, refresh } = usePolling<Alert[]>({
+const { data: alertsRef, loading, refresh } = usePolling<Alert[]>({
   fetchFn: async () => {
     const res = await monitorApi.listAlerts()
     if (res.data.status === 'success') {
@@ -29,6 +29,9 @@ const { data: alerts, loading, refresh } = usePolling<Alert[]>({
   interval: 30000,
   autoStart: true,
 })
+
+// Unwrap ref for template (Vue auto-unwraps in templates but TS needs help)
+const alerts = computed(() => alertsRef.value)
 
 // 告警严重程度样式映射
 function getLevelBadge(level: string) {
@@ -84,21 +87,21 @@ async function handleRefresh() {
     </PageHeader>
 
     <!-- 加载状态 -->
-    <div v-if="loading && !alerts.value" class="space-y-3">
+    <div v-if="loading && !alerts" class="space-y-3">
       <Skeleton v-for="i in 3" :key="i" class="h-24" />
     </div>
 
     <!-- 空状态 -->
     <EmptyState
-      v-else-if="alerts.value && alerts.value.length === 0"
+      v-else-if="alerts && alerts.length === 0"
       :title="t('monitorAlerts.noAlerts')"
       :description="t('monitorAlerts.noAlertsDesc')"
     />
 
     <!-- 告警列表 -->
-    <div v-else-if="alerts.value && alerts.value.length > 0" class="space-y-3">
+    <div v-else-if="alerts && alerts.length > 0" class="space-y-3">
       <Card
-        v-for="alert in alerts.value"
+        v-for="alert in alerts"
         :key="alert.id"
         class="border-l-4"
         :class="getLevelBorderColor(alert.level)"

--- a/web/src/views/MonitorContainers.vue
+++ b/web/src/views/MonitorContainers.vue
@@ -56,19 +56,17 @@ function formatBytes(bytes: number): string {
 }
 
 // 获取容器指标数据（用于表格展示）
-function getTableData() {
-  return apps.value.map((app) => {
-    const metrics = containerMetricsMap.value[app.container_name || app.name]
-    return {
-      container_name: app.container_name || app.name,
-      app_name: app.name,
-      cpu_usage: metrics?.cpu_usage ?? 0,
-      memory_usage: metrics?.memory_usage ?? 0,
-      memory_limit: metrics?.memory_limit ?? 0,
-      status: metrics?.status || app.status,
-    }
-  })
-}
+const tableData = computed(() => apps.value.map((app) => {
+  const metrics = containerMetricsMap.value[app.container_name || app.name]
+  return {
+    container_name: app.container_name || app.name,
+    app_name: app.name,
+    cpu_usage: metrics?.cpu_usage ?? 0,
+    memory_usage: metrics?.memory_usage ?? 0,
+    memory_limit: metrics?.memory_limit ?? 0,
+    status: metrics?.status || app.status,
+  }
+}))
 
 // 获取应用列表
 async function fetchApps() {
@@ -169,7 +167,7 @@ onMounted(async () => {
     <!-- 容器列表 -->
     <Table
       :columns="columns"
-      :data="getTableData()"
+      :data="tableData"
       :loading="loading"
     >
       <template #cell-container_name="{ row }">


### PR DESCRIPTION
## Bugs Fixed

- MonitorAlerts: template used `alerts.value` but Vue auto-unwraps refs in templates, so `.value` returned undefined. Alerts list never rendered.
- MonitorAlertRules: same issue with `rules.value`, table always empty.
- MonitorContainers: `getTableData()` called in template was not reactive, converted to `computed`.
- FeatureFlags: removed unused `Ref` import.