### PR TITLE
fix(security): elevate audit log write failures from Warn to Error

### DIFF
--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -106,7 +106,7 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 				ResourceID:   apiKey.ID,
 				Detail:       map[string]string{"name": input.Name, "prefix": apiKey.KeyPrefix},
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -157,7 +157,7 @@ func DeleteAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 				ResourceType: "apikey",
 				ResourceID:   keyID,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -279,7 +279,7 @@ func UpdateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 				ResourceType: "apikey",
 				ResourceID:   keyID,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -229,7 +229,7 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 				IPAddress:    c.ClientIP(),
 				UserAgent:    c.GetHeader("User-Agent"),
 			}); err != nil {
-				slog.Warn("failed to record audit log", "error", err)
+				slog.Error("failed to record audit log", "error", err)
 			}
 		}
 
@@ -463,7 +463,7 @@ func Login(db *gorm.DB, bf *bruteforce.Protector) gin.HandlerFunc {
 				IPAddress:    c.ClientIP(),
 				UserAgent:    c.GetHeader("User-Agent"),
 			}); err != nil {
-				slog.Warn("failed to record audit log", "error", err)
+				slog.Error("failed to record audit log", "error", err)
 			}
 		}
 

--- a/internal/api/twofa.go
+++ b/internal/api/twofa.go
@@ -90,7 +90,7 @@ func Verify2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 				ResourceType: "user",
 				ResourceID:   user.ID,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -169,7 +169,7 @@ func Setup2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 				ResourceType: "user",
 				ResourceID:   uid,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -239,7 +239,7 @@ func Confirm2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 				ResourceType: "user",
 				ResourceID:   uid,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -311,7 +311,7 @@ func Disable2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 				ResourceType: "user",
 				ResourceID:   uid,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -388,7 +388,7 @@ func RegenerateBackupCodes(db *gorm.DB, auditSvc *service.AuditService) gin.Hand
 				ResourceType: "user",
 				ResourceID:   uid,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 
@@ -488,7 +488,7 @@ func ResetUser2FA(db *gorm.DB, auditSvc *service.AuditService) gin.HandlerFunc {
 				ResourceID:   targetUserID,
 				Detail:       "admin reset 2FA for user " + user.Username,
 			}); err != nil {
-				slog.WarnContext(c.Request.Context(), "failed to record audit log", "error", err)
+				slog.ErrorContext(c.Request.Context(), "failed to record audit log", "error", err)
 			}
 		}
 


### PR DESCRIPTION
## Description

Audit log write failures are critical security events but were logged at `slog.Warn` level, making them easy to miss in production.

## Changes

- Replace `slog.Warn` → `slog.Error` in `auth.go` (2 occurrences)
- Replace `slog.WarnContext` → `slog.ErrorContext` in `twofa.go` (6 occurrences)
- Replace `slog.WarnContext` → `slog.ErrorContext` in `apikeys.go` (3 occurrences)

## Type of Change
- [x] security

## Related Issue

Fixes #663

## Testing

- [x] `make test` passes
- [x] `make lint` passes

## Checklist
- [x] No modification to version.go
- [x] Commit message follows Conventional Commits