### PR TITLE
fix: auto-beta pass inputs.ref to release dispatch

### DIFF
--- a/.github/workflows/auto-beta.yml
+++ b/.github/workflows/auto-beta.yml
@@ -81,6 +81,6 @@ jobs:
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release.yml/dispatches" \
-            -d "{\"ref\":\"refs/tags/${TAG}\"}"
+            -d "{\"ref\":\"refs/tags/${TAG}\",\"inputs\":{\"ref\":\"refs/tags/${TAG}\"}}"
 
           echo "Triggered release workflow for ${TAG}"


### PR DESCRIPTION
Pass inputs.ref parameter when calling workflow_dispatch API.