### PR TITLE
fix: auto-beta use AUTO_BETA_PAT for workflow dispatch

### DIFF
--- a/.github/workflows/auto-beta.yml
+++ b/.github/workflows/auto-beta.yml
@@ -81,6 +81,6 @@ jobs:
             -H "Authorization: token ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/actions/workflows/release.yml/dispatches" \
-            -d "{\"ref\":\"refs/tags/${TAG}\"}"
+            -d "{\"ref\":\"refs/tags/${TAG}\",\"inputs\":{\"ref\":\"refs/tags/${TAG}\"}}"
 
           echo "Triggered release workflow for ${TAG}"

--- a/.github/workflows/auto-beta.yml
+++ b/.github/workflows/auto-beta.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Trigger release workflow
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.AUTO_BETA_PAT }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           curl -s -X POST \


### PR DESCRIPTION
GITHUB_TOKEN cannot trigger workflow_dispatch. Use AUTO_BETA_PAT secret (with workflow scope) instead.