### PR TITLE
chore: remove unused icon imports

### DIFF
--- a/web/src/views/ActivityFeed.vue
+++ b/web/src/views/ActivityFeed.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
 
-import { Activity, Filter } from 'lucide-vue-next'
+import { Activity } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import Button from '@/components/ui/Button.vue'

--- a/web/src/views/BatchOperations.vue
+++ b/web/src/views/BatchOperations.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
 
-import { Layers, Play, CheckCircle, XCircle } from 'lucide-vue-next'
+import { Play, CheckCircle, XCircle } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import Button from '@/components/ui/Button.vue'

--- a/web/src/views/GrafanaDashboards.vue
+++ b/web/src/views/GrafanaDashboards.vue
@@ -7,7 +7,6 @@ import {
   Pencil,
   Trash2,
   RefreshCw,
-  Loader2,
   Tag,
 } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'


### PR DESCRIPTION
Remove unused icon imports from:
- BatchOperations.vue (Layers)
- GrafanaDashboards.vue (Loader2)
- ActivityFeed.vue (Filter)