### PR TITLE
fix(frontend): fix audit API return type

### DIFF
--- a/web/src/api/modules/audit.ts
+++ b/web/src/api/modules/audit.ts
@@ -1,5 +1,6 @@
 import api from '@/api'
 import type { AuditLog } from '@/types/models'
+import type { ApiResponse, PaginatedResponse } from '@/types/api'
 
 export interface AuditLogParams {
   page?: number
@@ -12,7 +13,7 @@ export interface AuditLogParams {
 }
 
 export function list(params?: AuditLogParams) {
-  return api.get<AuditLog[]>('/audit', { params })
+  return api.get<ApiResponse<PaginatedResponse<AuditLog>>>('/audit', { params })
 }
 
 // Alias for backward compatibility

--- a/web/src/views/Audit.vue
+++ b/web/src/views/Audit.vue
@@ -81,8 +81,8 @@ async function fetchLogs() {
     if (filterEndDate.value) params.end_date = filterEndDate.value
     const res = await auditApi.listLogs(params)
     if (res.data.status === 'success') {
-      logs.value = res.data.data
-      total.value = res.data.pagination?.total || 0
+      logs.value = res.data.data.data
+      total.value = res.data.data.pagination?.total || 0
     }
   } catch (err: any) {
     toast(err.response?.data?.message || t('audit.fetchFailed'), 'destructive')

--- a/web/src/views/credentials/index.vue
+++ b/web/src/views/credentials/index.vue
@@ -193,7 +193,7 @@ async function fetchDetailAudit(item: any) {
   try {
     const res = await auditApi.listLogs({ resource_type: 'credential', page: 1, page_size: 10 })
     if (res.data.status === 'success') {
-      detailAuditLogs.value = res.data.data.filter(
+      detailAuditLogs.value = res.data.data.data.filter(
         (log: any) => log.detail?.includes(item.name) || String(log.resource_id) === String(item.id)
       )
     }


### PR DESCRIPTION
## Description

Fix audit API return type to match component expectations.

## Changes

- **api/modules/audit.ts**: Change return type to `ApiResponse<PaginatedResponse<AuditLog>>`
- **views/Audit.vue**: Access `res.data.data.data` for logs array
- **views/credentials/index.vue**: Access `res.data.data.data` for logs array

## Type of Change
- [x] fix (bug fix)

## Testing
- [x] TypeScript compilation passes

## Checklist
- [x] No modification to version.go