### PR TITLE
fix: improve Gitee sync and install script reliability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
     needs: [build-binaries, create-release]
     if: always() && needs.create-release.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -197,17 +197,50 @@ jobs:
               "https://gitee.com/api/v5/repos/Yogdunana/deploypilot/releases/$release_id"
           done
 
-      - name: Sync Release to Gitee
-        uses: nicennnnnnnlee/action-gitee-release@master
-        with:
-          gitee_action: create_release
-          gitee_owner: Yogdunana
-          gitee_repo: deploypilot
-          gitee_token: ${{ secrets.GITEE_TOKEN }}
-          gitee_tag_name: ${{ github.ref_name }}
-          gitee_release_name: ${{ github.ref_name }}
-          gitee_release_body: ${{ github.ref_name }}
-          gitee_target_commitish: main
-          gitee_upload_retry_times: 5
-          gitee_files: |
-            dist/*
+      - name: Create Gitee Release
+        env:
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          
+          # Create release
+          echo "Creating Gitee release for tag $TAG"
+          release_response=$(curl -s -X POST \
+            -H "Authorization: token ${GITEE_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"tag_name\": \"$TAG\", \"name\": \"$TAG\", \"body\": \"Release $TAG\", \"target_commitish\": \"main\"}" \
+            "https://gitee.com/api/v5/repos/Yogdunana/deploypilot/releases")
+          
+          release_id=$(echo "$release_response" | jq -r '.id')
+          if [ "$release_id" = "null" ] || [ -z "$release_id" ]; then
+            echo "Failed to create release: $release_response"
+            exit 1
+          fi
+          echo "Created release ID: $release_id"
+          
+          # Upload assets with retry
+          for file in dist/*; do
+            filename=$(basename "$file")
+            echo "Uploading $filename..."
+            
+            for attempt in 1 2 3; do
+              response=$(curl -s -X POST \
+                -H "Authorization: token ${GITEE_TOKEN}" \
+                -F "file=@$file" \
+                "https://gitee.com/api/v5/repos/Yogdunana/deploypilot/releases/$release_id/attach_files")
+              
+              if echo "$response" | jq -e '.id' > /dev/null 2>&1; then
+                echo "  ✓ $filename uploaded successfully"
+                break
+              else
+                echo "  ✗ Attempt $attempt failed: $response"
+                if [ $attempt -eq 3 ]; then
+                  echo "  Failed to upload $filename after 3 attempts"
+                else
+                  sleep 30
+                fi
+              fi
+            done
+          done
+          
+          echo "Gitee release sync completed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -240,15 +240,29 @@ function download_file() {
     local url="$1"
     local output="$2"
     local desc="$3"
-    if command -v curl >/dev/null 2>&1; then
-        # Download with progress bar (-# shows progress as bar)
-        curl -fSL# "$url" -o "$output"
-    elif command -v wget >/dev/null 2>&1; then
-        wget --show-progress "$url" -O "$output" 2>&1
-    else
-        print_error "需要 curl 或 wget 来下载文件"
-        return 1
-    fi
+    local max_attempts="${4:-2}"
+    
+    for attempt in $(seq 1 $max_attempts); do
+        if command -v curl >/dev/null 2>&1; then
+            # Download with timeout (60s) and retry
+            if curl -fsSL --connect-timeout 30 --max-time 300 "$url" -o "$output" 2>/dev/null; then
+                return 0
+            fi
+        elif command -v wget >/dev/null 2>&1; then
+            if wget --timeout=300 -q "$url" -O "$output" 2>/dev/null; then
+                return 0
+            fi
+        else
+            print_error "需要 curl 或 wget 来下载文件"
+            return 1
+        fi
+        
+        if [ $attempt -lt $max_attempts ]; then
+            sleep 5
+        fi
+    done
+    
+    return 1
 }
 
 function install_docker() {
@@ -326,11 +340,10 @@ function download_binaries() {
     local urls=()
 
     if [ "$use_mirror" = "true" ]; then
-        # Gitee Release (most reliable for China)
-        urls+=("https://gitee.com/${GITHUB_REPO}/releases/download/${version}")
-        # GitHub mirror proxies
-        urls+=("https://mirror.ghproxy.com/https://github.com/${GITHUB_REPO}/releases/download/${version}")
+        # GitHub mirror proxies (most reliable for China)
         urls+=("https://ghfast.top/https://github.com/${GITHUB_REPO}/releases/download/${version}")
+        # Gitee Release (backup)
+        urls+=("https://gitee.com/${GITHUB_REPO}/releases/download/${version}")
     fi
 
     # GitHub direct (always try last)
@@ -685,8 +698,8 @@ EOF
         cat > /etc/systemd/system/deploypilot.service << EOF
 [Unit]
 Description=DeployPilot API Server
-After=network.target docker.service
-Requires=docker.service
+After=network.target
+Wants=docker.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Description

Fix Gitee release sync timeout and improve install script download reliability.

## Changes

### Release Workflow (.github/workflows/release.yml)
- Replace `action-gitee-release` action with native curl API calls
- Increase timeout from 60 to 120 minutes
- Add retry logic (3 attempts) for each file upload
- More reliable file upload with proper error handling

### Install Script (scripts/install.sh)
- **Download order**: Prioritize `ghfast.top` mirror (more reliable) over Gitee
- **Download function**: Add `--connect-timeout 30 --max-time 300` for better timeout handling
- **Download retries**: 2 retry attempts with 5s delay between attempts

### Systemd Service
- Remove `Requires=docker.service` (DeployPilot can run standalone)
- Change to `Wants=docker.service` (soft dependency)
- This prevents startup failures if Docker is slow to initialize

## Type of Change
- [x] fix (bug fix)
- [x] improvement

## Testing
- [x] CI passes
- [x] Tested on fresh Ubuntu 22.04 VM

## Related Issues
- Fixes Gitee release sync timeout
- Fixes service startup failure during installation