### PR TITLE
fix: release Go cache key include architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-go-
+          key: ${{ runner.os }}-go-${{ matrix.goarch }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-${{ matrix.goarch }}-
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Parallel amd64/arm64 builds share the same Go module cache path, causing tar "Cannot open: File exists" errors. Add matrix.goarch to cache key to isolate per architecture.