### PR TITLE
fix: all Vue components and API modules align with string ID type

### DIFF
--- a/web/src/api/modules/apps.ts
+++ b/web/src/api/modules/apps.ts
@@ -6,7 +6,7 @@ export function list(params?: PaginationParams) {
   return api.get<PaginatedResponse<App[]>>('/apps', { params })
 }
 
-export function get(id: number) {
+export function get(id: string) {
   return api.get<ApiResponse<App>>(`/apps/${id}`)
 }
 
@@ -14,54 +14,54 @@ export function create(data: Partial<App>) {
   return api.post<ApiResponse<App>>('/apps', data)
 }
 
-export function update(id: number, data: Partial<App>) {
+export function update(id: string, data: Partial<App>) {
   return api.put<ApiResponse<App>>(`/apps/${id}`, data)
 }
 
-export function deleteApp(id: number) {
+export function deleteApp(id: string) {
   return api.delete<ApiResponse<void>>(`/apps/${id}`)
 }
 
-export function deploy(id: number, config?: DeployConfig, async = true) {
+export function deploy(id: string, config?: DeployConfig, async = true) {
   return api.post<ApiResponse<DeploymentRecord>>(`/apps/${id}/deploy`, { ...config, async })
 }
 
-export function build(id: number, data: BuildConfig) {
+export function build(id: string, data: BuildConfig) {
   return api.post<ApiResponse<any>>(`/apps/${id}/build`, data)
 }
 
-export function getStatus(id: number) {
+export function getStatus(id: string) {
   return api.get<ApiResponse<any>>(`/apps/${id}/status`)
 }
 
-export function rollback(id: number, data: RollbackConfig) {
+export function rollback(id: string, data: RollbackConfig) {
   return api.post<ApiResponse<DeploymentRecord>>(`/apps/${id}/rollback`, data)
 }
 
-export function getLogs(id: number, tail?: number) {
+export function getLogs(id: string, tail?: number) {
   return api.get<ApiResponse<string>>(`/apps/${id}/logs/container`, { params: { tail } })
 }
 
-export function backup(id: number) {
+export function backup(id: string) {
   return api.post<ApiResponse<any>>(`/apps/${id}/backup`)
 }
 
-export function listBackups(id: number) {
+export function listBackups(id: string) {
   return api.get<ApiResponse<any[]>>(`/apps/${id}/backups`)
 }
 
-export function restore(id: number, data: RestoreConfig) {
+export function restore(id: string, data: RestoreConfig) {
   return api.post<ApiResponse<void>>(`/apps/${id}/restore`, data)
 }
 
-export function deleteBackup(id: number, backupId: string) {
+export function deleteBackup(id: string, backupId: string) {
   return api.delete<ApiResponse<void>>(`/apps/${id}/backups/${backupId}`)
 }
 
-export function getEnv(id: number) {
+export function getEnv(id: string) {
   return api.get<ApiResponse<Record<string, string>>>(`/apps/${id}/env`)
 }
 
-export function updateEnv(id: number, data: Record<string, string>) {
+export function updateEnv(id: string, data: Record<string, string>) {
   return api.put<ApiResponse<Record<string, string>>>(`/apps/${id}/env`, data)
 }

--- a/web/src/api/modules/credentials.ts
+++ b/web/src/api/modules/credentials.ts
@@ -2,7 +2,7 @@ import api from '@/api'
 import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/api'
 import type { Credential } from '@/types/models'
 
-export function list(tenantId?: number, params?: PaginationParams) {
+export function list(tenantId?: string, params?: PaginationParams) {
   return api.get<PaginatedResponse<Credential[]>>('/credentials', { params: { tenant_id: tenantId, ...params } })
 }
 
@@ -10,14 +10,14 @@ export function create(data: { name: string; type: string; value: string; expire
   return api.post<ApiResponse<Credential>>('/credentials', data)
 }
 
-export function update(id: number, data: { name?: string; type?: string; value?: string }) {
+export function update(id: string, data: { name?: string; type?: string; value?: string }) {
   return api.put<ApiResponse<Credential>>(`/credentials/${id}`, data)
 }
 
-export function deleteCredential(id: number) {
+export function deleteCredential(id: string) {
   return api.delete<ApiResponse<void>>(`/credentials/${id}`)
 }
 
-export function rotate(id: number, data: { value: string }) {
+export function rotate(id: string, data: { value: string }) {
   return api.post<ApiResponse<Credential>>(`/credentials/${id}/rotate`, data)
 }

--- a/web/src/api/modules/deployments.ts
+++ b/web/src/api/modules/deployments.ts
@@ -2,10 +2,10 @@ import api from '@/api'
 import type { ApiResponse, PaginatedResponse, PaginationParams } from '@/types/api'
 import type { DeploymentRecord } from '@/types/models'
 
-export function list(appId?: number, status?: string, params?: PaginationParams) {
+export function list(appId?: string, status?: string, params?: PaginationParams) {
   return api.get<PaginatedResponse<DeploymentRecord[]>>('/deployments', { params: { app_id: appId, status, ...params } })
 }
 
-export function get(id: number) {
+export function get(id: string) {
   return api.get<ApiResponse<DeploymentRecord>>(`/deployments/${id}`)
 }

--- a/web/src/api/modules/notifications.ts
+++ b/web/src/api/modules/notifications.ts
@@ -10,10 +10,10 @@ export function create(data: { type: string; name: string; config: Record<string
   return api.post<ApiResponse<Notification>>('/notifications', data)
 }
 
-export function update(id: number, data: Partial<Notification>) {
+export function update(id: string, data: Partial<Notification>) {
   return api.put<ApiResponse<Notification>>(`/notifications/${id}`, data)
 }
 
-export function deleteNotification(id: number) {
+export function deleteNotification(id: string) {
   return api.delete<ApiResponse<void>>(`/notifications/${id}`)
 }

--- a/web/src/api/modules/providers.ts
+++ b/web/src/api/modules/providers.ts
@@ -10,10 +10,10 @@ export function create(data: { type: string; name: string; config: Record<string
   return api.post<ApiResponse<Provider>>('/providers', data)
 }
 
-export function update(id: number, data: Partial<Provider>) {
+export function update(id: string, data: Partial<Provider>) {
   return api.put<ApiResponse<Provider>>(`/providers/${id}`, data)
 }
 
-export function deleteProvider(id: number) {
+export function deleteProvider(id: string) {
   return api.delete<ApiResponse<void>>(`/providers/${id}`)
 }

--- a/web/src/api/modules/servers.ts
+++ b/web/src/api/modules/servers.ts
@@ -10,22 +10,22 @@ export function create(data: Partial<Server>) {
   return api.post<ApiResponse<Server>>('/servers', data)
 }
 
-export function update(id: number, data: Partial<Server>) {
+export function update(id: string, data: Partial<Server>) {
   return api.put<ApiResponse<Server>>(`/servers/${id}`, data)
 }
 
-export function deleteServer(id: number) {
+export function deleteServer(id: string) {
   return api.delete<ApiResponse<void>>(`/servers/${id}`)
 }
 
-export function test(id: number) {
+export function test(id: string) {
   return api.post<ApiResponse<{ success: boolean; message: string }>>(`/servers/${id}/test`)
 }
 
-export function detect(id: number, data: { host: string; port?: number }) {
+export function detect(id: string, data: { host: string; port?: number }) {
   return api.post<ApiResponse<Server['detected_info']>>(`/servers/${id}/detect`, data)
 }
 
-export function getEnvironment(id: number) {
+export function getEnvironment(id: string) {
   return api.get<ApiResponse<Server['detected_info']>>(`/servers/${id}/environment`)
 }

--- a/web/src/api/modules/users.ts
+++ b/web/src/api/modules/users.ts
@@ -10,11 +10,11 @@ export function list(params?: PaginationParams) {
   return api.get<PaginatedResponse<User[]>>('/users', { params })
 }
 
-export function deleteUser(id: number) {
+export function deleteUser(id: string) {
   return api.delete<ApiResponse<void>>(`/users/${id}`)
 }
 
-export function updateRole(id: number, roleId: number) {
+export function updateRole(id: string, roleId: string) {
   return api.put<ApiResponse<User>>(`/users/${id}/role`, { role_id: roleId })
 }
 

--- a/web/src/views/AppBackups.vue
+++ b/web/src/views/AppBackups.vue
@@ -49,7 +49,7 @@ const columns = computed(() => [
 async function fetchBackups() {
   loading.value = true
   try {
-    const res = await appsApi.listBackups(Number(props.id))
+    const res = await appsApi.listBackups(props.id)
     if (res.data.status === 'success') {
       backups.value = res.data.data || []
     }
@@ -64,7 +64,7 @@ async function fetchBackups() {
 async function createBackup() {
   creating.value = true
   try {
-    await appsApi.backup(Number(props.id))
+    await appsApi.backup(props.id)
     toast(t('appBackups.backupCreated'), 'success')
     fetchBackups()
   } catch (err: any) {
@@ -84,7 +84,7 @@ async function confirmRestore() {
   if (!selectedBackup.value) return
   restoring.value = true
   try {
-    await appsApi.restore(Number(props.id), { backup_id: selectedBackup.value.id })
+    await appsApi.restore(props.id, { backup_id: selectedBackup.value.id })
     toast(t('appBackups.restored'), 'success')
     restoreDialogOpen.value = false
   } catch (err: any) {
@@ -104,7 +104,7 @@ async function confirmDelete() {
   if (!selectedBackup.value) return
   deleting.value = true
   try {
-    await appsApi.deleteBackup(Number(props.id), selectedBackup.value.id)
+    await appsApi.deleteBackup(props.id, selectedBackup.value.id)
     toast(t('appBackups.deleted'), 'success')
     deleteDialogOpen.value = false
     fetchBackups()
@@ -118,7 +118,7 @@ async function confirmDelete() {
 // 获取应用信息
 async function fetchApp() {
   try {
-    const res = await appsApi.get(Number(props.id))
+    const res = await appsApi.get(props.id)
     if (res.data.status === 'success') {
       appName.value = res.data.data.name
     }

--- a/web/src/views/AppEnv.vue
+++ b/web/src/views/AppEnv.vue
@@ -33,7 +33,7 @@ const envList = ref<EnvItem[]>([])
 async function fetchEnv() {
   loading.value = true
   try {
-    const res = await appsApi.getEnv(Number(props.id))
+    const res = await appsApi.getEnv(props.id)
     if (res.data.status === 'success') {
       const envData = res.data.data || {}
       envList.value = Object.entries(envData).map(([key, value]) => ({
@@ -95,7 +95,7 @@ async function saveEnv() {
       }
     })
 
-    await appsApi.updateEnv(Number(props.id), { env_vars: JSON.stringify(envObject) })
+    await appsApi.updateEnv(props.id, { env_vars: JSON.stringify(envObject) })
     toast(t('appEnv.saved'), 'success')
   } catch (err: any) {
     toast(err.response?.data?.message || t('appEnv.saveFailed'), 'destructive')
@@ -107,7 +107,7 @@ async function saveEnv() {
 // 获取应用信息
 async function fetchApp() {
   try {
-    const res = await appsApi.get(Number(props.id))
+    const res = await appsApi.get(props.id)
     if (res.data.status === 'success') {
       appName.value = res.data.data.name
     }

--- a/web/src/views/AppLogs.vue
+++ b/web/src/views/AppLogs.vue
@@ -49,7 +49,7 @@ function toggleRealtime() {
 async function loadHistory() {
   loadingHistory.value = true
   try {
-    const res = await appsApi.getLogs(Number(props.id), 500)
+    const res = await appsApi.getLogs(props.id, 500)
     if (res.data.status === 'success') {
       const logText = res.data.data
       if (logText && typeof logText === 'string') {
@@ -77,7 +77,7 @@ function clearLogs() {
 // 获取应用信息
 async function fetchApp() {
   try {
-    const res = await appsApi.get(Number(props.id))
+    const res = await appsApi.get(props.id)
     if (res.data.status === 'success') {
       appName.value = res.data.data.name
     }

--- a/web/src/views/Notifications.vue
+++ b/web/src/views/Notifications.vue
@@ -30,7 +30,7 @@ const loading = ref(true)
 // Dialog
 const dialogOpen = ref(false)
 const dialogTitle = ref(t('notifications.createTitle'))
-const editingId = ref<number | null>(null)
+const editingId = ref<string | null>(null)
 const formName = ref('')
 const formType = ref('')
 const formConfig = ref('')

--- a/web/src/views/Providers.vue
+++ b/web/src/views/Providers.vue
@@ -32,7 +32,7 @@ const activeTab = ref('')
 // Dialog
 const dialogOpen = ref(false)
 const dialogTitle = ref(t('providers.createTitle'))
-const editingId = ref<number | null>(null)
+const editingId = ref<string | null>(null)
 const formName = ref('')
 const formType = ref('')
 const formConfig = ref('')

--- a/web/src/views/ServerDetail.vue
+++ b/web/src/views/ServerDetail.vue
@@ -44,7 +44,7 @@ async function fetchServer() {
     // Use list and filter since there's no single get endpoint
     const res = await serversApi.list({ page: 1, page_size: 1000 })
     if (res.data.status === 'success') {
-      const found = res.data.data.find((s: Server) => s.id === Number(props.id))
+      const found = res.data.data.find((s: Server) => s.id === props.id)
       if (found) {
         server.value = found
       } else {

--- a/web/src/views/ServerEnvironment.vue
+++ b/web/src/views/ServerEnvironment.vue
@@ -74,7 +74,7 @@ const infoSections = computed(() => {
 async function fetchEnvironment() {
   loading.value = true
   try {
-    const res = await serversApi.getEnvironment(Number(props.id))
+    const res = await serversApi.getEnvironment(props.id)
     if (res.data.status === 'success') {
       envInfo.value = res.data.data || null
     }
@@ -92,7 +92,7 @@ async function handleRedetect() {
     // 先获取服务器信息
     const serverRes = await serversApi.list({ page: 1, page_size: 1000 })
     if (serverRes.data.status === 'success') {
-      const found = (serverRes.data.data as Server[]).find((s) => s.id === Number(props.id))
+      const found = (serverRes.data.data as Server[]).find((s) => s.id === props.id)
       if (found) {
         await serversApi.detect(found.id, { host: found.host, port: found.port })
         toast(t('serverEnvironment.detectTriggered'), 'success')
@@ -114,7 +114,7 @@ async function fetchServer() {
   try {
     const res = await serversApi.list({ page: 1, page_size: 1000 })
     if (res.data.status === 'success') {
-      const found = (res.data.data as Server[]).find((s) => s.id === Number(props.id))
+      const found = (res.data.data as Server[]).find((s) => s.id === props.id)
       if (found) {
         serverName.value = found.name
       } else {

--- a/web/src/views/ServerTerminal.vue
+++ b/web/src/views/ServerTerminal.vue
@@ -76,7 +76,7 @@ async function fetchServer() {
   try {
     const res = await serversApi.list({ page: 1, page_size: 1000 })
     if (res.data.status === 'success') {
-      const found = (res.data.data as Server[]).find((s) => s.id === Number(props.id))
+      const found = (res.data.data as Server[]).find((s) => s.id === props.id)
       if (found) {
         serverName.value = found.name
       } else {

--- a/web/src/views/Servers.vue
+++ b/web/src/views/Servers.vue
@@ -40,7 +40,7 @@ const deletingServer = ref<Server | null>(null)
 const deleting = ref(false)
 
 // Testing connection
-const testingId = ref<number | null>(null)
+const testingId = ref<string | null>(null)
 
 // Table columns
 const columns = computed(() => [

--- a/web/src/views/Users.vue
+++ b/web/src/views/Users.vue
@@ -81,7 +81,7 @@ function getUserRoleName(user: User): string {
 }
 
 // Change role
-async function handleChangeRole(user: User, roleId: number) {
+async function handleChangeRole(user: User, roleId: string) {
   try {
     await usersApi.updateRole(user.id, roleId)
     toast(t('users.roleUpdated', { username: user.username }), 'success')

--- a/web/src/views/app-detail/index.vue
+++ b/web/src/views/app-detail/index.vue
@@ -84,7 +84,7 @@ function toggleRealtime(value: boolean) {
 async function loadHistory() {
   loadingHistory.value = true
   try {
-    const res = await appsApi.getLogs(Number(props.id), 500)
+    const res = await appsApi.getLogs(props.id, 500)
     if (res.data.status === 'success') {
       const logText = res.data.data
       if (logText && typeof logText === 'string') {
@@ -116,7 +116,7 @@ const envSaving = ref(false)
 async function fetchEnv() {
   envLoading.value = true
   try {
-    const res = await appsApi.getEnv(Number(props.id))
+    const res = await appsApi.getEnv(props.id)
     if (res.data.status === 'success') {
       const envData = res.data.data || {}
       envList.value = Object.entries(envData).map(([key, value]) => ({
@@ -165,7 +165,7 @@ async function saveEnv() {
         envObject[item.key.trim()] = item.value
       }
     })
-    await appsApi.updateEnv(Number(props.id), { env_vars: JSON.stringify(envObject) })
+    await appsApi.updateEnv(props.id, { env_vars: JSON.stringify(envObject) })
     toast(t('appDetail.envSaved'), 'success')
   } catch (err: any) {
     toast(err.response?.data?.message || t('appDetail.envSaveFailed'), 'destructive')
@@ -202,7 +202,7 @@ const backupColumns = computed(() => [
 async function fetchBackups() {
   backupsLoading.value = true
   try {
-    const res = await appsApi.listBackups(Number(props.id))
+    const res = await appsApi.listBackups(props.id)
     if (res.data.status === 'success') {
       backups.value = res.data.data || []
     }
@@ -216,7 +216,7 @@ async function fetchBackups() {
 async function createBackup() {
   creating.value = true
   try {
-    await appsApi.backup(Number(props.id))
+    await appsApi.backup(props.id)
     toast(t('appDetail.backupCreated'), 'success')
     fetchBackups()
   } catch (err: any) {
@@ -235,7 +235,7 @@ async function confirmRestore() {
   if (!selectedBackup.value) return
   restoring.value = true
   try {
-    await appsApi.restore(Number(props.id), { backup_id: selectedBackup.value.id })
+    await appsApi.restore(props.id, { backup_id: selectedBackup.value.id })
     toast(t('appDetail.backupRestored'), 'success')
     restoreDialogOpen.value = false
   } catch (err: any) {
@@ -254,7 +254,7 @@ async function confirmDelete() {
   if (!selectedBackup.value) return
   deleting.value = true
   try {
-    await appsApi.deleteBackup(Number(props.id), selectedBackup.value.id)
+    await appsApi.deleteBackup(props.id, selectedBackup.value.id)
     toast(t('appDetail.backupDeleted'), 'success')
     deleteDialogOpen.value = false
     fetchBackups()
@@ -278,7 +278,7 @@ const detailTabs = computed(() => [
 async function fetchApp() {
   loading.value = true
   try {
-    const res = await appsApi.get(Number(props.id))
+    const res = await appsApi.get(props.id)
     if (res.data.status === 'success') {
       app.value = res.data.data
     }
@@ -293,7 +293,7 @@ async function fetchApp() {
 async function fetchDeployments() {
   deploymentsLoading.value = true
   try {
-    const res = await deploymentsApi.list(Number(props.id))
+    const res = await deploymentsApi.list(props.id)
     if (res.data.status === 'success') {
       deployments.value = res.data.data
     }

--- a/web/src/views/credentials/CredentialDialog.vue
+++ b/web/src/views/credentials/CredentialDialog.vue
@@ -13,7 +13,7 @@ const { t } = useI18n()
 const props = defineProps<{
   open: boolean
   title: string
-  editingId: number | null
+  editingId: string | null
   formName: string
   formType: string
   formValue: string

--- a/web/src/views/credentials/index.vue
+++ b/web/src/views/credentials/index.vue
@@ -34,7 +34,7 @@ const total = ref(0)
 // Dialog
 const dialogOpen = ref(false)
 const dialogTitle = ref(t('credentials.createTitle'))
-const editingId = ref<number | null>(null)
+const editingId = ref<string | null>(null)
 const formName = ref('')
 const formType = ref('')
 const formValue = ref('')


### PR DESCRIPTION
Follow-up to #756: update all API function params and Vue component refs from number to string for UUID IDs.

Fixes TypeScript errors in 20 files: Apps, Servers, Notifications, Providers, Credentials, Users, Deployments views and their API modules.