### PR TITLE
fix: release workflow support workflow_dispatch trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag ref (e.g. refs/tags/v1.0.0)'
+        required: true
 
 permissions:
   contents: write
@@ -24,8 +29,11 @@ jobs:
             goarch: arm64
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
       - name: Verify annotated tag
+        if: github.event_name == 'push'
         run: |
           TAG_TYPE=$(git cat-file -t ${{ github.ref_name }})
           if [ "$TAG_TYPE" != "tag" ]; then
@@ -108,6 +116,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
       - uses: actions/download-artifact@v4
         with:
@@ -133,6 +142,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref_name }}
           body: |
             ## Changes
 


### PR DESCRIPTION
Add workflow_dispatch trigger with ref input so auto-beta workflow can trigger releases via API dispatch call.