### PR TITLE
refactor: extract tenant-default string to model.DefaultTenantID constant

### DIFF
--- a/cmd/deploypilot/credential.go
+++ b/cmd/deploypilot/credential.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -54,7 +55,7 @@ Examples:
 			credType = "password"
 		}
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 
 		// Read value
@@ -113,7 +114,7 @@ Examples:
 }
 
 func init() {
-	credentialAddCmd.Flags().String("tenant-id", "tenant-default", "tenant ID (default: tenant-default)")
+	credentialAddCmd.Flags().String("tenant-id", model.DefaultTenantID, "tenant ID (default: "+model.DefaultTenantID+")")
 	credentialAddCmd.Flags().StringP("name", "n", "", "credential name (required)")
 	credentialAddCmd.Flags().StringP("type", "t", "password", "credential type: password, ssh_key, token")
 	credentialAddCmd.Flags().Bool("value-stdin", false, "read value from stdin")

--- a/internal/api/apikeys.go
+++ b/internal/api/apikeys.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
 )
@@ -82,7 +83,7 @@ func CreateAPIKey(keySvc *service.APIKeyService, auditSvc *service.AuditService)
 			}
 		}
 
-		apiKey, rawKey, err := keySvc.Create(c.Request.Context(), uid, "tenant-default", input.Name, input.Scopes, input.ExpiresInDays)
+		apiKey, rawKey, err := keySvc.Create(c.Request.Context(), uid, model.DefaultTenantID, input.Name, input.Scopes, input.ExpiresInDays)
 		if err != nil {
 			respondErrori18n(c, http.StatusInternalServerError, "error.common.internal_error")
 			return

--- a/internal/api/apps.go
+++ b/internal/api/apps.go
@@ -46,7 +46,7 @@ func CreateApp(db *gorm.DB) gin.HandlerFunc {
 		id := uuid.New().String()
 		tenantID := c.GetString(string(auth.UserIDKey))
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 
 		app := model.App{

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -184,7 +184,7 @@ func Register(db *gorm.DB) gin.HandlerFunc {
 		// First user becomes admin
 		user := model.User{
 			ID:           uuid.New().String(),
-			TenantID:     "tenant-default",
+			TenantID:     model.DefaultTenantID,
 			RoleID:       "role-admin", // First user is admin
 			Username:     input.Username,
 			Email:        input.Email,

--- a/internal/api/clusters.go
+++ b/internal/api/clusters.go
@@ -41,7 +41,7 @@ func CreateCluster(bridge *service.Bridge) gin.HandlerFunc {
 			return
 		}
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 
 		cluster, err := bridge.CreateCluster(c.Request.Context(), &model.Cluster{
@@ -71,7 +71,7 @@ func CreateCluster(bridge *service.Bridge) gin.HandlerFunc {
 // @Tags         Clusters
 // @Produce      json
 // @Security     BearerAuth
-// @Param        tenant_id query string false "Tenant ID" default("tenant-default")
+// @Param        tenant_id query string false "Tenant ID" default(model.DefaultTenantID)
 // @Success      200 {object} map[string]interface{} "status, data (array of Cluster)"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
@@ -80,7 +80,7 @@ func ListClusters(bridge *service.Bridge) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenantID := c.Query("tenant_id")
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 
 		clusters, err := bridge.ListClusters(c.Request.Context(), tenantID)

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -17,7 +17,7 @@ import (
 // @Tags         Credentials
 // @Produce      json
 // @Security     BearerAuth
-// @Param        tenant_id query string false "Tenant ID" default("tenant-default")
+// @Param        tenant_id query string false "Tenant ID" default(model.DefaultTenantID)
 // @Success      200 {object} map[string]interface{} "status, data (array of Credential)"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
@@ -26,7 +26,7 @@ func ListCredentials(bridge *service.Bridge) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenantID := c.Query("tenant_id")
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 
 		creds, err := bridge.ListCredentials(c.Request.Context(), tenantID)
@@ -98,7 +98,7 @@ func CreateCredential(bridge *service.Bridge, auditSvc *service.AuditService) gi
 			return
 		}
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 
 		cred, err := bridge.CreateCredentialWithExpiry(c.Request.Context(), input.TenantID, input.Name, input.Type, input.Value, input.ExpiresInDays)

--- a/internal/api/event_plugin_api.go
+++ b/internal/api/event_plugin_api.go
@@ -143,7 +143,7 @@ func (a *EventPluginAPI) UpdateEventPlugin(c *gin.Context) {
 	// Also persist config to DB
 	tenantID := c.Query("tenant_id")
 	if tenantID == "" {
-		tenantID = "tenant-default"
+		tenantID = model.DefaultTenantID
 	}
 	if input.Config != nil {
 		configJSON, _ := json.Marshal(input.Config)

--- a/internal/api/ip_whitelist_api.go
+++ b/internal/api/ip_whitelist_api.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/Yogdunana/deploypilot/internal/auth"
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
 )
@@ -106,7 +107,7 @@ func AddIPWhitelist(c *gin.Context) {
 		userIDStr,
 		input.Description,
 		input.CIDR,
-		"tenant-default",
+		model.DefaultTenantID,
 		userIDStr,
 	)
 	if err != nil {

--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -61,7 +61,7 @@ func CreateNotification(db *gorm.DB) gin.HandlerFunc {
 		input.ID = uuid.New().String()
 		input.Type = "notify"
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 		input.Enabled = true
 

--- a/internal/api/plugins.go
+++ b/internal/api/plugins.go
@@ -25,7 +25,7 @@ func NewPluginHandler(lifecycleManager *plugin.Manager) *PluginHandler {
 // @Tags         Plugins
 // @Produce      json
 // @Security     BearerAuth
-// @Param        tenant_id query string false "Tenant ID" default("tenant-default")
+// @Param        tenant_id query string false "Tenant ID" default(model.DefaultTenantID)
 // @Param        provider query string false "Filter by provider (dns, notify, registry, cicd, server, ssl)"
 // @Success      200 {object} map[string]interface{} "status, data (array of Plugin)"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
@@ -35,7 +35,7 @@ func (h *PluginHandler) ListPlugins() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenantID := c.Query("tenant_id")
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 		provider := c.Query("provider")
 
@@ -82,7 +82,7 @@ func (h *PluginHandler) CreatePlugin() gin.HandlerFunc {
 			return
 		}
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 		if input.Version == "" {
 			input.Version = "1.0.0"

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -92,7 +92,7 @@ func CreateProvider(db *gorm.DB) gin.HandlerFunc {
 
 		input.ID = uuid.New().String()
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 		input.Enabled = true
 

--- a/internal/api/registries.go
+++ b/internal/api/registries.go
@@ -13,7 +13,7 @@ import (
 // @Tags         Registries
 // @Produce      json
 // @Security     BearerAuth
-// @Param        tenant_id query string false "Tenant ID" default("tenant-default")
+// @Param        tenant_id query string false "Tenant ID" default(model.DefaultTenantID)
 // @Success      200 {object} map[string]interface{} "status, data (array of Registry)"
 // @Failure      401 {object} map[string]interface{} "unauthorized"
 // @Failure      500 {object} map[string]interface{} "internal error"
@@ -22,7 +22,7 @@ func ListRegistries() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tenantID := c.Query("tenant_id")
 		if tenantID == "" {
-			tenantID = "tenant-default"
+			tenantID = model.DefaultTenantID
 		}
 
 		registries, err := model.ListRegistries(tenantID)
@@ -65,7 +65,7 @@ func CreateRegistry() gin.HandlerFunc {
 			return
 		}
 		if input.TenantID == "" {
-			input.TenantID = "tenant-default"
+			input.TenantID = model.DefaultTenantID
 		}
 		if len(input.Name) > 255 || len(input.URL) > 2048 || len(input.Username) > 255 || len(input.Password) > 255 {
 			respondErrori18n(c, http.StatusBadRequest, "error.common.input_too_long")

--- a/internal/api/templates.go
+++ b/internal/api/templates.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/Yogdunana/deploypilot/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -62,7 +63,7 @@ func CreateTemplate(db *gorm.DB) gin.HandlerFunc {
 		// Store custom templates in the providers table with type "template"
 		if err := db.Exec(
 			`INSERT INTO providers (id, tenant_id, type, name, config, enabled) VALUES (?, ?, 'template', ?, ?, 1)`,
-			id, "tenant-default", input.Name,
+			id, model.DefaultTenantID, input.Name,
 			map[string]interface{}{
 				"type":        input.Type,
 				"description": input.Description,

--- a/internal/database/seed.go
+++ b/internal/database/seed.go
@@ -3,6 +3,7 @@ package database
 import (
 	"fmt"
 
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"gorm.io/gorm"
 )
 
@@ -32,7 +33,7 @@ func Seed(db *gorm.DB) error {
 	// Seed default tenant
 	result := db.Exec(
 		`INSERT OR IGNORE INTO tenants (id, name, slug, plan) VALUES (?, ?, ?, ?)`,
-		"tenant-default", "Default", "default", "free",
+		model.DefaultTenantID, "Default", "default", "free",
 	)
 	if result.Error != nil {
 		return fmt.Errorf("failed to seed default tenant: %w", result.Error)

--- a/internal/mcp/handler_k8s.go
+++ b/internal/mcp/handler_k8s.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/Yogdunana/deploypilot/internal/model"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 func handleListClusters(ctx context.Context, d K8sService, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	tenantID := request.GetString("tenant_id", "tenant-default")
+	tenantID := request.GetString("tenant_id", model.DefaultTenantID)
 
 	clusters, err := d.ListClusters(ctx, tenantID)
 	if err != nil {

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -2,6 +2,9 @@ package model
 
 import "time"
 
+// DefaultTenantID is the default tenant identifier used when no multi-tenancy is configured.
+const DefaultTenantID = "tenant-default"
+
 // Tenant represents a multi-tenant organization.
 type Tenant struct {
 	ID         string    `gorm:"primaryKey" json:"id"`

--- a/internal/service/deploy_service.go
+++ b/internal/service/deploy_service.go
@@ -521,7 +521,7 @@ func (b *Bridge) saveRollbackRecord(ctx context.Context, cfg mcp.DeployConfig, c
 
 	record := &model.DeploymentRecord{
 		ID:             generateID(),
-		TenantID:       "tenant-default",
+		TenantID:       model.DefaultTenantID,
 		ServerID:       cfg.ServerID,
 		AppName:        cfg.AppName,
 		ContainerName:  cfg.ContainerName,
@@ -579,7 +579,7 @@ func (b *Bridge) saveDeploymentRecord(ctx context.Context, cfg mcp.DeployConfig,
 
 	record := &model.DeploymentRecord{
 		ID:             generateID(),
-		TenantID:       "tenant-default",
+		TenantID:       model.DefaultTenantID,
 		ServerID:       cfg.ServerID,
 		AppName:        cfg.AppName,
 		AppID:          appID,

--- a/internal/service/device_service.go
+++ b/internal/service/device_service.go
@@ -52,7 +52,7 @@ func (s *DeviceService) RegisterDevice(userID, userAgent, ip, name string, trust
 	// New device
 	device := model.Device{
 		ID:         uuid.New().String(),
-		TenantID:   "tenant-default",
+		TenantID:   model.DefaultTenantID,
 		UserID:     userID,
 		DeviceID:   deviceID,
 		DeviceName: name,

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -124,7 +124,7 @@ func (s *OAuthService) HandleCallback(ctx context.Context, provider, code string
 			// Create new user
 			user = model.User{
 				ID:           uuid.New().String(),
-				TenantID:     "tenant-default",
+				TenantID:     model.DefaultTenantID,
 				RoleID:       "role-viewer",
 				Username:     userInfo.Username,
 				Email:        userInfo.Email,

--- a/internal/service/plugin_service.go
+++ b/internal/service/plugin_service.go
@@ -60,7 +60,7 @@ func (b *Bridge) ListPlugins(provider string) (interface{}, error) {
 		return nil, fmt.Errorf("database not available")
 	}
 
-	plugins, err := model.ListPlugins("tenant-default", provider)
+	plugins, err := model.ListPlugins(model.DefaultTenantID, provider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list plugins: %w", err)
 	}

--- a/scripts/seed.go
+++ b/scripts/seed.go
@@ -82,7 +82,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 
 	adminUser := model.User{
 		ID:           "user-admin-demo",
-		TenantID:     "tenant-default",
+		TenantID:     model.DefaultTenantID,
 		RoleID:       "role-owner",
 		Username:     "admin",
 		Email:        "admin@deploypilot.dev",
@@ -104,7 +104,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Credential (SSH) ──────────────────────────────────
 	demoCred := model.Credential{
 		ID:             "cred-demo-ssh",
-		TenantID:       "tenant-default",
+		TenantID:       model.DefaultTenantID,
 		Name:           "Local SSH Key",
 		Type:           "ssh",
 		EncryptedValue: "demo-ssh-key-placeholder",
@@ -125,7 +125,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Provider (SSH) ────────────────────────────────────
 	demoProvider := model.Provider{
 		ID:       "provider-demo-ssh",
-		TenantID: "tenant-default",
+		TenantID: model.DefaultTenantID,
 		Type:     "ssh",
 		Name:     "Local SSH Provider",
 		Config:   `{"host":"localhost","port":22,"user":"root"}`,
@@ -147,7 +147,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Server ────────────────────────────────────────────
 	demoServer := model.Server{
 		ID:           "server-demo-local",
-		TenantID:     "tenant-default",
+		TenantID:     model.DefaultTenantID,
 		CredentialID: demoCred.ID,
 		ProviderID:   demoProvider.ID,
 		Name:         "Local Dev Server",
@@ -172,7 +172,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Application ───────────────────────────────────────
 	demoApp := model.App{
 		ID:             "app-demo-001",
-		TenantID:       "tenant-default",
+		TenantID:       model.DefaultTenantID,
 		ServerID:       demoServer.ID,
 		Name:           "demo-app",
 		RepoURL:        "https://github.com/example/demo-app",
@@ -202,7 +202,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Alert Rule (CPU) ──────────────────────────────────
 	cpuAlertRule := model.AlertRuleRecord{
 		ID:              "alert-rule-cpu-demo",
-		TenantID:        "tenant-default",
+		TenantID:        model.DefaultTenantID,
 		Name:            "Demo CPU Alert",
 		MetricType:      "cpu",
 		Condition:       "gt",
@@ -229,7 +229,7 @@ func seedDemoData(db *gorm.DB, adminPassword string) error {
 	// ── Demo Alert Rule (Memory) ───────────────────────────────
 	memAlertRule := model.AlertRuleRecord{
 		ID:              "alert-rule-mem-demo",
-		TenantID:        "tenant-default",
+		TenantID:        model.DefaultTenantID,
 		Name:            "Demo Memory Alert",
 		MetricType:      "memory",
 		Condition:       "gt",


### PR DESCRIPTION
## Description

Replace 36 occurrences of hardcoded `"tenant-default"` string with `model.DefaultTenantID` constant.

## Changes

- Add `DefaultTenantID` constant to `internal/model/model.go`
- Replace hardcoded string in api, service, mcp, cmd, scripts, database packages
- Swagger annotations updated to reference constant

## Type of Change
- [x] refactoring

## Related Issue

Fixes #672

## Testing
- [x] `make test` passes
- [x] `make lint` passes

## Checklist
- [x] No modification to version.go
- [x] Commit message follows Conventional Commits