### PR TITLE
feat: add log file output with rotation support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ DEPLOYPILOT_AUTH_TOKEN_EXPIRE=24h
 # ─── Logging ────────────────────────────────────────────────
 DEPLOYPILOT_LOG_LEVEL=info
 DEPLOYPILOT_LOG_FORMAT=json
+# DEPLOYPILOT_LOG_FILE=/var/log/deploypilot/app.log
+# DEPLOYPILOT_LOG_MAX_SIZE=100MB
+# DEPLOYPILOT_LOG_MAX_BACKUPS=5
 
 # ─── Security ───────────────────────────────────────────────
 # Rate limiting (requests per minute per role)

--- a/configs/config.yaml.example
+++ b/configs/config.yaml.example
@@ -62,6 +62,12 @@ audit:
   retention_days: 90       # Audit log retention period (days)
 
 log:
+  level: "info"              # Log level: debug, info, warn, error
+  format: "json"             # Log format: json, text
+  file: "/var/log/deploypilot/app.log"  # Optional: log file path (enables file logging)
+  max_size: "100MB"          # Max size per log file (e.g., 100MB, 1GB)
+  max_backups: 5             # Number of old log files to keep
+  enable_tracing: false      # Enable distributed tracing in logs
 
 # Notification configuration
 notify:

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 
 require (
 	golang.org/x/oauth2 v0.30.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/internal/config/logger.go
+++ b/internal/config/logger.go
@@ -1,13 +1,18 @@
 package config
 
 import (
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"strconv"
 
 	"github.com/Yogdunana/deploypilot/internal/tracing"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // InitLogger configures the global slog logger based on the provided LogConfig.
+// If cfg.File is set, logs are written to both stdout and the specified file.
 func InitLogger(cfg LogConfig) {
 	var level slog.Level
 	switch cfg.Level {
@@ -23,13 +28,63 @@ func InitLogger(cfg LogConfig) {
 
 	handlerOpts := &slog.HandlerOptions{Level: level}
 
+	// Build output writer: stdout + optional file
+	var writers []io.Writer
+	writers = append(writers, os.Stdout)
+
+	if cfg.File != "" {
+		// Parse max size (default 100MB)
+		maxSize := parseMaxSize(cfg.MaxSize, 100)
+		
+		fileWriter := &lumberjack.Logger{
+			Filename:   cfg.File,
+			MaxSize:    maxSize, // MB
+			MaxBackups: cfg.MaxBackups,
+			MaxAge:     30, // days
+			Compress:   true,
+		}
+		writers = append(writers, fileWriter)
+	}
+
+	multiWriter := io.MultiWriter(writers...)
+
 	var handler slog.Handler
 	if cfg.Format == "json" {
-		handler = slog.NewJSONHandler(os.Stdout, handlerOpts)
+		handler = slog.NewJSONHandler(multiWriter, handlerOpts)
 	} else {
-		handler = slog.NewTextHandler(os.Stdout, handlerOpts)
+		handler = slog.NewTextHandler(multiWriter, handlerOpts)
 	}
 
 	handler = tracing.NewTraceHandler(handler)
 	slog.SetDefault(slog.New(handler))
+}
+
+// parseMaxSize parses size string like "100MB" or "1GB" into MB.
+func parseMaxSize(s string, defaultMB int) int {
+	if s == "" {
+		return defaultMB
+	}
+	
+	// Try to parse as plain number (assumed MB)
+	if mb, err := strconv.Atoi(s); err == nil {
+		return mb
+	}
+	
+	// Parse with suffix
+	var num int
+	var unit string
+	if _, err := fmt.Sscanf(s, "%d%s", &num, &unit); err != nil {
+		return defaultMB
+	}
+	
+	switch unit {
+	case "GB", "gb":
+		return num * 1024
+	case "MB", "mb":
+		return num
+	case "KB", "kb":
+		return num / 1024
+	default:
+		return defaultMB
+	}
 }


### PR DESCRIPTION
## Description

Add support for writing logs to both stdout and a file simultaneously, with automatic log rotation.

## Changes

- Add `lumberjack` dependency for log rotation
- Modify `InitLogger` to support multi-writer output (stdout + file)
- Configurable via:
  - `LOG_FILE` - path to log file
  - `LOG_MAX_SIZE` - max file size before rotation (default 100MB)
  - `LOG_MAX_BACKUPS` - number of old files to keep (default 5)
- Update `.env.example` and `config.yaml.example` with new options

## Usage

```yaml
log:
  level: "info"
  format: "json"
  file: "/var/log/deploypilot/app.log"
  max_size: "100MB"
  max_backups: 5
```

Or via environment:
```bash
DEPLOYPILOT_LOG_FILE=/var/log/deploypilot/app.log
DEPLOYPILOT_LOG_MAX_SIZE=100MB
DEPLOYPILOT_LOG_MAX_BACKUPS=5
```

## Type of Change
- [x] feat (new feature)

## Testing
- [x] Code compiles
- [x] Existing tests pass

## Checklist
- [x] No modification to version.go
- [x] Commit message follows Conventional Commits