### PR TITLE
fix: remaining audit package uint to string type changes

### DIFF
--- a/internal/api/audit_api.go
+++ b/internal/api/audit_api.go
@@ -197,7 +197,7 @@ func GDPRDeleteUserData(c *gin.Context) {
 		return
 	}
 
-	if err := audit.DeleteUserData(globalAuditVerificationAPI.db, uint(uid)); err != nil {
+	if err := audit.DeleteUserData(globalAuditVerificationAPI.db, userIDStr); err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to delete user data")
 		return
 	}

--- a/internal/audit/chain.go
+++ b/internal/audit/chain.go
@@ -12,7 +12,7 @@ import (
 
 // ChainVerificationResult holds the result of verifying a single chain link.
 type ChainVerificationResult struct {
-	RecordID     uint   `json:"record_id"`
+	RecordID     string `json:"record_id"`
 	Valid        bool   `json:"valid"`
 	ExpectedHash string `json:"expected_hash"`
 	ActualHash   string `json:"actual_hash"`
@@ -47,7 +47,7 @@ func (ac *AuditChain) ComputeHash(prevHash string, record *model.AuditLog) strin
 
 // AppendHash stores the hash for a new audit record in the chain.
 // It looks up the previous record's hash to maintain chain continuity.
-func (ac *AuditChain) AppendHash(recordID uint, hash string) error {
+func (ac *AuditChain) AppendHash(recordID string, hash string) error {
 	// Find the previous audit record's hash
 	var prevHash string
 	var prevEntry model.AuditHash
@@ -69,7 +69,7 @@ func (ac *AuditChain) AppendHash(recordID uint, hash string) error {
 }
 
 // GetRecordHash retrieves the stored hash for an audit record.
-func (ac *AuditChain) GetRecordHash(recordID uint) (string, error) {
+func (ac *AuditChain) GetRecordHash(recordID string) (string, error) {
 	var entry model.AuditHash
 	if err := ac.db.Where("audit_id = ?", recordID).First(&entry).Error; err != nil {
 		return "", err
@@ -97,7 +97,7 @@ func (ac *AuditChain) VerifyChain() ([]ChainVerificationResult, error) {
 	}
 
 	// Build a map of auditID -> AuditHash
-	hashMap := make(map[uint]model.AuditHash, len(hashes))
+	hashMap := make(map[string]model.AuditHash, len(hashes))
 	for _, h := range hashes {
 		hashMap[h.AuditID] = h
 	}

--- a/internal/audit/compliance.go
+++ b/internal/audit/compliance.go
@@ -81,7 +81,7 @@ func ExportUserData(db *gorm.DB, userID string) (map[string]interface{}, error) 
 
 // DeleteUserData performs GDPR right-to-be-forgotten by anonymizing user data.
 // Audit logs are preserved but anonymized (username, IP, user agent are cleared).
-func DeleteUserData(db *gorm.DB, userID uint) error {
+func DeleteUserData(db *gorm.DB, userID string) error {
 	// Anonymize audit logs: keep the record but remove personal identifiers
 	result := db.Model(&model.AuditLog{}).
 		Where("user_id = ?", userID).
@@ -89,7 +89,7 @@ func DeleteUserData(db *gorm.DB, userID uint) error {
 			"username":  "[GDPR-DELETED]",
 			"ip_address": "[GDPR-DELETED]",
 			"user_agent": "[GDPR-DELETED]",
-			"user_id":    0,
+			"user_id":    "",
 		})
 	if result.Error != nil {
 		return fmt.Errorf("failed to anonymize audit logs: %w", result.Error)
@@ -121,7 +121,7 @@ func DataRetentionPolicy(db *gorm.DB, cfg *config.AuditConfig) error {
 	}
 
 	// Also clean up associated hash entries for deleted audit logs
-	var deletedAuditIDs []uint
+	var deletedAuditIDs []string
 	if err := db.Model(&model.AuditLog{}).
 		Select("id").
 		Where("created_at < ?", cutoff).

--- a/internal/audit/export.go
+++ b/internal/audit/export.go
@@ -15,8 +15,8 @@ import (
 // AuditExportRecord is an enriched audit log record for export,
 // including hash verification status.
 type AuditExportRecord struct {
-	ID               uint   `json:"id"`
-	UserID           uint   `json:"user_id"`
+	ID               string `json:"id"`
+	UserID           string `json:"user_id"`
 	Username         string `json:"username"`
 	Action           string `json:"action"`
 	ResourceType     string `json:"resource_type"`
@@ -137,13 +137,13 @@ func queryAuditLogs(db *gorm.DB, tenantID string, startTime, endTime time.Time) 
 }
 
 // buildHashMap builds a map of auditID -> hash from the audit_hashes table.
-func buildHashMap(db *gorm.DB) (map[uint]model.AuditHash, error) {
+func buildHashMap(db *gorm.DB) (map[string]model.AuditHash, error) {
 	var hashes []model.AuditHash
 	if err := db.Find(&hashes).Error; err != nil {
 		return nil, fmt.Errorf("failed to query audit hashes: %w", err)
 	}
 
-	hashMap := make(map[uint]model.AuditHash, len(hashes))
+	hashMap := make(map[string]model.AuditHash, len(hashes))
 	for _, h := range hashes {
 		hashMap[h.AuditID] = h
 	}
@@ -151,7 +151,7 @@ func buildHashMap(db *gorm.DB) (map[uint]model.AuditHash, error) {
 }
 
 // enrichExportRecords converts audit logs to export records with verification status.
-func enrichExportRecords(logs []model.AuditLog, hashMap map[uint]model.AuditHash) []AuditExportRecord {
+func enrichExportRecords(logs []model.AuditLog, hashMap map[string]model.AuditHash) []AuditExportRecord {
 	records := make([]AuditExportRecord, 0, len(logs))
 	for _, log := range logs {
 		_, hasChainHash := hashMap[log.ID]

--- a/internal/model/audit_chain.go
+++ b/internal/model/audit_chain.go
@@ -6,7 +6,7 @@ import "time"
 // Each entry links to the previous record, forming a tamper-evident chain.
 type AuditHash struct {
 	ID           uint      `gorm:"primaryKey" json:"id"`
-	AuditID      uint      `gorm:"uniqueIndex;not null" json:"audit_id"`
+	AuditID      string    `gorm:"uniqueIndex;not null;size:36" json:"audit_id"`
 	Hash         string    `gorm:"size:128;not null" json:"hash"`
 	PreviousHash string    `gorm:"size:128" json:"previous_hash"`
 	CreatedAt    time.Time `gorm:"autoCreateTime" json:"created_at"`

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -85,7 +85,7 @@ func TestAuditService_List(t *testing.T) {
 	// Create multiple entries
 	for i := uint(0); i < 5; i++ {
 		_ = svc.Record(context.TODO(), AuditEntry{
-			UserID:   i,
+			UserID:   fmt.Sprintf("user-%d", i),
 			Username: "user",
 			Action:   "app.create",
 		})
@@ -190,7 +190,7 @@ func TestAuditService_RecordWithNilDetail(t *testing.T) {
 	svc := NewAuditService(db)
 
 	err := svc.Record(context.TODO(), AuditEntry{
-		UserID: 1,
+		UserID: "1",
 		Action: "app.create",
 		Detail: nil,
 	})
@@ -270,7 +270,7 @@ func TestAuditService_VerifyRecord(t *testing.T) {
 	svc := NewAuditService(db)
 
 	_ = svc.Record(context.TODO(), AuditEntry{
-		UserID: 1, Username: "test", Action: "app.create",
+		UserID: "1", Username: "test", Action: "app.create",
 		ResourceType: "app", ResourceID: "1", IPAddress: "1.2.3.4",
 	})
 


### PR DESCRIPTION
Fix Go build errors in audit/chain.go, audit/export.go, compliance.go, audit_chain.go, audit_api.go, and audit_test.go.