### PR TITLE
fix: all remaining uint/string type errors across codebase

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -92,14 +92,14 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS audit_logs (
-		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT,
+		id TEXT PRIMARY KEY, user_id TEXT, username TEXT,
 		action TEXT, resource_type TEXT, resource_id TEXT, detail TEXT,
 		ip_address TEXT, user_agent TEXT, record_hash TEXT,
 		trace_id TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS audit_hashes (
-		id INTEGER PRIMARY KEY AUTOINCREMENT, audit_id INTEGER UNIQUE NOT NULL,
+		id INTEGER PRIMARY KEY AUTOINCREMENT, audit_id TEXT UNIQUE NOT NULL,
 		hash TEXT NOT NULL, previous_hash TEXT,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	)`)

--- a/internal/api/audit_api.go
+++ b/internal/api/audit_api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/audit"
@@ -54,7 +53,7 @@ func VerifyAuditChain(c *gin.Context) {
 
 	validCount := 0
 	invalidCount := 0
-	var failedIDs []uint
+	var failedIDs []string
 	for _, r := range results {
 		if r.Valid {
 			validCount++
@@ -191,12 +190,6 @@ func GDPRDeleteUserData(c *gin.Context) {
 		return
 	}
 
-	uid, err := strconv.ParseUint(userIDStr, 10, 64)
-	if err != nil {
-		respondErrori18n(c, http.StatusBadRequest, "error.common.invalid_request", "invalid user_id")
-		return
-	}
-
 	if err := audit.DeleteUserData(globalAuditVerificationAPI.db, userIDStr); err != nil {
 		respondError(c, http.StatusInternalServerError, "failed to delete user data")
 		return
@@ -204,7 +197,7 @@ func GDPRDeleteUserData(c *gin.Context) {
 
 	respondSuccess(c, gin.H{
 		"message": "user data anonymized successfully",
-		"user_id": uid,
+		"user_id": userIDStr,
 	})
 }
 

--- a/internal/api/audit_enhanced.go
+++ b/internal/api/audit_enhanced.go
@@ -123,9 +123,7 @@ func buildAuditFilter(c *gin.Context) service.AuditFilter {
 	filter := service.AuditFilter{}
 
 	if v := c.Query("user_id"); v != "" {
-		if uid, err := strconv.ParseUint(v, 10, 64); err == nil {
-			filter.UserID = uint(uid)
-		}
+		filter.UserID = v
 	}
 	filter.Username = c.Query("username")
 	filter.Action = c.Query("action")

--- a/internal/api/backups.go
+++ b/internal/api/backups.go
@@ -85,8 +85,7 @@ func ListAuditLogs(auditSvc *service.AuditService) gin.HandlerFunc {
 			PageSize: pageSize,
 		}
 		if userID := c.Query("user_id"); userID != "" {
-			uid, _ := strconv.ParseUint(userID, 10, 64)
-			filter.UserID = uint(uid)
+			filter.UserID = userID
 		}
 		if action := c.Query("action"); action != "" {
 			filter.Action = action

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -3,7 +3,6 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
@@ -262,8 +261,7 @@ func RotateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gi
 	}
 }
 
-// parseUserID converts a string user ID to uint for audit logging.
-func parseUserID(s string) uint {
-	n, _ := strconv.ParseUint(s, 10, 64)
-	return uint(n)
+// parseUserID returns the string user ID as-is (IDs are now UUID strings).
+func parseUserID(s string) string {
+	return s
 }

--- a/internal/api/plugins_test.go
+++ b/internal/api/plugins_test.go
@@ -47,7 +47,7 @@ func setupPluginTestDB(t *testing.T) *gorm.DB {
 		UNIQUE(tenant_id, name)
 	)`)
 	db.Exec(`CREATE TABLE IF NOT EXISTS audit_logs (
-		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT,
+		id TEXT PRIMARY KEY, user_id TEXT, username TEXT,
 		action TEXT, resource_type TEXT, resource_id TEXT, detail TEXT,
 		ip_address TEXT, user_agent TEXT, record_hash TEXT,
 		trace_id TEXT,

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -180,11 +180,11 @@ func ListLoginHistory(auditSvc *service.AuditService) gin.HandlerFunc {
 			pageSize = 20
 		}
 
-		// Parse user ID to uint for audit filter
-		uidUint := parseUserID(uid)
+		// Get user ID string for audit filter
+		uidStr := parseUserID(uid)
 
 		logs, total, err := auditSvc.List(c.Request.Context(), service.AuditFilter{
-			UserID:   uidUint,
+			UserID:   uidStr,
 			Action:   "user.login",
 			Page:     page,
 			PageSize: pageSize,

--- a/internal/audit/chain.go
+++ b/internal/audit/chain.go
@@ -34,7 +34,7 @@ func NewAuditChain(db *gorm.DB, secretKey []byte) *AuditChain {
 // ComputeHash computes an HMAC-SHA256 hash for a chain link.
 // The hash is derived from prevHash + record.ID + record.Action + record.Timestamp.
 func (ac *AuditChain) ComputeHash(prevHash string, record *model.AuditLog) string {
-	data := fmt.Sprintf("%s|%d|%s|%s",
+	data := fmt.Sprintf("%s|%s|%s|%s",
 		prevHash,
 		record.ID,
 		record.Action,

--- a/internal/audit/export.go
+++ b/internal/audit/export.go
@@ -61,8 +61,8 @@ func ExportCSV(db *gorm.DB, tenantID string, startTime, endTime time.Time) (io.R
 
 	for _, r := range records {
 		row := []string{
-			fmt.Sprintf("%d", r.ID),
-			fmt.Sprintf("%d", r.UserID),
+			r.ID,
+			r.UserID,
 			r.Username,
 			r.Action,
 			r.ResourceType,

--- a/internal/middleware/audit_test.go
+++ b/internal/middleware/audit_test.go
@@ -18,7 +18,7 @@ func setupAuditTestDB(t *testing.T) *gorm.DB {
 		t.Fatal(err)
 	}
 	db.Exec(`CREATE TABLE IF NOT EXISTS audit_logs (
-		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT,
+		id TEXT PRIMARY KEY, user_id TEXT, username TEXT,
 		action TEXT, resource_type TEXT, resource_id TEXT, detail TEXT,
 		log_type TEXT DEFAULT 'operation',
 		ip_address TEXT, user_agent TEXT, record_hash TEXT,

--- a/internal/service/audit_test.go
+++ b/internal/service/audit_test.go
@@ -18,7 +18,7 @@ func setupAuditTestDB(t *testing.T) *gorm.DB {
 		t.Fatal(err)
 	}
 	db.Exec(`CREATE TABLE IF NOT EXISTS audit_logs (
-		id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, username TEXT,
+		id TEXT PRIMARY KEY, user_id TEXT, username TEXT,
 		action TEXT, resource_type TEXT, resource_id TEXT, detail TEXT,
 		log_type TEXT DEFAULT 'operation',
 		ip_address TEXT, user_agent TEXT, record_hash TEXT,


### PR DESCRIPTION
- parseUserID returns string instead of uint
- Remove all uint(uid) conversions
- Fix fmt.Sprintf %d to %s for string IDs
- Fix test SQL schemas for TEXT primary keys