### PR TITLE
fix(security): log warning when audit service is nil at startup

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -142,6 +142,8 @@ func New(addr string, db *gorm.DB, bridge *service.Bridge, cfg *config.Config, b
 	// Set audit service for auth event logging
 	if auditSvc != nil {
 		api.SetAuditServiceForAuth(auditSvc)
+	} else {
+		slog.Warn("audit service is nil, auth event logging will be disabled")
 	}
 
 	// Initialize refresh token store


### PR DESCRIPTION
## Description

If the audit service fails to initialize, auth event logging is silently disabled with no indication to operators.

## Changes

- Add explicit `slog.Warn` when audit service is nil during server startup
- Ensures misconfiguration is visible in logs

## Type of Change
- [x] security

## Related Issue

Fixes #670

## Testing
- [x] `make lint` passes
- [x] No behavior change when audit service is properly initialized

## Checklist
- [x] No modification to version.go
- [x] Commit message follows Conventional Commits