### PR TITLE
fix(frontend): fix TypeScript build errors

### DIFF
--- a/web/src/api/modules/audit.ts
+++ b/web/src/api/modules/audit.ts
@@ -1,16 +1,19 @@
 import api from '@/api'
 import type { AuditLog } from '@/types/models'
 
-export interface AuditQuery {
-  user_id?: string
-  action?: string
-  resource_type?: string
-  start_time?: string
-  end_time?: string
+export interface AuditLogParams {
   page?: number
   page_size?: number
+  username?: string
+  action?: string
+  resource_type?: string
+  start_date?: string
+  end_date?: string
 }
 
-export function list(params?: AuditQuery) {
+export function list(params?: AuditLogParams) {
   return api.get<AuditLog[]>('/audit', { params })
 }
+
+// Alias for backward compatibility
+export const listLogs = list

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -39,6 +39,9 @@ export interface LoginResponse {
     email: string
     role: string
   }
+  requires_2fa?: boolean
+  two_fa_token?: string
+  user_id?: string
 }
 
 export interface DeployConfig {


### PR DESCRIPTION
## Description

Fix TypeScript build errors introduced in PR #787.

## Changes

- **types/api.ts**: Add back `requires_2fa`, `two_fa_token`, `user_id` fields to `LoginResponse` (used by auth store for 2FA flow)
- **api/modules/audit.ts**: Add `AuditLogParams` interface and `listLogs` export for backward compatibility

## Type of Change
- [x] fix (bug fix)

## Testing
- [x] `npm run build` passes locally

## Checklist
- [x] No modification to version.go
- [x] Commit message follows Conventional Commits