### PR TITLE
fix: gitee sync download artifact with merge-multiple

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,8 +182,8 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
-          name: binaries
-          path: dist
+          path: dist/
+          merge-multiple: true
 
       - name: Delete old Gitee releases
         env:


### PR DESCRIPTION
Artifact name is binaries-linux-amd64/arm64, not binaries.