### PR TITLE
fix: critical and high severity bugs from full project audit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,11 +36,8 @@ jobs:
           go mod tidy
           go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee base_bench.txt
 
-      - name: Install benchstat (Go 1.24 compatible version)
-        run: |
-          # Install benchstat version compatible with Go 1.24
-          # Latest benchstat requires Go 1.25+, so we use an older version
-          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20241209152558-5a4a8cd6e6dd
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
 
       - name: Compare benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,7 +37,7 @@ jobs:
           go test -bench=. -benchmem -count=5 ./internal/signing/ ./internal/auth/ 2>&1 | tee base_bench.txt
 
       - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20241001175251-5c7ff7c9ea32
 
       - name: Compare benchmarks
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # Install benchstat version compatible with Go 1.24
           # Latest benchstat requires Go 1.25+, so we use an older version
-          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20250305200910-02a15fd477ba
+          go install golang.org/x/perf/cmd/benchstat@v0.0.0-20241209152558-5a4a8cd6e6dd
 
       - name: Compare benchmarks
         run: |

--- a/internal/api/audit_api.go
+++ b/internal/api/audit_api.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Yogdunana/deploypilot/internal/audit"
 	"github.com/Yogdunana/deploypilot/internal/config"
+	"github.com/Yogdunana/deploypilot/internal/auth"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -140,7 +141,7 @@ func GDPRExportUserData(c *gin.Context) {
 		return
 	}
 
-	userIDVal, exists := c.Get("userID")
+	userIDVal, exists := c.Get(string(auth.UserIDKey))
 	if !exists {
 		respondError(c, http.StatusUnauthorized, "user not authenticated")
 		return

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -197,7 +197,7 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 		}
 
 		// Generate token
-		token, err := auth.GenerateToken(user.ID, "viewer")
+		token, err := auth.GenerateToken(user.ID, "owner")
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.auth.failed_to_generate_token")
 			return

--- a/internal/api/deployments.go
+++ b/internal/api/deployments.go
@@ -38,7 +38,7 @@ func ListDeployments(db *gorm.DB) gin.HandlerFunc {
 		query := db.Model(&model.DeploymentRecord{})
 
 		if appID := c.Query("app_id"); appID != "" {
-			query = query.Where("app_name = ?", appID)
+			query = query.Where("app_id = ?", appID)
 		}
 		if status := c.Query("status"); status != "" {
 			query = query.Where("status = ?", status)

--- a/internal/api/onboarding.go
+++ b/internal/api/onboarding.go
@@ -96,10 +96,7 @@ func GenerateDemoData(db *gorm.DB) gin.HandlerFunc {
 		var existingCount int64
 		db.Model(&model.Server{}).Where("tenant_id = ? AND name LIKE ?", user.TenantID, "Demo%").Count(&existingCount)
 		if existingCount > 0 {
-			c.JSON(http.StatusConflict, gin.H{
-				"status":  "error",
-				"message": "demo data already exists",
-			})
+			respondErrori18n(c, http.StatusConflict, "error.demo.already_exists")
 			return
 		}
 

--- a/internal/util/shell.go
+++ b/internal/util/shell.go
@@ -1,8 +1,19 @@
 package util
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // ShellQuote safely escapes a string for use in a shell command.
 func ShellQuote(s string) string {
+	// Reject control characters (especially newlines) that can break
+	// out of single-quoted shell arguments.
+	s = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, s)
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }

--- a/web/src/api/modules/activity.ts
+++ b/web/src/api/modules/activity.ts
@@ -15,7 +15,7 @@ export interface ActivityItem {
 }
 
 export function list(params?: PaginationParams & { type?: string }) {
-  return api.get<PaginatedResponse<ActivityItem[]>>('/activity', { params })
+  return api.get<PaginatedResponse<ActivityItem[]>>('/events', { params })
 }
 
 export function getStats() {
@@ -23,5 +23,5 @@ export function getStats() {
     today_count: number
     week_count: number
     by_type: Record<string, number>
-  }>>('/activity/stats')
+  }>>('/events/stats')
 }

--- a/web/src/api/modules/apps.ts
+++ b/web/src/api/modules/apps.ts
@@ -39,7 +39,7 @@ export function rollback(id: number, data: RollbackConfig) {
 }
 
 export function getLogs(id: number, tail?: number) {
-  return api.get<ApiResponse<string>>(`/apps/${id}/logs`, { params: { tail } })
+  return api.get<ApiResponse<string>>(`/apps/${id}/logs/container`, { params: { tail } })
 }
 
 export function backup(id: number) {

--- a/web/src/api/modules/audit.ts
+++ b/web/src/api/modules/audit.ts
@@ -12,5 +12,5 @@ export interface AuditLogParams extends PaginationParams {
 }
 
 export function listLogs(params?: AuditLogParams) {
-  return api.get<PaginatedResponse<AuditLog[]>>('/audit/logs', { params })
+  return api.get<PaginatedResponse<AuditLog[]>>('/audit-logs', { params })
 }

--- a/web/src/api/modules/cicd.ts
+++ b/web/src/api/modules/cicd.ts
@@ -3,9 +3,9 @@ import type { ApiResponse } from '@/types/api'
 import type { CICDBuild } from '@/types/models'
 
 export function triggerBuild(data: { provider: string; repo_url: string; branch: string; app_name?: string }) {
-  return api.post<ApiResponse<CICDBuild>>('/cicd/builds', data)
+  return api.post<ApiResponse<CICDBuild>>('/cicd/trigger', data)
 }
 
 export function getBuildStatus(runId: string, provider: string) {
-  return api.get<ApiResponse<CICDBuild>>(`/cicd/builds/${provider}/${runId}`)
+  return api.get<ApiResponse<CICDBuild>>(`/cicd/status/${runId}`, { params: { provider } })
 }

--- a/web/src/api/modules/monitor.ts
+++ b/web/src/api/modules/monitor.ts
@@ -7,7 +7,7 @@ export function getSystemMetrics() {
 }
 
 export function getContainerMetrics(name: string) {
-  return api.get<ApiResponse<ContainerMetrics>>(`/monitor/containers/${name}/metrics`)
+  return api.get<ApiResponse<ContainerMetrics>>(`/monitor/container/${name}`)
 }
 
 export function listAlerts(params?: PaginationParams) {
@@ -19,9 +19,9 @@ export function listAlertRules(params?: PaginationParams) {
 }
 
 export function heal(name: string) {
-  return api.post<ApiResponse<void>>(`/monitor/containers/${name}/heal`)
+  return api.post<ApiResponse<void>>(`/monitor/heal/${name}`)
 }
 
 export function check(name: string) {
-  return api.post<ApiResponse<{ healthy: boolean; message: string }>>(`/monitor/containers/${name}/check`)
+  return api.post<ApiResponse<{ healthy: boolean; message: string }>>(`/monitor/check/${name}`)
 }

--- a/web/src/components/common/TerminalEmulator.vue
+++ b/web/src/components/common/TerminalEmulator.vue
@@ -49,7 +49,7 @@ const { connected, reconnecting, send, disconnect, connect } = useWebSocket({
     }
   },
   onOpen() {
-    props.onStatusChange?.('connecting')
+    props.onStatusChange?.('connected')
   },
   onClose() {
     if (terminal) {

--- a/web/src/components/ui/AlertDialog.vue
+++ b/web/src/components/ui/AlertDialog.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { watch, onMounted, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { cn } from '@/lib/utils'
 import { X } from 'lucide-vue-next'
 import Button from './Button.vue'
+
+const { t } = useI18n()
 
 interface Props {
   open?: boolean
@@ -16,8 +19,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   open: false,
-  confirmText: '确认',
-  cancelText: '取消',
+  confirmText: undefined,
+  cancelText: undefined,
   variant: 'default',
 })
 
@@ -104,14 +107,14 @@ onBeforeUnmount(() => {
             </div>
             <div class="flex justify-end gap-2">
               <Button variant="outline" size="sm" @click="cancel">
-                {{ cancelText }}
+                {{ cancelText || t('common.cancel') }}
               </Button>
               <Button
                 :variant="variant === 'destructive' ? 'destructive' : 'default'"
                 size="sm"
                 @click="confirm"
               >
-                {{ confirmText }}
+                {{ confirmText || t('common.confirm') }}
               </Button>
             </div>
           </div>

--- a/web/src/components/ui/Button.vue
+++ b/web/src/components/ui/Button.vue
@@ -37,6 +37,7 @@ interface Props {
   size?: NonNullable<ButtonVariants['size']>
   disabled?: boolean
   loading?: boolean
+  type?: 'button' | 'reset' | 'submit'
   class?: string
 }
 
@@ -45,6 +46,7 @@ const props = withDefaults(defineProps<Props>(), {
   size: 'default',
   disabled: false,
   loading: false,
+  type: 'button',
 })
 
 const classes = computed(() =>
@@ -53,7 +55,7 @@ const classes = computed(() =>
 </script>
 
 <template>
-  <button :class="classes" :disabled="disabled || loading">
+  <button :class="classes" :type="type" :disabled="disabled || loading">
     <Loader2 v-if="loading" class="w-4 h-4 animate-spin" />
     <slot name="icon" />
     <slot />

--- a/web/src/components/ui/Input.vue
+++ b/web/src/components/ui/Input.vue
@@ -2,6 +2,8 @@
 import { computed } from 'vue'
 import { cn } from '@/lib/utils'
 
+defineOptions({ inheritAttrs: false })
+
 interface Props {
   modelValue?: string | number
   type?: string
@@ -39,6 +41,7 @@ function onInput(event: Event) {
 
 <template>
   <input
+    v-bind="$attrs"
     :class="classes"
     :type="type"
     :value="modelValue"

--- a/web/src/components/ui/Table.vue
+++ b/web/src/components/ui/Table.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { cn } from '@/lib/utils'
 import { Loader2 } from 'lucide-vue-next'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 interface TableColumn {
   key: string
@@ -12,6 +15,7 @@ interface Props {
   columns?: TableColumn[]
   data?: Record<string, any>[]
   loading?: boolean
+  noDataText?: string
   class?: string
 }
 
@@ -19,6 +23,7 @@ const props = withDefaults(defineProps<Props>(), {
   columns: () => [],
   data: () => [],
   loading: false,
+  noDataText: undefined,
 })
 </script>
 
@@ -45,7 +50,7 @@ const props = withDefaults(defineProps<Props>(), {
         </tr>
         <tr v-else-if="data.length === 0">
           <td :colspan="columns.length" class="h-24 text-center text-muted-foreground">
-            暂无数据
+            {{ noDataText || t('common.noData') }}
           </td>
         </tr>
         <template v-else>

--- a/web/src/components/ui/Toast.vue
+++ b/web/src/components/ui/Toast.vue
@@ -30,6 +30,9 @@ const variantClasses: Record<string, string> = {
   default: 'border-border bg-card text-foreground',
   success: 'border-success/30 bg-success/10 text-success',
   destructive: 'border-destructive/30 bg-destructive/10 text-destructive',
+  error: 'border-destructive/30 bg-destructive/10 text-destructive',
+  warning: 'bg-yellow-50 text-yellow-900 border-yellow-200 dark:bg-yellow-950 dark:text-yellow-200 dark:border-yellow-800',
+  info: 'bg-blue-50 text-blue-900 border-blue-200 dark:bg-blue-950 dark:text-blue-200 dark:border-blue-800',
 }
 </script>
 

--- a/web/src/i18n/locales/en.ts
+++ b/web/src/i18n/locales/en.ts
@@ -150,7 +150,7 @@ export default {
     emailRequired: 'Please enter email',
     emailInvalid: 'Please enter a valid email address',
     passwordRequired: 'Please enter password',
-    passwordTooShort: 'Password must be at least 6 characters',
+    passwordTooShort: 'Password must be at least 8 characters',
     confirmPasswordRequired: 'Please confirm password',
     passwordMismatch: 'Passwords do not match',
     failed: 'Registration failed, please try again later',
@@ -833,6 +833,9 @@ export default {
     healConfirmDesc: 'Are you sure you want to perform self-heal on container "{name}"? This will attempt to automatically fix container issues.',
     confirmHeal: 'Confirm Self-Heal',
     fetchAppsFailed: 'Failed to fetch app list',
+    refresh: 'Refresh',
+    healTriggered: 'Self-heal triggered for container "{name}"',
+    healFailed: 'Failed to trigger self-heal for container "{name}"',
   },
 
   ssl: {

--- a/web/src/i18n/locales/zh.ts
+++ b/web/src/i18n/locales/zh.ts
@@ -148,7 +148,7 @@ export default {
     emailRequired: '请输入邮箱',
     emailInvalid: '请输入有效的邮箱地址',
     passwordRequired: '请输入密码',
-    passwordTooShort: '密码长度至少为 6 位',
+    passwordTooShort: '密码长度至少为 8 位',
     confirmPasswordRequired: '请确认密码',
     passwordMismatch: '两次输入的密码不一致',
     failed: '注册失败，请稍后重试',
@@ -829,6 +829,9 @@ export default {
     healConfirmDesc: '确定要对容器「{name}」执行自愈操作吗？此操作将尝试自动修复容器问题。',
     confirmHeal: '确认自愈',
     fetchAppsFailed: '获取应用列表失败',
+    refresh: '刷新',
+    healTriggered: '已触发容器 "{name}" 自愈',
+    healFailed: '触发容器 "{name}" 自愈失败',
   },
 
   ssl: {

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -303,7 +303,7 @@ const router = createRouter({
         },
         {
           path: 'dashboard-tv',
-          name: 'DashboardTV',
+          name: 'DashboardTVMain',
           component: () => import('@/views/DashboardTV.vue'),
           meta: { titleKey: 'routes.dashboardTV' },
         },

--- a/web/src/stores/auth.test.ts
+++ b/web/src/stores/auth.test.ts
@@ -204,8 +204,10 @@ describe('useAuthStore', () => {
       expect(store.user).toEqual(mockUser)
     })
 
-    it('获取失败时调用 logout', async () => {
-      vi.mocked(getMe).mockRejectedValue(new Error('Unauthorized'))
+    it('401 错误时调用 logout', async () => {
+      const err = new Error('Unauthorized')
+      ;(err as any).response = { status: 401 }
+      vi.mocked(getMe).mockRejectedValue(err)
 
       const store = useAuthStore()
       store.token = 'some-token'
@@ -215,6 +217,21 @@ describe('useAuthStore', () => {
 
       expect(store.token).toBe('')
       expect(store.user).toBeNull()
+    })
+
+    it('非 401 错误时不调用 logout', async () => {
+      const err = new Error('Network Error')
+      ;(err as any).response = { status: 500 }
+      vi.mocked(getMe).mockRejectedValue(err)
+
+      const store = useAuthStore()
+      store.token = 'some-token'
+      store.user = mockUser
+
+      await store.fetchMe()
+
+      expect(store.token).toBe('some-token')
+      expect(store.user).toEqual(mockUser)
     })
   })
 

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -69,7 +69,11 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       const res = await getMe()
       user.value = res.data.data
-    } catch { logout() }
+    } catch (err: any) {
+      if (err.response?.status === 401) {
+        logout()
+      }
+    }
   }
 
   return {

--- a/web/src/views/ActivityFeed.vue
+++ b/web/src/views/ActivityFeed.vue
@@ -3,7 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
 
-import { Activity, Filter } from 'lucide-vue-next'
+import { Activity } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import Button from '@/components/ui/Button.vue'

--- a/web/src/views/BatchOperations.vue
+++ b/web/src/views/BatchOperations.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { useI18n } from 'vue-i18n'
 
-import { Layers, Play, CheckCircle, XCircle } from 'lucide-vue-next'
+import { Play, CheckCircle, XCircle } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import Button from '@/components/ui/Button.vue'

--- a/web/src/views/GrafanaDashboards.vue
+++ b/web/src/views/GrafanaDashboards.vue
@@ -7,7 +7,6 @@ import {
   Pencil,
   Trash2,
   RefreshCw,
-  Loader2,
   Tag,
 } from 'lucide-vue-next'
 import PageHeader from '@/components/common/PageHeader.vue'


### PR DESCRIPTION
## Backend Fixes
- ShellQuote: reject control characters to prevent newline injection
- Register: first user JWT gets owner role (was viewer)
- GDPRExport: use auth.UserIDKey constant
- ListDeployments: filter by app_id column (was app_name)
- GenerateDemoData: consistent error response format

## Frontend Fixes
- Button.vue: add type prop (form submit behavior)
- Input.vue: forward $attrs (maxlength/inputmode/autocomplete)
- TerminalEmulator: report connected status correctly
- Toast.vue: add error/warning/info variant styles
- Fix 7 API endpoint path mismatches
- auth store: fetchMe only logout on 401
- Router: fix duplicate DashboardTV name
- i18n: fix password length, add missing keys
- AlertDialog/Table: i18n instead of hardcoded Chinese